### PR TITLE
fix: edit task not deleting current last history

### DIFF
--- a/src/components/ChatBox/index.tsx
+++ b/src/components/ChatBox/index.tsx
@@ -444,9 +444,17 @@ export default function ChatBox(): JSX.Element {
 	};
 
 	// Edit query handler
-	const handleEditQuery = () => {
+	const handleEditQuery = async () => {
 		const taskId = chatStore.activeTaskId as string;
-		fetchDelete(`/chat/${taskId}`);
+		const projectId = projectStore.activeProjectId;
+
+		// Early validation
+		if (!projectId) {
+			console.error("No active project ID found for edit operation");
+			return;
+		}
+
+		// Get question and attachments before any deletions
 		const messageIndex = chatStore.tasks[taskId].messages.findLastIndex(
 			(item) => item.step === "to_sub_tasks"
 		);
@@ -454,6 +462,28 @@ export default function ChatBox(): JSX.Element {
 		const question = questionMessage.content;
 		// Get the file attachments from the original user message (not from task.attaches which gets cleared after sending)
 		const attachments = questionMessage.attaches || [];
+
+		// Delete task from backend first
+		try {
+			await fetchDelete(`/chat/${taskId}`);
+		} catch (error) {
+			console.error("Failed to delete task from backend:", error);
+			// Continue with local cleanup even if backend fails
+		}
+
+		// Delete chat history
+		const history_id = projectStore.getHistoryId(projectId);
+		if (history_id) {
+			try {
+				await proxyFetchDelete(`/api/chat/history/${history_id}`);
+			} catch(error) {
+				console.error(`Failed to delete chat history (ID: ${history_id}) for project ${projectId}:`, error);
+			}
+		} else {
+			console.warn(`No history ID found for project ${projectId} during edit operation`);
+		}
+
+		// Create new task and clean up locally
 		let id = chatStore.create();
 		chatStore.setHasMessages(id, true);
 		// Copy the file attachments to the new task
@@ -461,13 +491,6 @@ export default function ChatBox(): JSX.Element {
 			chatStore.setAttaches(id, attachments);
 		}
 		chatStore.removeTask(taskId);
-		const history_id = projectStore.getHistoryId(projectStore.activeProjectId);
-		try {
-			if(!history_id) throw new Error("No history ID found for the project");
-			proxyFetchDelete(`/api/chat/history/${history_id}`);
-		} catch(error) {
-			console.error("Failed to delete chat history:", error);
-		}
 		setMessage(question);
 	};
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
- Edit task tries to delete based on TaskId while endpoint expects historyId

### Hindsight possible issues
- Remember I mentioned about the limitation of current isolation of projectId-taskId in https://github.com/eigent-ai/eigent/pull/645 ?
- Well, its back when deleting history where `simple -> simple -> workforce` then when "edit" deletes the s -> s -> w history. As I mentioned before that simple & workforce chats are stored in same history.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
