### PR TITLE
enhance: Fix #352 install enhanced PR404

### DIFF
--- a/backend/app/component/command.py
+++ b/backend/app/component/command.py
@@ -6,4 +6,4 @@ def bun():
 
 
 def uv():
-    return os.path.expanduser("~/.local/bin/uv")
+    return os.path.expanduser("~/.eigent/bin/uv")

--- a/backend/app/component/command.py
+++ b/backend/app/component/command.py
@@ -6,4 +6,4 @@ def bun():
 
 
 def uv():
-    return os.path.expanduser("~/.eigent/bin/uv")
+    return os.path.expanduser("~/.local/bin/uv")

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -19,7 +19,6 @@ import { zipFolder } from './utils/log'
 import axios from 'axios';
 import FormData from 'form-data';
 import { checkAndInstallDepsOnUpdate, PromiseReturnType, getInstallationStatus } from './install-deps'
-import e from 'express'
 
 const userData = app.getPath('userData');
 
@@ -841,7 +840,7 @@ function registerIpcHandlers() {
   ipcMain.handle('check-tool-installed', async () => {
     try {
       const isInstalled = await checkToolInstalled();
-      return { success: true, isInstalled };
+      return { success: true, isInstalled: isInstalled.success };
     } catch (error) {
       return { success: false, error: (error as Error).message };
     }
@@ -987,21 +986,21 @@ const checkAndStartBackend = async () => {
   log.info('Checking and starting backend service...');
   try {
     const isToolInstalled = await checkToolInstalled();
-    if (isToolInstalled) {
+    if (isToolInstalled.success) {
       log.info('Tool installed, starting backend service...');
-  
+
       // Notify frontend installation success
       if (win && !win.isDestroyed()) {
         win.webContents.send('install-dependencies-complete', { success: true, code: 0 });
       }
-  
+
       python_process = await startBackend((port) => {
         backendPort = port;
         log.info('Backend service started successfully', { port });
       });
-  
+
       python_process?.on('exit', (code, signal) => {
-  
+
         log.info('Python process exited', { code, signal });
       });
     } else {

--- a/electron/main/init.ts
+++ b/electron/main/init.ts
@@ -21,10 +21,12 @@ export async function checkToolInstalled() {
     return new Promise<PromiseReturnType>(async (resolve, reject) => {
         if (!(await isBinaryExists('uv'))) {
             resolve({success: false, message: "uv doesn't exist"})
+            return
         }
 
         if (!(await isBinaryExists('bun'))) {
             resolve({success: false, message: "Bun doesn't exist"})
+            return
         }
 
         resolve({success: true, message: "Tools exist already"})

--- a/electron/main/install-deps.ts
+++ b/electron/main/install-deps.ts
@@ -100,7 +100,7 @@ Promise<PromiseReturnType> => {
  * Check if command line tools are installed, install if not
  */
 export async function installCommandTool(): Promise<PromiseReturnType> {
-  return new Promise(async (resolve, reject) => {
+  try {
       const ensureInstalled = async (toolName: 'uv' | 'bun', scriptName: string): Promise<PromiseReturnType> => {
         if (await isBinaryExists(toolName)) {
             return { message: `${toolName} already installed`, success: true };
@@ -123,24 +123,26 @@ export async function installCommandTool(): Promise<PromiseReturnType> {
           });
         }
 
-        return { 
+        return {
           message: installed ? `${toolName} installed successfully` : `${toolName} installation failed`,
-          success: installed 
+          success: installed
         };
       };
 
       const uvResult = await ensureInstalled('uv', 'install-uv.js');
       if (!uvResult.success) {
-          return reject({ message: uvResult.message, success: false });
-      }
-      
-      const bunResult = await ensureInstalled('bun', 'install-bun.js');
-      if (!bunResult.success) {
-          return reject({ message: bunResult.message, success: false });
+          return { message: uvResult.message, success: false };
       }
 
-      return resolve({ message: "Command tools installed successfully", success: true });
-  })
+      const bunResult = await ensureInstalled('bun', 'install-bun.js');
+      if (!bunResult.success) {
+          return { message: bunResult.message, success: false };
+      }
+
+      return { message: "Command tools installed successfully", success: true };
+  } catch (error) {
+      return { message: `Command tool installation failed: ${error}`, success: false };
+  }
 }
 
 let uv_path:string;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

  1. Removed unused import - Deleted import e from 'express' in electron/main/index.ts:21
  2. Fixed type inconsistency - Updated code to handle checkToolInstalled() returning PromiseReturnType instead of boolean
  3. Improved error handling - Converted installCommandTool() from Promise constructor to async/await with proper try-catch
  4. Fixed UV path configuration - Updated uv() function path from ~/.eigent/bin/uv to ~/.local/bin/uv in
  backend/app/component/command.py:9


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
