### PR TITLE
fixed image preview by replacing localfile:// with dataURL loader and…

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -16,6 +16,7 @@ import { copyBrowserData } from './copy'
 import { findAvailablePort } from './init'
 import kill from 'tree-kill';
 import { zipFolder } from './utils/log'
+import mime from "mime";
 import axios from 'axios';
 import FormData from 'form-data';
 import { checkAndInstallDepsOnUpdate, PromiseReturnType, getInstallationStatus } from './install-deps'
@@ -397,6 +398,12 @@ function registerIpcHandlers() {
       return { success: false, error: error.message };
     }
   });
+
+  ipcMain.handle("read-file-dataurl", async (event, filePath) => {
+  const file = fs.readFileSync(filePath);
+  const mimeType = mime.getType(path.extname(filePath)) || "application/octet-stream";
+  return `data:${mimeType};base64,${file.toString("base64")}`;
+});
 
   // ==================== log export handler ====================
   ipcMain.handle('export-log', async () => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -1,6 +1,8 @@
 import { ipcRenderer, contextBridge } from 'electron'
 
 
+
+
 contextBridge.exposeInMainWorld('ipcRenderer', {
   on(...args: Parameters<typeof ipcRenderer.on>) {
     const [channel, listener] = args
@@ -59,6 +61,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   executeCommand: (command: string,email:string) => ipcRenderer.invoke('execute-command', command,email),
   // file operations
   readFile: (filePath: string) => ipcRenderer.invoke('read-file', filePath),
+  readFileAsDataUrl: (path : string) => ipcRenderer.invoke("read-file-dataurl", path),
   deleteFolder: (email: string) => ipcRenderer.invoke('delete-folder', email),
   getMcpConfigPath: (email: string) => ipcRenderer.invoke('get-mcp-config-path', email),
   // install dependencies related API

--- a/src/components/Folder/index.tsx
+++ b/src/components/Folder/index.tsx
@@ -575,18 +575,7 @@ export default function Folder({ data }: { data?: Agent }) {
 										"svg",
 								  ].includes(selectedFile.type.toLowerCase()) ? (
 									<div className="flex items-center justify-center h-full">
-										<img
-											src={
-												selectedFile.isRemote
-													? "localfile://" +
-													  encodeURIComponent(selectedFile.content as string)
-													: `localfile://${encodeURIComponent(
-															selectedFile.path
-													  )}`
-											}
-											alt={selectedFile.name}
-											className="max-w-full max-h-full object-contain"
-										/>
+										<ImageLoader selectedFile={selectedFile} />
 									</div>
 								) : (
 									<pre className="text-sm text-zinc-700 font-mono whitespace-pre-wrap break-words overflow-x-auto">
@@ -616,4 +605,27 @@ export default function Folder({ data }: { data?: Agent }) {
 			</div>
 		</div>
 	);
+}
+
+function ImageLoader({ selectedFile }: { selectedFile: FileInfo }) {
+    const [src, setSrc] = useState("");
+
+    useEffect(() => {
+        const filePath = selectedFile.isRemote
+            ? (selectedFile.content as string)
+            : selectedFile.path;
+
+        window.electronAPI
+            .readFileAsDataUrl(filePath)
+            .then(setSrc)
+            .catch((err: any) => console.error("Image load error:", err));
+    }, [selectedFile]);
+
+    return (
+        <img
+            src={src}
+            alt={selectedFile.name}
+            className="max-w-full max-h-full object-contain"
+        />
+    );
 }


### PR DESCRIPTION
# Description

This PR fixes the issue where generated chart images were not displayed inside the app and instead appeared as blocked localfile:// URLs, causing the Electron renderer to download the image instead of showing it.

# What this PR does

Adds a new IPC handler: read-file-dataurl, which reads image files from disk and returns them as a Base64 data URL.

Updates the preload script to expose electronAPI.readFileAsDataUrl.

Replaces the old localfile://-based <img src> logic with a new ImageLoader component that uses the data URL provided by Electron.

Ensures all image types (png, jpg, svg, etc.) render correctly in the File Viewer.

# Root Cause

Electron's renderer does not allow loading raw filesystem paths with localfile://, so images returned from generated tasks were blocked with:

``` bash
GET localfile://... net::ERR_UNKNOWN_URL_SCHEME 
```
# screenshot
<img width="1470" height="914" alt="Screenshot 2025-11-15 at 12 57 06 PM" src="https://github.com/user-attachments/assets/5a23051c-0695-4c78-9efa-0428fe20e229" />

### What is the purpose of this pull request?
- [x] Bug fix  
- [ ] New Feature  
- [ ] Documentation update  
- [ ] Other
