### PR TITLE
feat: support multi tasks with project store #419

### DIFF
--- a/src/components/ChatBox/BottomInput.tsx
+++ b/src/components/ChatBox/BottomInput.tsx
@@ -226,7 +226,7 @@ export const BottomInput = ({
 		let taskId = chatStore.activeTaskId as string;
 		const question =
 			chatStore.tasks[chatStore.activeTaskId as string].messages[0].content;
-		chatStore.replay(taskId, question, 0.1);
+		projectStore.replayProject([taskId], question);
 	};
 
 	return (

--- a/src/components/ChatBox/BottomInput.tsx
+++ b/src/components/ChatBox/BottomInput.tsx
@@ -58,7 +58,7 @@ export const BottomInput = ({
 	useCloudModelInDev: boolean;
 }) => {
 	//Get Chatstore for the active project's task
-	const { chatStore } = useChatStoreAdapter();
+	const { chatStore, projectStore } = useChatStoreAdapter();
 	if (!chatStore) {
 		return <div>Loading...</div>;
 	}
@@ -212,7 +212,10 @@ export const BottomInput = ({
 			chatStore.tasks[chatStore.activeTaskId as string].messages[
 				messageIndex - 2
 			].content;
-		let id = chatStore.create();
+		//Create new chat in same project
+		if(!projectStore.activeProjectId) return
+		let id = projectStore.createChatStore(projectStore.activeProjectId);
+		
 		chatStore.setHasMessages(id, true);
 		chatStore.removeTask(tempTaskId as string);
 		proxyFetchDelete(`/api/chat/history/${tempTaskId}`);

--- a/src/components/ChatBox/BottomInput.tsx
+++ b/src/components/ChatBox/BottomInput.tsx
@@ -213,8 +213,7 @@ export const BottomInput = ({
 				messageIndex - 2
 			].content;
 		//Create new chat in same project
-		if(!projectStore.activeProjectId) return
-		let id = projectStore.createChatStore(projectStore.activeProjectId);
+		let id = chatStore.create();
 		
 		chatStore.setHasMessages(id, true);
 		chatStore.removeTask(tempTaskId as string);

--- a/src/components/ChatBox/BottomInput.tsx
+++ b/src/components/ChatBox/BottomInput.tsx
@@ -26,6 +26,7 @@ import { Tag } from "../ui/tag";
 import { useTranslation } from "react-i18next";
 import { TooltipSimple } from "../ui/tooltip";
 import { toast } from "sonner";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export const BottomInput = ({
 	message,
@@ -56,7 +57,12 @@ export const BottomInput = ({
 	setIsTakeControl?: (v: boolean) => void;
 	useCloudModelInDev: boolean;
 }) => {
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const {t} = useTranslation();
 	const [isConfirm, setIsConfirm] = useState(true);
 	const [hasSubTask, setHasSubTask] = useState(false);

--- a/src/components/ChatBox/NoticeCard.tsx
+++ b/src/components/ChatBox/NoticeCard.tsx
@@ -8,12 +8,18 @@ import { useChatStore } from "@/store/chatStore";
 
 import { ChevronDown, SquareCode } from "lucide-react";
 import { useMemo, useState, useRef, useEffect } from "react";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export function NoticeCard() {
 	const [isExpanded, setIsExpanded] = useState(false);
 	const contentRef = useRef<HTMLDivElement>(null);
 
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 
 	// when cotList is added, smooth scroll to the bottom
 	useEffect(() => {

--- a/src/components/ChatBox/TaskCard.tsx
+++ b/src/components/ChatBox/TaskCard.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { useMemo, useState, useRef, useEffect } from "react";
 import { TaskState, TaskStateType } from "../TaskState";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 interface TaskCardProps {
 	taskInfo: any[];
@@ -51,7 +52,12 @@ export function TaskCard({
 	const [isExpanded, setIsExpanded] = useState(true);
 	const contentRef = useRef<HTMLDivElement>(null);
 	const [contentHeight, setContentHeight] = useState<number | "auto">("auto");
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 
 	const [selectedState, setSelectedState] = useState<TaskStateType>("all");
 	const [filterTasks, setFilterTasks] = useState<any[]>([]);

--- a/src/components/ChatBox/index.tsx
+++ b/src/components/ChatBox/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { fetchPost, proxyFetchPut } from "@/api/http";
 import { BottomInput } from "./BottomInput";
 import { TaskCard } from "./TaskCard";
@@ -6,17 +6,23 @@ import { MessageCard } from "./MessageCard";
 import { TypeCardSkeleton } from "./TypeCardSkeleton";
 import { FileText, TriangleAlert } from "lucide-react";
 import { generateUniqueId } from "@/lib";
-import { useChatStore } from "@/store/chatStore";
 import { proxyFetchGet } from "@/api/http";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { NoticeCard } from "./NoticeCard";
 import { useAuthStore } from "@/store/authStore";
 import { useTranslation } from "react-i18next";
 import { TaskStateType } from "../TaskState";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export default function ChatBox(): JSX.Element {
 	const [message, setMessage] = useState<string>("");
-	const chatStore = useChatStore();
+
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const { t } = useTranslation();
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);

--- a/src/components/Folder/index.tsx
+++ b/src/components/Folder/index.tsx
@@ -18,6 +18,7 @@ import { MarkDown } from "@/components/ChatBox/MarkDown";
 import { useAuthStore } from "@/store/authStore";
 import { proxyFetchGet } from "@/api/http";
 import { useTranslation } from "react-i18next";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 // Type definitions
 interface FileTreeNode {
@@ -154,7 +155,12 @@ function downloadByBrowser(url: string) {
 }
 
 export default function Folder({ data }: { data?: Agent }) {
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const authStore = useAuthStore();
 	const { t } = useTranslation();
 	const [selectedFile, setSelectedFile] = useState<FileInfo | null>(null);

--- a/src/components/HistorySidebar/index.tsx
+++ b/src/components/HistorySidebar/index.tsx
@@ -161,7 +161,7 @@ export default function HistorySidebar() {
 
 	const handleReplay = async (taskId: string, question: string) => {
 		close();
-		chatStore.replay(taskId, question, 0);
+		projectStore.replayProject([taskId], question);
 		navigate({ pathname: "/" });
 	};
 

--- a/src/components/HistorySidebar/index.tsx
+++ b/src/components/HistorySidebar/index.tsx
@@ -44,7 +44,7 @@ export default function HistorySidebar() {
 	const { isOpen, close } = useSidebarStore();
 	const navigate = useNavigate();
 	//Get Chatstore for the active project's task
-	const { chatStore } = useChatStoreAdapter();
+	const { chatStore, projectStore } = useChatStoreAdapter();
 	if (!chatStore) {
 		return <div>Loading...</div>;
 	}
@@ -87,7 +87,8 @@ export default function HistorySidebar() {
 			chatStore.tasks[chatStore.activeTaskId as string].messages.length === 0
 		) {
 		}
-		chatStore.create();
+		//Create a new project
+		projectStore.createProject("new project");
 		navigate("/");
 	};
 

--- a/src/components/HistorySidebar/index.tsx
+++ b/src/components/HistorySidebar/index.tsx
@@ -37,12 +37,18 @@ import { proxyFetchGet, proxyFetchDelete, proxyFetchPost } from "@/api/http";
 import { Tag } from "../ui/tag";
 import { share } from "@/lib/share";
 import { useTranslation } from "react-i18next";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export default function HistorySidebar() {
 	const { t } = useTranslation();
 	const { isOpen, close } = useSidebarStore();
 	const navigate = useNavigate();
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const getTokens = chatStore.getTokens;
 	const { history_type, toggleHistoryType } = useGlobalStore();
 	const [searchValue, setSearchValue] = useState("");

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -11,10 +11,18 @@ import { useChatStore } from "@/store/chatStore";
 import { useInstallationUI } from "@/store/installationStore";
 import { useInstallationSetup } from "@/hooks/useInstallationSetup";
 import InstallationErrorDialog from "../InstallStep/InstallationErrorDialog/InstallationErrorDialog";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 const Layout = () => {
 	const { initState, isFirstLaunch, setIsFirstLaunch, setInitState } = useAuthStore();
 	const [noticeOpen, setNoticeOpen] = useState(false);
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {		
+		console.log(chatStore);
+		
+		return <div>Loading...</div>;
+	}
+
 	const {
 		installationState,
 		latestLog,

--- a/src/components/SearchAgentWrokSpace/index.tsx
+++ b/src/components/SearchAgentWrokSpace/index.tsx
@@ -21,7 +21,7 @@ import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export default function Home() {
 	//Get Chatstore for the active project's task
-	const { chatStore } = useChatStoreAdapter();
+	const { chatStore, projectStore } = useChatStoreAdapter();
 	if (!chatStore) {
 		return <div>Loading...</div>;
 	}
@@ -115,8 +115,9 @@ export default function Home() {
 
 	// listen to webview container size
 	useEffect(() => {
-		if (!chatStore.activeTaskId) {
-			chatStore.create();
+		if (!projectStore.activeProjectId) {
+			projectStore.createProject("new project");
+			console.warn("No active projectId found in WorkSpace, creating a new project");
 		}
 
 		const webviewContainer = document.getElementById("webview-container");

--- a/src/components/SearchAgentWrokSpace/index.tsx
+++ b/src/components/SearchAgentWrokSpace/index.tsx
@@ -17,9 +17,15 @@ import {
 import { Button } from "../ui/button";
 import { fetchPut } from "@/api/http";
 import { TaskState } from "../TaskState";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export default function Home() {
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const [isSingleMode, setIsSingleMode] = useState(false);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/SearchHistoryDialog.tsx
+++ b/src/components/SearchHistoryDialog.tsx
@@ -37,7 +37,7 @@ export function SearchHistoryDialog() {
 	const [open, setOpen] = useState(false);
 	const [historyTasks, setHistoryTasks] = useState<any[]>([]);
 	//Get Chatstore for the active project's task
-	const { chatStore } = useChatStoreAdapter();
+	const { chatStore, projectStore } = useChatStoreAdapter();
 	if (!chatStore) {
 		return <div>Loading...</div>;
 	}
@@ -55,7 +55,7 @@ export function SearchHistoryDialog() {
 		}
 	};
 	const handleReplay = async (taskId: string, question: string) => {
-		chatStore.replay(taskId, question, 0);
+		projectStore.replayProject([taskId], question);
 		navigate({ pathname: "/" });
 	};
 	useEffect(() => {

--- a/src/components/SearchHistoryDialog.tsx
+++ b/src/components/SearchHistoryDialog.tsx
@@ -30,12 +30,18 @@ import { useChatStore } from "@/store/chatStore";
 import { useNavigate } from "react-router-dom";
 import { generateUniqueId } from "@/lib";
 import { useTranslation } from "react-i18next";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export function SearchHistoryDialog() {
 	const {t} = useTranslation()
 	const [open, setOpen] = useState(false);
 	const [historyTasks, setHistoryTasks] = useState<any[]>([]);
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const navigate = useNavigate();
 	const handleSetActive = (taskId: string, question: string) => {
 		const task = chatStore.tasks[taskId];

--- a/src/components/TaskState/index.tsx
+++ b/src/components/TaskState/index.tsx
@@ -1,6 +1,7 @@
 import { CircleCheckBig, CircleSlash2, LoaderCircle } from "lucide-react";
 import { useChatStore } from "@/store/chatStore";
 import { useTranslation } from "react-i18next";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export type TaskStateType =
 	| "all"
@@ -35,7 +36,12 @@ export const TaskState = ({
 	onStateChange,
 	clickable = true,
 }: TaskStateProps) => {
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const { t } = useTranslation();
 	const handleStateClick = (state: TaskStateType) => {
 		if (!clickable || !onStateChange) return;

--- a/src/components/Terminal/index.tsx
+++ b/src/components/Terminal/index.tsx
@@ -4,6 +4,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 // Terminal Component Properties Interface
 interface TerminalComponentProps {
@@ -17,7 +18,12 @@ export default function TerminalComponent({
 	instanceId = "default",
 	showWelcome = false,
 }: TerminalComponentProps) {
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 
 	// DOM references
 	const terminalContainerRef = useRef<HTMLDivElement>(null); // terminal container reference

--- a/src/components/TerminalAgentWrokSpace/index.tsx
+++ b/src/components/TerminalAgentWrokSpace/index.tsx
@@ -18,9 +18,15 @@ import { Button } from "../ui/button";
 import { fetchPut } from "@/api/http";
 import Terminal from "@/components/Terminal";
 import { useTranslation } from "react-i18next";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export default function TerminalAgentWrokSpace() {
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const { t } = useTranslation();
 	const [isSingleMode, setIsSingleMode] = useState(false);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -20,6 +20,7 @@ import { getAuthStore } from "@/store/authStore";
 import { useTranslation } from "react-i18next";
 import {  proxyFetchGet } from "@/api/http";
 import { toast } from "sonner";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 function HeaderWin() {
 	const { t } = useTranslation();
 	const titlebarRef = useRef<HTMLDivElement>(null);
@@ -27,7 +28,12 @@ function HeaderWin() {
 	const [platform, setPlatform] = useState<string>("");
 	const navigate = useNavigate();
 	const location = useLocation();
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const { toggle } = useSidebarStore();
 	const [isFullscreen, setIsFullscreen] = useState(false);
 	const { token } = getAuthStore();

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -29,7 +29,7 @@ function HeaderWin() {
 	const navigate = useNavigate();
 	const location = useLocation();
 	//Get Chatstore for the active project's task
-	const { chatStore } = useChatStoreAdapter();
+	const { chatStore, projectStore } = useChatStoreAdapter();
 	if (!chatStore) {
 		return <div>Loading...</div>;
 	}
@@ -99,7 +99,7 @@ function HeaderWin() {
 			navigate("/");
 			return;
 		}
-		chatStore.create();
+		projectStore.createProject("new project");
 		navigate("/");
 	};
 

--- a/src/components/WorkFlow/index.tsx
+++ b/src/components/WorkFlow/index.tsx
@@ -16,6 +16,7 @@ import { useChatStore } from "@/store/chatStore";
 import { useWorkerList } from "@/store/authStore";
 import { share } from "@/lib/share";
 import { useTranslation } from "react-i18next";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 interface NodeData {
 	agent: Agent;
@@ -37,7 +38,12 @@ export default function Workflow({
 	taskAssigning: Agent[];
 }) {
 	const {t} = useTranslation();
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const [isEditMode, setIsEditMode] = useState(false);
 	const [lastViewport, setLastViewport] = useState({ x: 0, y: 0, zoom: 1 });
 	const [nodes, setNodes, onNodesChange] = useNodesState<CustomNode>([]);

--- a/src/components/WorkFlow/node.tsx
+++ b/src/components/WorkFlow/node.tsx
@@ -35,6 +35,7 @@ import {
 	PopoverTrigger,
 } from "../ui/popover";
 import { AddWorker } from "@/components/AddWorker";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 interface NodeProps {
 	id: string;
@@ -99,7 +100,12 @@ export function Node({ id, data }: NodeProps) {
 		}
 	}, [selectedState, data.agent?.tasks]);
 
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const { setCenter, getNode, setViewport, setNodes } = useReactFlow();
 	const workerList = useWorkerList();
 	const { setWorkerList } = useAuthStore();

--- a/src/components/WorkSpaceMenu/index.tsx
+++ b/src/components/WorkSpaceMenu/index.tsx
@@ -15,9 +15,15 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useEffect, useState } from "react";
 import { AddWorker } from "@/components/AddWorker";
 import { Badge } from "../ui/badge";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export function WorkSpaceMenu() {
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const workerList = useWorkerList();
 	const baseWorker: Agent[] = [
 		{

--- a/src/hooks/useChatStoreAdapter.tsx
+++ b/src/hooks/useChatStoreAdapter.tsx
@@ -1,0 +1,57 @@
+import { useProjectStore } from '@/store/projectStore';
+import React, { useEffect, useMemo, useState } from 'react'
+
+const useChatStoreAdapter = () => {
+  const projectStore = useProjectStore();
+    
+  // Get the active chat store from project store
+  // This creates a hook-like interface for the vanilla store
+  const activeChatStore = projectStore.getActiveChatStore();
+  
+  // Create a state subscription to make the component reactive
+  const [chatState, setChatState] = useState(() => 
+    activeChatStore ? activeChatStore.getState() : null
+  );
+  
+  useEffect(() => {
+    if (!activeChatStore) {
+      setChatState(null);
+      return;
+    }
+
+    // Subscribe to store changes
+    const unsubscribe = activeChatStore.subscribe((state) => {
+      setChatState(state);
+    });
+    // Set initial state
+    setChatState(activeChatStore.getState());
+    return unsubscribe;
+  }, [activeChatStore]);
+  
+  // Create a chatStore-like object that mimics the original interface
+  const chatStore = useMemo(() => {
+    if (!activeChatStore || !chatState) return null;
+    
+    // Get the store methods (actions) from the vanilla store
+    const storeMethods = activeChatStore.getState();
+    
+    return {
+      ...chatState,
+      // Bind store methods to maintain proper context
+      ...Object.keys(storeMethods).reduce((acc, key) => {
+        const value = (storeMethods as any)[key];
+        if (typeof value === 'function') {
+          (acc as any)[key] = value.bind(storeMethods);
+        }
+        return acc;
+      }, {} as any)
+    };
+  }, [activeChatStore, chatState]);
+
+  return {
+    projectStore,
+    chatStore
+  }
+}
+
+export default useChatStoreAdapter

--- a/src/hooks/useChatStoreAdapter.tsx
+++ b/src/hooks/useChatStoreAdapter.tsx
@@ -1,7 +1,11 @@
-import { useProjectStore } from '@/store/projectStore';
+import { ChatStore } from '@/store/chatStore';
+import { ProjectStore, useProjectStore } from '@/store/projectStore';
 import React, { useEffect, useMemo, useState } from 'react'
 
-const useChatStoreAdapter = () => {
+const useChatStoreAdapter = ():{
+  projectStore: ProjectStore, 
+  chatStore: ChatStore
+} => {
   const projectStore = useProjectStore();
     
   // Get the active chat store from project store

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -51,7 +51,7 @@ export default function Home() {
 	const {t} = useTranslation()
 	const navigate = useNavigate();
 	//Get Chatstore for the active project's task
-	const { chatStore } = useChatStoreAdapter();
+	const { chatStore, projectStore } = useChatStoreAdapter();
 	if (!chatStore) {
 		return <div>Loading...</div>;
 	}
@@ -224,7 +224,7 @@ export default function Home() {
 			navigate(`/`);
 			return;
 		}
-		chatStore.create();
+		projectStore.createProject("new project");
 		navigate("/");
 	};
 

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -45,11 +45,17 @@ import { SearchHistoryDialog } from "@/components/SearchHistoryDialog";
 import { Tag } from "@/components/ui/tag";
 import { share } from "@/lib/share";
 import { useTranslation } from "react-i18next";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export default function Home() {
 	const {t} = useTranslation()
 	const navigate = useNavigate();
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const { history_type, setHistoryType } = useGlobalStore();
 	const [historyTasks, setHistoryTasks] = useState<any[]>([]);
 	const [deleteModalOpen, setDeleteModalOpen] = useState(false);

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -176,7 +176,7 @@ export default function Home() {
 	};
 
 	const handleReplay = async (taskId: string, question: string) => {
-		chatStore.replay(taskId, question, 0);
+		projectStore.replayProject([taskId], question);
 		navigate({ pathname: "/" });
 	};
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,10 +16,16 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable"
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export default function Home() {
 	const { toggle } = useSidebarStore();
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 	const [activeWebviewId, setActiveWebviewId] = useState<string | null>(null);
 
 	window.ipcRenderer?.on("webview-show", (_event, id: string) => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,7 +21,7 @@ import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 export default function Home() {
 	const { toggle } = useSidebarStore();
 	//Get Chatstore for the active project's task
-	const { chatStore } = useChatStoreAdapter();
+	const { chatStore, projectStore } = useChatStoreAdapter();
 	if (!chatStore) {
 		return <div>Loading...</div>;
 	}
@@ -144,7 +144,7 @@ export default function Home() {
 
 	useEffect(() => {
 		if (!chatStore.activeTaskId) {
-			chatStore.create();
+			projectStore.createProject("new project");
 		}
 
 		const webviewContainer = document.getElementById("webview-container");

--- a/src/pages/Setting/General.tsx
+++ b/src/pages/Setting/General.tsx
@@ -23,6 +23,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import useChatStoreAdapter from "@/hooks/useChatStoreAdapter";
 
 export default function SettingGeneral() {
 	const { t } = useTranslation();
@@ -36,7 +37,12 @@ export default function SettingGeneral() {
 	const fullNameRef: RefObject<HTMLInputElement> = createRef();
 	const nickNameRef: RefObject<HTMLInputElement> = createRef();
 	const workDescRef: RefObject<HTMLInputElement> = createRef();
-	const chatStore = useChatStore();
+	//Get Chatstore for the active project's task
+	const { chatStore } = useChatStoreAdapter();
+	if (!chatStore) {
+		return <div>Loading...</div>;
+	}
+	
 
 	const [themeList, setThemeList] = useState<any>([
 		{

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -1,6 +1,6 @@
 import { fetchPost, fetchPut, getBaseURL, proxyFetchPost, proxyFetchPut, proxyFetchGet, uploadFile, fetchDelete } from '@/api/http';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
-import { create } from 'zustand';
+import { createStore } from 'zustand';
 import { generateUniqueId, uploadLog } from "@/lib";
 import { FileText } from 'lucide-react';
 import { getAuthStore, useWorkerList } from './authStore';
@@ -41,7 +41,7 @@ interface Task {
 	isTaskEdit: boolean;
 }
 
-interface ChatStore {
+export interface ChatStore {
 	updateCount: number;
 	activeTaskId: string | null;
 	tasks: { [key: string]: Task };
@@ -99,10 +99,10 @@ interface ChatStore {
 
 
 
-const chatStore = create<ChatStore>()(
+const chatStore = (initial?: Partial<ChatStore>) => createStore<ChatStore>()(
 	(set, get) => ({
 		activeTaskId: null,
-		tasks: {},
+		tasks: initial?.tasks ?? {},
 		updateCount: 0,
 		create(id?: string, type?: any) {
 			const taskId = id ? id : generateUniqueId();
@@ -1724,4 +1724,6 @@ const filterMessage = (message: AgentMessage) => {
 
 export const useChatStore = chatStore;
 
-export const getToolStore = () => chatStore.getState();
+export type VanillaChatStore = ReturnType<typeof chatStore>;
+
+export const getToolStore = () => chatStore().getState();

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1,0 +1,166 @@
+import { create } from 'zustand';
+import { generateUniqueId } from "@/lib";
+import { useChatStore, VanillaChatStore } from './chatStore';
+
+interface Project {
+	id: string;
+	name: string;
+	description?: string;
+	createdAt: number;
+	updatedAt: number;
+	chatStore: VanillaChatStore | null; // Serialized state of the chatStore for this project
+	metadata?: {
+		tags?: string[];
+		priority?: 'low' | 'medium' | 'high';
+		status?: 'active' | 'completed' | 'archived';
+	};
+}
+
+interface ProjectStore {
+	activeProjectId: string | null;
+	projects: { [projectId: string]: Project };
+	
+	// Project management
+	createProject: (name: string, description?: string) => string;
+	setActiveProject: (projectId: string) => void;
+	removeProject: (projectId: string) => void;
+	updateProject: (projectId: string, updates: Partial<Omit<Project, 'id' | 'createdAt'>>) => void;
+	
+	// Chat store state management
+	saveChatStore: (projectId: string, state: VanillaChatStore) => void;
+	getChatStore: (projectId: string) => VanillaChatStore | null;
+	
+	// Utility methods
+	getAllProjects: () => Project[];
+	getProjectById: (projectId: string) => Project | null;
+}
+
+
+const projectStore = create<ProjectStore>()((set, get) => ({
+	activeProjectId: null,
+	projects: {},
+	
+	createProject: (name: string, description?: string) => {
+		const projectId = generateUniqueId();
+		const now = Date.now();
+		
+		// Create new project with default chat store state
+		const newProject: Project = {
+			id: projectId,
+			name,
+			description,
+			createdAt: now,
+			updatedAt: now,
+			chatStore: useChatStore(),
+			metadata: {
+				status: 'active'
+			}
+		};
+		
+		set((state) => ({
+			projects: {
+				...state.projects,
+				[projectId]: newProject
+			},
+			activeProjectId: projectId
+		}));
+		
+		return projectId;
+	},
+	
+	setActiveProject: (projectId: string) => {
+		const { projects } = get();
+		
+		if (!projects[projectId]) {
+			console.warn(`Project ${projectId} not found`);
+			return;
+		}
+		
+		set({ activeProjectId: projectId });
+		
+		// Update project's updatedAt
+		set((state) => ({
+			projects: {
+				...state.projects,
+				[projectId]: {
+					...state.projects[projectId],
+					updatedAt: Date.now()
+				}
+			}
+		}));
+	},
+	
+	removeProject: (projectId: string) => {
+		const { activeProjectId, projects } = get();
+		
+		if (!projects[projectId]) {
+			console.warn(`Project ${projectId} not found`);
+			return;
+		}
+		
+		// If removing the active project, switch to another project or set to null
+		let newActiveId = activeProjectId;
+		if (activeProjectId === projectId) {
+			const remainingProjects = Object.keys(projects).filter(id => id !== projectId);
+			newActiveId = remainingProjects.length > 0 ? remainingProjects[0] : null;
+		}
+		
+		set((state) => {
+			const newProjects = { ...state.projects };
+			delete newProjects[projectId];
+			
+			return {
+				projects: newProjects,
+				activeProjectId: newActiveId
+			};
+		});
+	},
+	
+	updateProject: (projectId: string, updates: Partial<Omit<Project, 'id' | 'createdAt'>>) => {
+		set((state) => ({
+			projects: {
+				...state.projects,
+				[projectId]: {
+					...state.projects[projectId],
+					...updates,
+					updatedAt: Date.now()
+				}
+			}
+		}));
+	},
+	
+	saveChatStore: (projectId: string, state: VanillaChatStore) => {
+		const { projects } = get();
+		
+		if (projects[projectId]) {
+			set((currentState) => ({
+				projects: {
+					...currentState.projects,
+					[projectId]: {
+						...currentState.projects[projectId],
+						chatStore: state
+					}
+				}
+			}));
+		}
+	},
+	
+	getChatStore: (projectId: string) => {
+		const { projects } = get();
+		const project = projects[projectId];
+		return project?.chatStore || null;
+	},
+	
+	getAllProjects: () => {
+		const { projects } = get();
+		return Object.values(projects).sort((a, b) => b.updatedAt - a.updatedAt);
+	},
+	
+	getProjectById: (projectId: string) => {
+		const { projects } = get();
+		return projects[projectId] || null;
+	}
+}));
+
+export const useProjectStore = projectStore;
+export type { Project, ProjectStore };

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -125,9 +125,6 @@ const projectStore = create<ProjectStore>()((set, get) => ({
 		const chatId = generateUniqueId();
 		const newChatStore = useChatStore();
 		
-		// Initialize the chat store with a task using the create() function
-		newChatStore.getState().create();
-		
 		set((state) => ({
 			projects: {
 				...state.projects,
@@ -339,7 +336,7 @@ const projectStore = create<ProjectStore>()((set, get) => ({
 	},
 	
 	getChatStore: (projectId?: string, chatId?: string) => {
-		const { projects, activeProjectId, createProject, createChatStore } = get();
+		const { projects, activeProjectId, createProject } = get();
 		
 		// Use provided projectId or fall back to activeProjectId
 		const targetProjectId = projectId || activeProjectId;

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { generateUniqueId } from "@/lib";
 import { useChatStore, VanillaChatStore } from './chatStore';
+import { devtools } from 'zustand/middleware';
 
 interface Project {
 	id: string;
@@ -54,6 +55,9 @@ const projectStore = create<ProjectStore>()((set, get) => ({
 		const initialChatId = generateUniqueId();
 		const initialChatStore = useChatStore();
 		
+		// Initialize the chat store with a task using the create() function
+		initialChatStore.getState().create();
+		
 		// Create new project with default chat store
 		const newProject: Project = {
 			id: projectId,
@@ -69,6 +73,8 @@ const projectStore = create<ProjectStore>()((set, get) => ({
 				status: 'active'
 			}
 		};
+		
+		console.log("[store] Creating a new project");
 		
 		set((state) => ({
 			projects: {
@@ -113,6 +119,9 @@ const projectStore = create<ProjectStore>()((set, get) => ({
 		
 		const chatId = generateUniqueId();
 		const newChatStore = useChatStore();
+		
+		// Initialize the chat store with a task using the create() function
+		newChatStore.getState().create();
 		
 		set((state) => ({
 			projects: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<img width="3924" height="1684" alt="image" src="https://github.com/user-attachments/assets/cb425cb5-fdef-43b0-bd95-c6589d7058a6" />

### Description
- Support for least coupled multi-task chatStore
- Elevated `chatStore` to use `createStore` i.e vanilla zustand, so introduced `useChatStoreAdapter` hook for backward compatibility with current components. 
- ⭐ Thus this design enabled a clean & robust integration to the current store thus enabling backward compatibility without much changes to the current state logic:
```ts
//old: const chatStore = useChatStore()
const { chatStore, projectStore } = useChatStoreAdapter();
if (!chatStore) {
   return <div>Loading...</div>;
}
```
- Hopefully this will enable multi-task (with its own subtask, summary etc..) per each project

<img width="500" height="570" alt="image" src="https://github.com/user-attachments/assets/9bbd4936-07aa-455f-8e21-c45c5063f2fb" />

### Tested Features
- New Chat ✅ 
- History API✅ 
- Replay API✅ 
- Reuse New Project if exists✅ 
- Create New Project + ChatStore on `useChatStoreAdapter`✅ 


### Known limitations / future enhancements
- use the code below to debug:
```ts
// Helper function to get chatStore states
const getChatStoreStates = (chatStores: any) => {
  const result: any = {};
  for (const [chatId, chatStore] of Object.entries(chatStores)) {
    result[chatId] = chatStore && typeof (chatStore as any).getState === 'function' 
      ? (chatStore as any).getState() 
      : chatStore;
  }
  return result;
};

// Get all projects and properly structure them with chatStore states
const allProjects = projectStore.getAllProjects();
const projectsWithChatStoreStates = allProjects.reduce((acc: any, project: any) => {
  acc[project.id] = {
    ...project,
    chatStores: getChatStoreStates(project.chatStores || {})
  };
  return acc;
}, {});

console.debug("[Store]: ", {
  activeProjectId: projectStore.activeProjectId,
  projects: projectsWithChatStoreStates
})
```

- on projectReply it uses the `question` as the project id (untill project_id is introduced later)
- currently `chatStore` saves a list of tasks[] for backward compatibility. In the future we need to update the state to have single task per chatStore. Currently creating nested ids i.e. as key and as "id" field:
```json
{
activeProjectId: "myProjectId",
"projects": {
     "activeProjectId":"myProjectId",
     "myProjectId": {
        "id": "myProjectId",
         "activeChatStoreId": "chatStoreId",
        "chatStores": {
            "chatStoreId": {
                 "activeTaskId":1234234,
                 "tasks": {},
                 ....
            }  
        }
     }
}
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
