### PR TITLE
fix: use uv init env

### DIFF
--- a/backend/app/utils/toolkit/terminal_toolkit.py
+++ b/backend/app/utils/toolkit/terminal_toolkit.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 from camel.toolkits.terminal_toolkit import TerminalToolkit as BaseTerminalToolkit
+from app.component.command import uv
 from app.component.environment import env
 from app.service.task import Action, ActionTerminalData, Agents, get_task_lock
 from app.utils.listen.toolkit_listen import listen_toolkit
@@ -55,6 +56,10 @@ class TerminalToolkit(BaseTerminalToolkit, AbstractToolkit):
         )
         if hasattr(task_lock, "add_background_task"):
             task_lock.add_background_task(task)
+
+    def _ensure_uv_available(self) -> bool:
+        self.uv_path = uv()
+        return True
 
     @listen_toolkit(
         BaseTerminalToolkit.shell_exec,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

when electron start python, use venv.create() function create venv has problem, change to  electron installed uv 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
