### PR TITLE
chore: filter console logs (#91)

### DIFF
--- a/backend/app/utils/agent.py
+++ b/backend/app/utils/agent.py
@@ -221,7 +221,7 @@ class ListenChatAgent(ChatAgent):
         error_info = None
         message = None
         res = None
-        traceroot_logger.info(f"Agent {self.agent_name} starting async step with message: {input_message.content if isinstance(input_message, BaseMessage) else input_message}")
+        traceroot_logger.debug(f"Agent {self.agent_name} starting async step with message: {input_message.content if isinstance(input_message, BaseMessage) else input_message}")
 
         try:
             res = await super().astep(input_message, response_format)
@@ -290,7 +290,7 @@ class ListenChatAgent(ChatAgent):
                 task_lock = get_task_lock(self.api_task_id)
 
                 toolkit_name = getattr(tool, "_toolkit_name") if hasattr(tool, "_toolkit_name") else "mcp_toolkit"
-                traceroot_logger.info(f"Agent {self.agent_name} executing tool: {func_name} from toolkit: {toolkit_name} with args: {json.dumps(args, ensure_ascii=False)}")
+                traceroot_logger.debug(f"Agent {self.agent_name} executing tool: {func_name} from toolkit: {toolkit_name} with args: {json.dumps(args, ensure_ascii=False)}")
                 asyncio.create_task(
                     task_lock.put_queue(
                         ActionActivateToolkitData(

--- a/backend/app/utils/listen/toolkit_listen.py
+++ b/backend/app/utils/listen/toolkit_listen.py
@@ -129,7 +129,7 @@ def listen_toolkit(
                 error = None
                 res = None
                 try:
-                    logger.debug(">>>>", func.__name__, "<<<<")
+                    logger.debug(f"Executing toolkit method: {toolkit_name}.{method_name} for agent '{toolkit.agent_name}'")
                     res = func(*args, **kwargs)
                     # Safety check: if the result is a coroutine, we need to await it
                     if asyncio.iscoroutine(res):

--- a/backend/app/utils/listen/toolkit_listen.py
+++ b/backend/app/utils/listen/toolkit_listen.py
@@ -129,7 +129,7 @@ def listen_toolkit(
                 error = None
                 res = None
                 try:
-                    print(">>>>", func.__name__, "<<<<")
+                    logger.debug(">>>>", func.__name__, "<<<<")
                     res = func(*args, **kwargs)
                     # Safety check: if the result is a coroutine, we need to await it
                     if asyncio.iscoroutine(res):

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,24 +5,20 @@ import asyncio
 import atexit
 from app import api
 from loguru import logger
-from app.utils import traceroot_wrapper as traceroot
 from app.component.environment import auto_include_routers, env
-
-# Create traceroot logger for main application
-traceroot_logger = traceroot.get_logger('main')
 
 
 os.environ["PYTHONIOENCODING"] = "utf-8"
 
 # Log application startup
-traceroot_logger.info("Starting Eigent Multi-Agent System API")
-traceroot_logger.info(f"Python encoding: {os.environ.get('PYTHONIOENCODING')}")
-traceroot_logger.info(f"Environment: {os.environ.get('ENVIRONMENT', 'development')}")
+logger.info("Starting Eigent Multi-Agent System API")
+logger.info(f"Python encoding: {os.environ.get('PYTHONIOENCODING')}")
+logger.info(f"Environment: {os.environ.get('ENVIRONMENT', 'development')}")
 
 prefix = env("url_prefix", "")
-traceroot_logger.info(f"Loading routers with prefix: '{prefix}'")
+logger.info(f"Loading routers with prefix: '{prefix}'")
 auto_include_routers(api, prefix, "app/controller")
-traceroot_logger.info("All routers loaded successfully")
+logger.info("All routers loaded successfully")
 
 
 # Configure Loguru
@@ -35,36 +31,34 @@ logger.add(
     level="DEBUG",  # Log level
     encoding="utf-8",
 )
-traceroot_logger.info(f"Loguru configured with log file: {log_path}")
+logger.info(f"Loguru configured with log file: {log_path}")
 
 dir = pathlib.Path(__file__).parent / "runtime"
 dir.mkdir(parents=True, exist_ok=True)
 
 
 # Write PID file asynchronously
-@traceroot.trace()
 async def write_pid_file():
     r"""Write PID file asynchronously"""
     import aiofiles
 
     async with aiofiles.open(dir / "run.pid", "w") as f:
         await f.write(str(os.getpid()))
-    traceroot_logger.info(f"PID file written: {os.getpid()}")
+    logger.info(f"PID file written: {os.getpid()}")
 
 
 # Create task to write PID
 pid_task = asyncio.create_task(write_pid_file())
-traceroot_logger.info("PID write task created")
+logger.info("PID write task created")
 
 # Graceful shutdown handler
 shutdown_event = asyncio.Event()
 
 
-@traceroot.trace()
 async def cleanup_resources():
     r"""Cleanup all resources on shutdown"""
     logger.info("Starting graceful shutdown...")
-    traceroot_logger.info("Starting graceful shutdown process")
+    logger.info("Starting graceful shutdown process")
 
     from app.service.task import task_locks, _cleanup_task
 
@@ -89,14 +83,13 @@ async def cleanup_resources():
         pid_file.unlink()
 
     logger.info("Graceful shutdown completed")
-    traceroot_logger.info("All resources cleaned up successfully")
+    logger.info("All resources cleaned up successfully")
 
 
-@traceroot.trace()
 def signal_handler(signum, frame):
     r"""Handle shutdown signals"""
     logger.info(f"Received signal {signum}")
-    traceroot_logger.warning(f"Received shutdown signal: {signum}")
+    logger.warning(f"Received shutdown signal: {signum}")
     asyncio.create_task(cleanup_resources())
     shutdown_event.set()
 
@@ -108,4 +101,4 @@ signal.signal(signal.SIGINT, signal_handler)
 atexit.register(lambda: asyncio.run(cleanup_resources()))
 
 # Log successful initialization
-traceroot_logger.info("Application initialization completed successfully")
+logger.info("Application initialization completed successfully")

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -123,6 +123,8 @@ nativeTheme.themeSource = 'light';
 // Set log level
 log.transports.console.level = 'info';
 log.transports.file.level = 'info';
+log.transports.console.format = '[{level}]{text}';
+log.transports.file.format = '[{level}]{text}';
 
 // Disable GPU Acceleration for Windows 7
 if (os.release().startsWith('6.1')) app.disableHardwareAcceleration()
@@ -362,7 +364,7 @@ function registerIpcHandlers() {
           stderr += output;
           if (output.includes('OAuth callback server running at')) {
             const url = output.split('OAuth callback server running at')[1].trim();
-            log.info(' detect OAuth callback URL:', url);
+            log.info('detect OAuth callback URL:', url);
 
             // Notify frontend to callback URL
             if (win && !win.isDestroyed()) {

--- a/electron/main/init.ts
+++ b/electron/main/init.ts
@@ -312,6 +312,8 @@ export async function startBackend(setPort?: (port: number) => void): Promise<an
         } else if (msg.toLowerCase().includes("warn")) {
             //Skip Warnings
             // log.warn(`BACKEND: ${msg}`);
+        } else if (msg.includes("DEBUG")) {
+            log.debug(`BACKEND: ${msg}`);
         } else {
             log.info(`BACKEND: ${msg}`); // treat uvicorn info logs as normal
         }

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -170,7 +170,7 @@ async function proxyFetchRequest(
     ...customHeaders,
   }
 
-  console.log('url', url, token)
+  console.debug('url', url, token)
   if (!url.includes('http://') && !url.includes('https://') && token) {
     headers['Authorization'] = `Bearer ${token}`
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
closes #91 

1. `04:40:44.826 > fastapi output: 2025-08-28 01:40:44,793` **TO** `[info] BACKEND: 2025-08-28 01:33:36,659`
2. Fix `fastapi stderr output` for non errors (Currently manual i.e. if contains `error`/`trace`) btw according to config only [info] is logged to electron console
3. Truncated Lines
4. Log Agent system message to DEBUG instead of INFO
2. To show `console.debug` logs, click on verbose settings
<img width="423" height="289" alt="image" src="https://github.com/user-attachments/assets/d33049d8-3631-40d2-b03e-a050a9253608" />

To Enhance:
1. Add colors
2. Further filter unnecessary logs


### Before] [After
<img width="1900" height="810" alt="image" src="https://github.com/user-attachments/assets/b263a769-865b-4df7-9f1e-bf9350be6a84" />

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
