### PR TITLE
chore: fix setting blank

### DIFF
--- a/package/@stackframe/react/dist/esm/lib/stack-app/apps/implementations/common.js
+++ b/package/@stackframe/react/dist/esm/lib/stack-app/apps/implementations/common.js
@@ -98,6 +98,18 @@ function createEmptyTokenStore() {
   });
 }
 var cachePromiseByHookId = /* @__PURE__ */ new Map();
+var useReactPromise = typeof React.use === "function" ? React.use.bind(React) : (promise) => {
+  if (!promise || typeof promise !== "object") {
+    return promise;
+  }
+  if (promise.status === "fulfilled") {
+    return promise.value;
+  }
+  if (promise.status === "rejected") {
+    throw promise.reason ?? promise;
+  }
+  throw promise;
+};
 function useAsyncCache(cache, dependencies, caller) {
   suspendIfSsr(caller);
   const id = React.useId();
@@ -119,7 +131,7 @@ function useAsyncCache(cache, dependencies, caller) {
     getSnapshot,
     () => throwErr(new Error("getServerSnapshot should never be called in useAsyncCache because we restrict to CSR earlier"))
   );
-  const result = React.use(promise);
+  const result = useReactPromise(promise);
   if (result.status === "error") {
     const error = result.error;
     if (error instanceof Error && !error.__stackHasConcatenatedStacktraces) {

--- a/package/@stackframe/react/dist/lib/stack-app/apps/implementations/common.js
+++ b/package/@stackframe/react/dist/lib/stack-app/apps/implementations/common.js
@@ -143,6 +143,18 @@ function createEmptyTokenStore() {
   });
 }
 var cachePromiseByHookId = /* @__PURE__ */ new Map();
+var useReactPromise = typeof import_react2.default.use === "function" ? import_react2.default.use.bind(import_react2.default) : (promise) => {
+  if (!promise || typeof promise !== "object") {
+    return promise;
+  }
+  if (promise.status === "fulfilled") {
+    return promise.value;
+  }
+  if (promise.status === "rejected") {
+    throw promise.reason ?? promise;
+  }
+  throw promise;
+};
 function useAsyncCache(cache, dependencies, caller) {
   (0, import_react.suspendIfSsr)(caller);
   const id = import_react2.default.useId();
@@ -164,7 +176,7 @@ function useAsyncCache(cache, dependencies, caller) {
     getSnapshot,
     () => (0, import_errors.throwErr)(new Error("getServerSnapshot should never be called in useAsyncCache because we restrict to CSR earlier"))
   );
-  const result = import_react2.default.use(promise);
+  const result = useReactPromise(promise);
   if (result.status === "error") {
     const error = result.error;
     if (error instanceof Error && !error.__stackHasConcatenatedStacktraces) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds a compatibility shim so our bundled useAsyncCache no longer calls React.use directly when running under
  React 18; we unwrap the cached promise manually, avoiding the settings-page crash until we upgrade to React 19

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
