### PR TITLE
fix: clean string to remove punctuation of {.," around links

### DIFF
--- a/src/components/ChatBox/MessageItem/MarkDown.tsx
+++ b/src/components/ChatBox/MessageItem/MarkDown.tsx
@@ -128,9 +128,12 @@ export const MarkDown = memo(
 							const cleanChildren = typeof children === 'string' 
 								? children.replace(/^[.,"'{}()\[\]]+|[.,"'{}()\[\]]+$/g, '') 
 								: children;
+							const cleanHref = typeof href === 'string'
+								? href.replace(/^[.,"'{}()\[\]]+|[.,"'{}()\[\]]+$/g, '').replace(/(%[0-9A-Fa-f]{2})+$/g, '')
+								: href;
 							return (
 								<a 
-									href={href} 
+									href={cleanHref} 
 									className="text-blue-600 hover:text-blue-800 underline break-words inline"
 									style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}
 									target="_blank" 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
- Fix link punctuation issues
- Looks like:
<img width="301" height="388" alt="image" src="https://github.com/user-attachments/assets/cc48f35c-7b53-469d-8b2c-9288ae463909" />

From: "{\"link\": \"https://calendar.example.com/event/6h9ankk8vnnij6ngeu4pi2kr2k\"} Value",

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
