### PR TITLE
chore: adjust timeout setting

### DIFF
--- a/backend/app/controller/chat_controller.py
+++ b/backend/app/controller/chat_controller.py
@@ -34,8 +34,8 @@ router = APIRouter()
 # Create traceroot logger for chat controller
 chat_logger = traceroot.get_logger("chat_controller")
 
-# SSE timeout configuration (10 minutes in seconds)
-SSE_TIMEOUT_SECONDS = 10 * 60
+# SSE timeout configuration (30 minutes in seconds)
+SSE_TIMEOUT_SECONDS = 30 * 60
 
 
 async def timeout_stream_wrapper(stream_generator, timeout_seconds: int = SSE_TIMEOUT_SECONDS):
@@ -58,8 +58,7 @@ async def timeout_stream_wrapper(stream_generator, timeout_seconds: int = SSE_TI
                 yield data
             except asyncio.TimeoutError:
                 chat_logger.warning(f"SSE timeout: No data received for {timeout_seconds} seconds, closing connection")
-                # yield sse_json("error", {"message": "Connection timeout: No data received for 10 minutes"})
-                # TODO: Temporary change: suppress error signal to frontend on timeout. Needs proper fix later.
+                yield sse_json("error", {"message": f"Connection timeout: No data received for {timeout_seconds // 60} minutes"})
                 break
             except StopAsyncIteration:
                 break

--- a/backend/app/service/task.py
+++ b/backend/app/service/task.py
@@ -45,6 +45,7 @@ class Action(str, Enum):
     add_task = "add_task"  # user -> backend
     remove_task = "remove_task"  # user -> backend
     skip_task = "skip_task"  # user -> backend
+    timeout = "timeout"  # backend -> user (task timeout error)
 
 
 class ActionImproveData(BaseModel):
@@ -173,6 +174,11 @@ class ActionEndData(BaseModel):
     action: Literal[Action.end] = Action.end
 
 
+class ActionTimeoutData(BaseModel):
+    action: Literal[Action.timeout] = Action.timeout
+    data: dict[Literal["message", "in_flight_tasks", "pending_tasks", "timeout_seconds"], str | int]
+
+
 class ActionSupplementData(BaseModel):
     action: Literal[Action.supplement] = Action.supplement
     data: SupplementChat
@@ -233,6 +239,7 @@ ActionData = (
     | ActionTerminalData
     | ActionStopData
     | ActionEndData
+    | ActionTimeoutData
     | ActionSupplementData
     | ActionTakeControl
     | ActionNewAgent

--- a/backend/app/utils/workforce.py
+++ b/backend/app/utils/workforce.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Generator, List
+from typing import Generator, List, Optional
 from camel.agents import ChatAgent
 from camel.societies.workforce.workforce import (
     Workforce as BaseWorkforce,
@@ -22,6 +22,7 @@ from app.service.task import (
     ActionAssignTaskData,
     ActionEndData,
     ActionTaskStateData,
+    ActionTimeoutData,
     get_camel_task,
     get_task_lock,
 )
@@ -60,6 +61,7 @@ class Workforce(BaseWorkforce):
             graceful_shutdown_timeout=graceful_shutdown_timeout,
             share_memory=share_memory,
             use_structured_output_handler=use_structured_output_handler,
+            task_timeout_seconds=1800,  # 30 minutes
             failure_handling_config=FailureHandlingConfig(
                 enabled_strategies=["retry", "replan"],
             ),
@@ -501,6 +503,55 @@ class Workforce(BaseWorkforce):
         )
 
         return result
+
+    async def _get_returned_task(self) -> Optional[Task]:
+        r"""Override to handle timeout and send notification to frontend.
+
+        Get the task that's published by this node and just get returned
+        from the assignee. Includes timeout handling to prevent indefinite
+        waiting.
+
+        Raises:
+            asyncio.TimeoutError: If waiting for task exceeds timeout
+        """
+        try:
+            return await asyncio.wait_for(
+                self._channel.get_returned_task_by_publisher(self.node_id),
+                timeout=self.task_timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            # Send timeout notification to frontend before re-raising
+            logger.warning(
+                f"⏰ [WF-TIMEOUT] Task timeout in workforce {self.node_id}. "
+                f"Timeout: {self.task_timeout_seconds}s, "
+                f"Pending tasks: {len(self._pending_tasks)}, "
+                f"In-flight tasks: {self._in_flight_tasks}"
+            )
+
+            # Try to notify frontend, but don't let notification failure mask the timeout
+            try:
+                task_lock = get_task_lock(self.api_task_id)
+                timeout_minutes = self.task_timeout_seconds // 60
+                await task_lock.put_queue(
+                    ActionTimeoutData(
+                        data={
+                            "message": f"Task execution timeout: No response received for {timeout_minutes} minutes",
+                            "in_flight_tasks": self._in_flight_tasks,
+                            "pending_tasks": len(self._pending_tasks),
+                            "timeout_seconds": self.task_timeout_seconds,
+                        }
+                    )
+                )
+            except Exception as notify_err:
+                logger.error(f"Failed to send timeout notification: {notify_err}")
+            raise
+        except Exception as e:
+            logger.error(
+                f"Error getting returned task {e} in workforce {self.node_id}. "
+                f"Current pending tasks: {len(self._pending_tasks)}, "
+                f"In-flight tasks: {self._in_flight_tasks}"
+            )
+            raise
 
     def stop(self) -> None:
         logger.info("=" * 80)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

  Summary

  - Increase SSE and task timeout from 10 minutes to 30 minutes
  - Add proper error notifications when timeouts occur instead of silent disconnection

  Changes

  - SSE timeout: Now sends error message to frontend before closing connection
  - Task timeout: Added new Action.timeout type to notify frontend when workforce task execution times out, including details
  about in-flight and pending tasks

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
