### PR TITLE
fix: avoid task not found bug

### DIFF
--- a/backend/app/controller/chat_controller.py
+++ b/backend/app/controller/chat_controller.py
@@ -16,6 +16,7 @@ from app.service.task import (
     ActionInstallMcpData,
     ActionStopData,
     ActionSupplementData,
+    create_task_lock,
     get_task_lock,
 )
 
@@ -25,6 +26,7 @@ router = APIRouter(tags=["chat"])
 
 @router.post("/chat", name="start chat")
 def post(data: Chat, request: Request):
+    task_lock = create_task_lock(data.task_id)
     load_dotenv(dotenv_path=data.env_path)
 
     # logger.debug(f"start chat: {data.model_dump_json()}")
@@ -43,7 +45,7 @@ def post(data: Chat, request: Request):
 
     if data.is_cloud():
         os.environ["cloud_api_key"] = data.api_key
-    return StreamingResponse(step_solve(data, request), media_type="text/event-stream")
+    return StreamingResponse(step_solve(data, request, task_lock), media_type="text/event-stream")
 
 
 @router.post("/chat/{id}", name="improve chat")

--- a/backend/app/service/chat_service.py
+++ b/backend/app/service/chat_service.py
@@ -12,7 +12,7 @@ from app.service.task import (
     ActionImproveData,
     ActionInstallMcpData,
     ActionNewAgent,
-    create_task_lock,
+    TaskLock,
     delete_task_lock,
 )
 from camel.toolkits import AgentCommunicationToolkit, ToolkitMessageIntegration
@@ -43,14 +43,13 @@ from camel.models import ModelProcessingError
 
 
 @sync_step
-async def step_solve(options: Chat, request: Request):
+async def step_solve(options: Chat, request: Request, task_lock: TaskLock):
     # if True:
     #     import faulthandler
 
     #     faulthandler.enable()
     #     for second in [5, 10, 20, 30, 60, 120, 240]:
     #         faulthandler.dump_traceback_later(second)
-    task_lock = create_task_lock(options.task_id)
 
     start_event_loop = True
     question_agent = question_confirm_agent(options)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When user send task and click the pause button immediately, it will trick Task not found error.
move create_task_lock to top postion.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
