### PR TITLE
fix: convert Node.js Buffer to Uint8Array for Response constructor

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -962,7 +962,7 @@ app.whenReady().then(() => {
           break;
       }
 
-      return new Response(data, {
+      return new Response(new Uint8Array(data), {
         headers: {
           'Content-Type': contentType,
         },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
