### PR TITLE
enhance: browser_install PR451

### DIFF
--- a/electron/main/install-deps.ts
+++ b/electron/main/install-deps.ts
@@ -333,11 +333,28 @@ export async function installDependencies(version: string): Promise<PromiseRetur
     installHybridBrowserDependencies: async (): Promise<boolean> => {
       try {
         // Find the hybrid_browser_toolkit ts directory in the virtual environment
-        const sitePackagesPath = path.join(venvPath, 'lib', 'site-packages');
+        // Need to determine the Python version to construct the correct path
+        let sitePackagesPath: string | null = null;
+        const libPath = path.join(venvPath, 'lib');
+
+        // Try to find the site-packages directory (it varies by Python version)
+        if (fs.existsSync(libPath)) {
+          const libContents = fs.readdirSync(libPath);
+          const pythonDir = libContents.find(name => name.startsWith('python'));
+          if (pythonDir) {
+            sitePackagesPath = path.join(libPath, pythonDir, 'site-packages');
+          }
+        }
+
+        if (!sitePackagesPath || !fs.existsSync(sitePackagesPath)) {
+          log.warn('[DEPS INSTALL] site-packages directory not found in venv, skipping npm install');
+          return true; // Not an error if the venv structure is different
+        }
+
         const toolkitPath = path.join(sitePackagesPath, 'camel', 'toolkits', 'hybrid_browser_toolkit', 'ts');
 
         if (!fs.existsSync(toolkitPath)) {
-          log.warn('[DEPS INSTALL] hybrid_browser_toolkit ts directory not found, skipping npm install');
+          log.warn('[DEPS INSTALL] hybrid_browser_toolkit ts directory not found at ' + toolkitPath + ', skipping npm install');
           return true; // Not an error if the toolkit isn't installed
         }
 
@@ -350,8 +367,9 @@ export async function installDependencies(version: string): Promise<PromiseRetur
         // Try to find npm - first try system npm, then try uv run npm
         let npmCommand: string[];
         const testNpm = spawn('npm', ['--version'], { shell: true });
-        const npmExists = await new Promise(resolve => {
+        const npmExists = await new Promise<boolean>(resolve => {
           testNpm.on('close', (code) => resolve(code === 0));
+          testNpm.on('error', () => resolve(false));
         });
 
         if (npmExists) {
@@ -375,15 +393,19 @@ export async function installDependencies(version: string): Promise<PromiseRetur
         });
 
         await new Promise<void>((resolve, reject) => {
-          npmInstall.stdout.on('data', (data) => {
-            log.info(`[DEPS INSTALL] npm install: ${data}`);
-            safeMainWindowSend('install-dependencies-log', { type: 'stdout', data: data.toString() });
-          });
+          if (npmInstall.stdout) {
+            npmInstall.stdout.on('data', (data) => {
+              log.info(`[DEPS INSTALL] npm install: ${data}`);
+              safeMainWindowSend('install-dependencies-log', { type: 'stdout', data: data.toString() });
+            });
+          }
 
-          npmInstall.stderr.on('data', (data) => {
-            log.warn(`[DEPS INSTALL] npm install stderr: ${data}`);
-            safeMainWindowSend('install-dependencies-log', { type: 'stderr', data: data.toString() });
-          });
+          if (npmInstall.stderr) {
+            npmInstall.stderr.on('data', (data) => {
+              log.warn(`[DEPS INSTALL] npm install stderr: ${data}`);
+              safeMainWindowSend('install-dependencies-log', { type: 'stderr', data: data.toString() });
+            });
+          }
 
           npmInstall.on('close', (code) => {
             if (code === 0) {
@@ -393,6 +415,11 @@ export async function installDependencies(version: string): Promise<PromiseRetur
               log.error(`[DEPS INSTALL] npm install failed with code ${code}`);
               reject(new Error(`npm install failed with code ${code}`));
             }
+          });
+
+          npmInstall.on('error', (err) => {
+            log.error(`[DEPS INSTALL] npm install process error: ${err}`);
+            reject(err);
           });
         });
 
@@ -414,16 +441,20 @@ export async function installDependencies(version: string): Promise<PromiseRetur
         });
 
         await new Promise<void>((resolve, reject) => {
-          npmBuild.stdout.on('data', (data) => {
-            log.info(`[DEPS INSTALL] npm build: ${data}`);
-            safeMainWindowSend('install-dependencies-log', { type: 'stdout', data: data.toString() });
-          });
+          if (npmBuild.stdout) {
+            npmBuild.stdout.on('data', (data) => {
+              log.info(`[DEPS INSTALL] npm build: ${data}`);
+              safeMainWindowSend('install-dependencies-log', { type: 'stdout', data: data.toString() });
+            });
+          }
 
-          npmBuild.stderr.on('data', (data) => {
-            // TypeScript build warnings are common, don't treat as errors
-            log.info(`[DEPS INSTALL] npm build output: ${data}`);
-            safeMainWindowSend('install-dependencies-log', { type: 'stdout', data: data.toString() });
-          });
+          if (npmBuild.stderr) {
+            npmBuild.stderr.on('data', (data) => {
+              // TypeScript build warnings are common, don't treat as errors
+              log.info(`[DEPS INSTALL] npm build output: ${data}`);
+              safeMainWindowSend('install-dependencies-log', { type: 'stdout', data: data.toString() });
+            });
+          }
 
           npmBuild.on('close', (code) => {
             if (code === 0) {
@@ -433,6 +464,11 @@ export async function installDependencies(version: string): Promise<PromiseRetur
               log.error(`[DEPS INSTALL] TypeScript build failed with code ${code}`);
               reject(new Error(`TypeScript build failed with code ${code}`));
             }
+          });
+
+          npmBuild.on('error', (err) => {
+            log.error(`[DEPS INSTALL] npm build process error: ${err}`);
+            reject(err);
           });
         });
 
@@ -460,6 +496,11 @@ export async function installDependencies(version: string): Promise<PromiseRetur
                 log.warn('[DEPS INSTALL] Playwright installation failed, but continuing anyway');
               }
               resolve();
+            });
+
+            playwrightInstall.on('error', (err) => {
+              log.warn('[DEPS INSTALL] Playwright installation process error:', err);
+              resolve(); // Non-critical, continue
             });
           });
         } catch (error) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

  1.  The original code used `lib/site-packages`, but Python venvs actually use `lib/python3.X/site-packages` where X is the version number, the toolkit directory could never be found. fixed it to automatically detect the Python version and build the correct path.

  2. The code assumed stdout and stderr are always available, but they can be null in certain scenarios, added safety checks before trying to read from these streams to prevent crashes.

  3. When testing if npm exists, the code only listened for the 'close' event. If npm doesn't exist or fails to run, the 'error'
  event fires instead, causing the check to hang forever. added an error handler to properly handle this case.

  4. the npm/build/playwright processes only had 'close' handlers but no 'error' handlers. If a process fails to start,
  it triggers 'error' not 'close', which would cause the installation to hang. added error handlers for all three processes.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
