### PR TITLE
chore: refactor api_task_id to api_project_id

### DIFF
--- a/backend/app/utils/listen/toolkit_listen.py
+++ b/backend/app/utils/listen/toolkit_listen.py
@@ -89,12 +89,12 @@ def listen_toolkit(
             @wraps(wrap)
             async def async_wrapper(*args, **kwargs):
                 toolkit: AbstractToolkit = args[0]
-                # Check if api_task_id exists
-                if not hasattr(toolkit, 'api_task_id'):
-                    logger.warning(f"[listen_toolkit] {toolkit.__class__.__name__} missing api_task_id, calling method directly")
+                # Check if api_project_id exists
+                if not hasattr(toolkit, 'api_project_id'):
+                    logger.warning(f"[listen_toolkit] {toolkit.__class__.__name__} missing api_project_id, calling method directly")
                     return await func(*args, **kwargs)
                     
-                task_lock = get_task_lock(toolkit.api_task_id)
+                task_lock = get_task_lock(toolkit.api_project_id)
 
                 if inputs is not None:
                     args_str = inputs(*args, **kwargs)
@@ -122,9 +122,9 @@ def listen_toolkit(
                 # Multi-layer fallback to get process_task_id
                 process_task_id = process_task.get("")
                 if not process_task_id:
-                    process_task_id = getattr(toolkit, 'api_task_id', "")
+                    process_task_id = getattr(toolkit, 'api_project_id', "")
                     if not process_task_id:
-                        logger.warning(f"[toolkit_listen] Both ContextVar process_task and toolkit.api_task_id are empty for {toolkit_name}.{method_name}")
+                        logger.warning(f"[toolkit_listen] Both ContextVar process_task and toolkit.api_project_id are empty for {toolkit_name}.{method_name}")
 
                 if not skip_workflow_display:
                     activate_data = ActionActivateToolkitData(
@@ -193,12 +193,12 @@ def listen_toolkit(
             def sync_wrapper(*args, **kwargs):
                 toolkit: AbstractToolkit = args[0]
 
-                # Check if api_task_id exists
-                if not hasattr(toolkit, 'api_task_id'):
-                    logger.warning(f"[listen_toolkit] {toolkit.__class__.__name__} missing api_task_id, calling method directly")
+                # Check if api_project_id exists
+                if not hasattr(toolkit, 'api_project_id'):
+                    logger.warning(f"[listen_toolkit] {toolkit.__class__.__name__} missing api_project_id, calling method directly")
                     return func(*args, **kwargs)
 
-                task_lock = get_task_lock(toolkit.api_task_id)
+                task_lock = get_task_lock(toolkit.api_project_id)
 
                 if inputs is not None:
                     args_str = inputs(*args, **kwargs)
@@ -225,9 +225,9 @@ def listen_toolkit(
                 # Multi-layer fallback to get process_task_id
                 process_task_id = process_task.get("")
                 if not process_task_id:
-                    process_task_id = getattr(toolkit, 'api_task_id', "")
+                    process_task_id = getattr(toolkit, 'api_project_id', "")
                     if not process_task_id:
-                        logger.warning(f"[toolkit_listen] Both ContextVar process_task and toolkit.api_task_id are empty for {toolkit_name}.{method_name}")
+                        logger.warning(f"[toolkit_listen] Both ContextVar process_task and toolkit.api_project_id are empty for {toolkit_name}.{method_name}")
 
                 if not skip_workflow_display:
                     activate_data = ActionActivateToolkitData(

--- a/backend/app/utils/toolkit/abstract_toolkit.py
+++ b/backend/app/utils/toolkit/abstract_toolkit.py
@@ -3,13 +3,13 @@ from inflection import titleize
 
 
 class AbstractToolkit:
-    api_task_id: str
+    api_project_id: str
     agent_name: str
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> list[FunctionTool]:
+    def get_can_use_tools(cls, api_project_id: str) -> list[FunctionTool]:
         """default return all tools, subclass can override this method to filter tools"""
-        return cls(api_task_id).get_tools()  # type: ignore
+        return cls(api_project_id).get_tools()  # type: ignore
 
     @classmethod
     def toolkit_name(cls) -> str:

--- a/backend/app/utils/toolkit/audio_analysis_toolkit.py
+++ b/backend/app/utils/toolkit/audio_analysis_toolkit.py
@@ -14,7 +14,7 @@ class AudioAnalysisToolkit(BaseAudioAnalysisToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         cache_dir: str | None = None,
         transcribe_model: BaseAudioModel | None = None,
         audio_reasoning_model: BaseModelBackend | None = None,
@@ -23,4 +23,4 @@ class AudioAnalysisToolkit(BaseAudioAnalysisToolkit, AbstractToolkit):
         if cache_dir is None:
             cache_dir = env("file_save_path", os.path.expanduser("~/.eigent/tmp/"))
         super().__init__(cache_dir, transcribe_model, audio_reasoning_model, timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id

--- a/backend/app/utils/toolkit/code_execution_toolkit.py
+++ b/backend/app/utils/toolkit/code_execution_toolkit.py
@@ -11,7 +11,7 @@ class CodeExecutionToolkit(BaseCodeExecutionToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         sandbox: Literal["internal_python", "jupyter", "docker", "subprocess", "e2b"] = "subprocess",
         verbose: bool = False,
         unsafe_mode: bool = False,
@@ -19,7 +19,7 @@ class CodeExecutionToolkit(BaseCodeExecutionToolkit, AbstractToolkit):
         require_confirm: bool = False,
         timeout: float | None = None,
     ) -> None:
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         super().__init__(sandbox, verbose, unsafe_mode, import_white_list, require_confirm, timeout)
 
     def get_tools(self) -> List[FunctionTool]:

--- a/backend/app/utils/toolkit/craw4ai_toolkit.py
+++ b/backend/app/utils/toolkit/craw4ai_toolkit.py
@@ -9,8 +9,8 @@ from app.utils.toolkit.abstract_toolkit import AbstractToolkit
 class Crawl4AIToolkit(BaseCrawl4AIToolkit, AbstractToolkit):
     agent_name: str = Agents.search_agent
 
-    def __init__(self, api_task_id: str, timeout: float | None = None):
-        self.api_task_id = api_task_id
+    def __init__(self, api_project_id: str, timeout: float | None = None):
+        self.api_project_id = api_project_id
         super().__init__(timeout)
 
     def toolkit_name(self) -> str:

--- a/backend/app/utils/toolkit/excel_toolkit.py
+++ b/backend/app/utils/toolkit/excel_toolkit.py
@@ -13,11 +13,11 @@ class ExcelToolkit(BaseExcelToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         timeout: float | None = None,
         working_directory: str | None = None,
     ):
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         if working_directory is None:
             working_directory = env("file_save_path", os.path.expanduser("~/Downloads"))
         super().__init__(timeout=timeout, working_directory=working_directory)

--- a/backend/app/utils/toolkit/file_write_toolkit.py
+++ b/backend/app/utils/toolkit/file_write_toolkit.py
@@ -15,7 +15,7 @@ class FileToolkit(BaseFileToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         working_directory: str | None = None,
         timeout: float | None = None,
         default_encoding: str = "utf-8",
@@ -24,7 +24,7 @@ class FileToolkit(BaseFileToolkit, AbstractToolkit):
         if working_directory is None:
             working_directory = env("file_save_path", os.path.expanduser("~/Downloads"))
         super().__init__(working_directory, timeout, default_encoding, backup_enabled)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
 
     @listen_toolkit(
         BaseFileToolkit.write_to_file,
@@ -45,7 +45,7 @@ class FileToolkit(BaseFileToolkit, AbstractToolkit):
     ) -> str:
         res = super().write_to_file(title, content, filename, encoding, use_latex)
         if "Content successfully written to file: " in res:
-            task_lock = get_task_lock(self.api_task_id)
+            task_lock = get_task_lock(self.api_project_id)
             # Capture ContextVar value before creating async task
             current_process_task_id = process_task.get("")
 

--- a/backend/app/utils/toolkit/github_toolkit.py
+++ b/backend/app/utils/toolkit/github_toolkit.py
@@ -13,16 +13,16 @@ class GithubToolkit(BaseGithubToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         access_token: str | None = None,
         timeout: float | None = None,
     ) -> None:
         super().__init__(access_token, timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> list[FunctionTool]:
+    def get_can_use_tools(cls, api_project_id: str) -> list[FunctionTool]:
         if env("GITHUB_ACCESS_TOKEN"):
-            return GithubToolkit(api_task_id).get_tools()
+            return GithubToolkit(api_project_id).get_tools()
         else:
             return []

--- a/backend/app/utils/toolkit/google_calendar_toolkit.py
+++ b/backend/app/utils/toolkit/google_calendar_toolkit.py
@@ -19,8 +19,8 @@ SCOPES = ['https://www.googleapis.com/auth/calendar']
 class GoogleCalendarToolkit(BaseGoogleCalendarToolkit, AbstractToolkit):
     agent_name: str = Agents.social_medium_agent
 
-    def __init__(self, api_task_id: str, timeout: float | None = None):
-        self.api_task_id = api_task_id
+    def __init__(self, api_project_id: str, timeout: float | None = None):
+        self.api_project_id = api_project_id
         # Use a stable token file (no per-task suffix). Can be overridden by env.
         self._token_path = env("GOOGLE_CALENDAR_TOKEN_PATH") or os.path.join(
             os.path.expanduser("~"),
@@ -42,7 +42,7 @@ class GoogleCalendarToolkit(BaseGoogleCalendarToolkit, AbstractToolkit):
         )
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str):
+    def get_can_use_tools(cls, api_project_id: str):
         from dotenv import load_dotenv
         
         # Force reload environment variables
@@ -51,7 +51,7 @@ class GoogleCalendarToolkit(BaseGoogleCalendarToolkit, AbstractToolkit):
             load_dotenv(dotenv_path=default_env_path, override=True)
         
         if os.environ.get("GOOGLE_CLIENT_ID") and os.environ.get("GOOGLE_CLIENT_SECRET"):
-            return cls(api_task_id).get_tools()
+            return cls(api_project_id).get_tools()
         else:
             return []
 
@@ -151,7 +151,7 @@ class GoogleCalendarToolkit(BaseGoogleCalendarToolkit, AbstractToolkit):
         return creds
     
     @staticmethod
-    def start_background_auth(api_task_id: str = "install_auth") -> str:
+    def start_background_auth(api_project_id: str = "install_auth") -> str:
         """
         Start background OAuth authorization flow with timeout
         Returns the status of the authorization

--- a/backend/app/utils/toolkit/google_drive_mcp_toolkit.py
+++ b/backend/app/utils/toolkit/google_drive_mcp_toolkit.py
@@ -11,12 +11,12 @@ class GoogleDriveMCPToolkit(BaseGoogleDriveMCPToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         timeout: float | None = None,
         credentials_path: str | None = None,
         input_env: dict[str, str] | None = None,
     ) -> None:
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         super().__init__(timeout, credentials_path)
         credentials_path = credentials_path or env("GDRIVE_CREDENTIALS_PATH")
         self._mcp_toolkit = MCPToolkit(
@@ -33,10 +33,10 @@ class GoogleDriveMCPToolkit(BaseGoogleDriveMCPToolkit, AbstractToolkit):
         )
 
     @classmethod
-    async def get_can_use_tools(cls, api_task_id: str, input_env: dict[str, str] | None = None) -> list[FunctionTool]:
+    async def get_can_use_tools(cls, api_project_id: str, input_env: dict[str, str] | None = None) -> list[FunctionTool]:
         if env("GDRIVE_CREDENTIALS_PATH") is None:
             return []
-        toolkit = cls(api_task_id, 180, env("GDRIVE_CREDENTIALS_PATH"), input_env)
+        toolkit = cls(api_project_id, 180, env("GDRIVE_CREDENTIALS_PATH"), input_env)
         await toolkit.connect()
         tools = []
         for item in toolkit.get_tools():

--- a/backend/app/utils/toolkit/google_gmail_mcp_toolkit.py
+++ b/backend/app/utils/toolkit/google_gmail_mcp_toolkit.py
@@ -10,13 +10,13 @@ class GoogleGmailMCPToolkit(BaseToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         credentials_path: str | None = None,
         timeout: float | None = None,
         input_env: dict[str, str] | None = None,
     ):
         super().__init__(timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         credentials_path = credentials_path or env("GMAIL_CREDENTIALS_PATH")
         self._mcp_toolkit = MCPToolkit(
             config_dict={
@@ -41,10 +41,10 @@ class GoogleGmailMCPToolkit(BaseToolkit, AbstractToolkit):
         return self._mcp_toolkit.get_tools()
 
     @classmethod
-    async def get_can_use_tools(cls, api_task_id: str, input_env: dict[str, str] | None = None) -> list[FunctionTool]:
+    async def get_can_use_tools(cls, api_project_id: str, input_env: dict[str, str] | None = None) -> list[FunctionTool]:
         if env("GMAIL_CREDENTIALS_PATH") is None:
             return []
-        toolkit = cls(api_task_id, env_or_fail("GMAIL_CREDENTIALS_PATH"), 180, input_env)
+        toolkit = cls(api_project_id, env_or_fail("GMAIL_CREDENTIALS_PATH"), 180, input_env)
         await toolkit.connect()
         tools = []
         for item in toolkit.get_tools():

--- a/backend/app/utils/toolkit/human_toolkit.py
+++ b/backend/app/utils/toolkit/human_toolkit.py
@@ -20,11 +20,11 @@ class HumanToolkit(BaseToolkit, AbstractToolkit):
 
     agent_name: str
 
-    def __init__(self, api_task_id: str, agent_name: str, timeout: float | None = None):
+    def __init__(self, api_project_id: str, agent_name: str, timeout: float | None = None):
         super().__init__(timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         self.agent_name = agent_name
-        task_lock = get_task_lock(self.api_task_id)
+        task_lock = get_task_lock(self.api_project_id)
         task_lock.add_human_input_listen(self.agent_name)
 
     @listen_toolkit(inputs=lambda _, question: question)
@@ -46,7 +46,7 @@ class HumanToolkit(BaseToolkit, AbstractToolkit):
             str: The user's response to the question.
         """
         logger.info(f"Question: {question}")
-        task_lock = get_task_lock(self.api_task_id)
+        task_lock = get_task_lock(self.api_project_id)
         await task_lock.put_queue(
             ActionAskData(
                 action=Action.ask,
@@ -106,13 +106,13 @@ class HumanToolkit(BaseToolkit, AbstractToolkit):
         if message_attachment:
             print(message_attachment)
 
-        task_lock = get_task_lock(self.api_task_id)
+        task_lock = get_task_lock(self.api_project_id)
 
         # Get process_task_id from ContextVar with fallback
         current_process_task_id = process_task.get("")
         if not current_process_task_id:
-            current_process_task_id = self.api_task_id
-            logger.warning(f"[send_message_to_user] ContextVar process_task is empty, using api_task_id as fallback: '{current_process_task_id}'")
+            current_process_task_id = self.api_project_id
+            logger.warning(f"[send_message_to_user] ContextVar process_task is empty, using api_project_id as fallback: '{current_process_task_id}'")
 
         from app.utils.listen.toolkit_listen import _safe_put_queue
 
@@ -139,8 +139,8 @@ class HumanToolkit(BaseToolkit, AbstractToolkit):
         ]
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str, agent_name: str) -> list[FunctionTool]:
-        human = cls(api_task_id, agent_name)
+    def get_can_use_tools(cls, api_project_id: str, agent_name: str) -> list[FunctionTool]:
+        human = cls(api_project_id, agent_name)
         return [
             FunctionTool(human.ask_human_via_gui),
             # Note: send_message_to_user is not included in get_can_use_tools

--- a/backend/app/utils/toolkit/hybrid_browser_python_toolkit.py
+++ b/backend/app/utils/toolkit/hybrid_browser_python_toolkit.py
@@ -132,7 +132,7 @@ class HybridBrowserPythonToolkit(BaseHybridBrowserToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         *,
         headless: bool = False,
         user_data_dir: str | None = None,
@@ -150,7 +150,7 @@ class HybridBrowserPythonToolkit(BaseHybridBrowserToolkit, AbstractToolkit):
         page_stability_timeout: int | None = None,
         dom_content_loaded_timeout: int | None = None,
     ) -> None:
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         self._headless = headless
         self._user_data_dir = user_data_dir
         self._stealth = stealth
@@ -276,9 +276,9 @@ class HybridBrowserPythonToolkit(BaseHybridBrowserToolkit, AbstractToolkit):
         return {"result": nav_result, "snapshot": snapshot, **tab_info}
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> list[FunctionTool]:
+    def get_can_use_tools(cls, api_project_id: str) -> list[FunctionTool]:
         browser = HybridBrowserPythonToolkit(
-            api_task_id,
+            api_project_id,
             headless=False,
             browser_log_to_file=True,
             stealth=True,
@@ -312,7 +312,7 @@ class HybridBrowserPythonToolkit(BaseHybridBrowserToolkit, AbstractToolkit):
             new_session_id = str(uuid.uuid4())[:8]
 
         return HybridBrowserPythonToolkit(
-            self.api_task_id,
+            self.api_project_id,
             headless=self._headless,
             user_data_dir=self._user_data_dir,
             stealth=self._stealth,

--- a/backend/app/utils/toolkit/hybrid_browser_toolkit.py
+++ b/backend/app/utils/toolkit/hybrid_browser_toolkit.py
@@ -219,7 +219,7 @@ class HybridBrowserToolkit(BaseHybridBrowserToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         *,
         headless: bool = False,
         user_data_dir: str | None = None,
@@ -243,9 +243,9 @@ class HybridBrowserToolkit(BaseHybridBrowserToolkit, AbstractToolkit):
         cdp_keep_current_page: bool = False,
         full_visual_mode: bool = False,
     ) -> None:
-        logger.info(f"[HybridBrowserToolkit] Initializing with api_task_id: {api_task_id}")
-        self.api_task_id = api_task_id
-        logger.debug(f"[HybridBrowserToolkit] api_task_id set to: {self.api_task_id}")
+        logger.info(f"[HybridBrowserToolkit] Initializing with api_project_id: {api_project_id}")
+        self.api_project_id = api_project_id
+        logger.debug(f"[HybridBrowserToolkit] api_project_id set to: {self.api_project_id}")
         
         # Set default user_data_dir if not provided
         if user_data_dir is None:
@@ -281,11 +281,11 @@ class HybridBrowserToolkit(BaseHybridBrowserToolkit, AbstractToolkit):
             cdp_keep_current_page=cdp_keep_current_page,
             full_visual_mode=full_visual_mode,
         )
-        logger.info(f"[HybridBrowserToolkit] Initialization complete for api_task_id: {self.api_task_id}")
+        logger.info(f"[HybridBrowserToolkit] Initialization complete for api_project_id: {self.api_project_id}")
 
     async def _ensure_ws_wrapper(self):
         """Ensure WebSocket wrapper is initialized using connection pool."""
-        logger.debug(f"[HybridBrowserToolkit] _ensure_ws_wrapper called for api_task_id: {getattr(self, 'api_task_id', 'NOT SET')}")
+        logger.debug(f"[HybridBrowserToolkit] _ensure_ws_wrapper called for api_project_id: {getattr(self, 'api_project_id', 'NOT SET')}")
         global websocket_connection_pool
 
         # Get session ID from config or use default
@@ -319,7 +319,7 @@ class HybridBrowserToolkit(BaseHybridBrowserToolkit, AbstractToolkit):
         # Use the same session_id to share the same browser instance
         # This ensures all clones use the same WebSocket connection and browser
         return HybridBrowserToolkit(
-            self.api_task_id,
+            self.api_project_id,
             headless=self._headless,
             user_data_dir=self._user_data_dir,  # Use the same user_data_dir
             stealth=self._stealth,

--- a/backend/app/utils/toolkit/image_analysis_toolkit.py
+++ b/backend/app/utils/toolkit/image_analysis_toolkit.py
@@ -12,9 +12,9 @@ class ImageAnalysisToolkit(BaseImageAnalysisToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         model: BaseModelBackend | None = None,
         timeout: float | None = None,
     ):
         super().__init__(model, timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id

--- a/backend/app/utils/toolkit/lark_toolkit.py
+++ b/backend/app/utils/toolkit/lark_toolkit.py
@@ -9,12 +9,12 @@ from app.utils.toolkit.abstract_toolkit import AbstractToolkit
 @auto_listen_toolkit(BaseLarkToolkit)
 class LarkToolkit(BaseLarkToolkit, AbstractToolkit):
 
-    def __init__(self, api_task_id: str, timeout: float | None = None):
+    def __init__(self, api_project_id: str, timeout: float | None = None):
         super().__init__(timeout=timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> list[FunctionTool]:
+    def get_can_use_tools(cls, api_project_id: str) -> list[FunctionTool]:
         if env("LARK_APP_ID") and env("LARK_APP_SECRET"):
-            return LarkToolkit(api_task_id).get_tools()
+            return LarkToolkit(api_project_id).get_tools()
         return []

--- a/backend/app/utils/toolkit/linkedin_toolkit.py
+++ b/backend/app/utils/toolkit/linkedin_toolkit.py
@@ -10,13 +10,13 @@ from app.utils.toolkit.abstract_toolkit import AbstractToolkit
 class LinkedInToolkit(BaseLinkedInToolkit, AbstractToolkit):
     agent_name: str = Agents.social_medium_agent
 
-    def __init__(self, api_task_id: str, timeout: float | None = None):
+    def __init__(self, api_project_id: str, timeout: float | None = None):
         super().__init__(timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> list[FunctionTool]:
+    def get_can_use_tools(cls, api_project_id: str) -> list[FunctionTool]:
         if env("LINKEDIN_ACCESS_TOKEN"):
-            return LinkedInToolkit(api_task_id).get_tools()
+            return LinkedInToolkit(api_project_id).get_tools()
         else:
             return []

--- a/backend/app/utils/toolkit/markitdown_toolkit.py
+++ b/backend/app/utils/toolkit/markitdown_toolkit.py
@@ -10,6 +10,6 @@ from app.utils.toolkit.abstract_toolkit import AbstractToolkit
 class MarkItDownToolkit(BaseMarkItDownToolkit, AbstractToolkit):
     agent_name: str = Agents.document_agent
 
-    def __init__(self, api_task_id: str, timeout: float | None = None):
-        self.api_task_id = api_task_id
+    def __init__(self, api_project_id: str, timeout: float | None = None):
+        self.api_project_id = api_project_id
         super().__init__(timeout)

--- a/backend/app/utils/toolkit/mcp_search_toolkit.py
+++ b/backend/app/utils/toolkit/mcp_search_toolkit.py
@@ -10,9 +10,9 @@ from app.utils.toolkit.abstract_toolkit import AbstractToolkit
 class McpSearchToolkit(BaseToolkit, AbstractToolkit):
     agent_name: str = Agents.mcp_agent
 
-    def __init__(self, api_task_id: str, timeout: float | None = None):
+    def __init__(self, api_project_id: str, timeout: float | None = None):
         super().__init__(timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
 
     @listen_toolkit(
         inputs=lambda _,
@@ -49,7 +49,7 @@ class McpSearchToolkit(BaseToolkit, AbstractToolkit):
             if response.status_code != 200:
                 raise Exception(f"MCP server search failed: {response.text}")
             data = response.json()
-            task_lock = get_task_lock(self.api_task_id)
+            task_lock = get_task_lock(self.api_project_id)
             await task_lock.put_queue(
                 ActionSearchMcpData(action=Action.search_mcp, data=data["items"])
             )

--- a/backend/app/utils/toolkit/note_taking_toolkit.py
+++ b/backend/app/utils/toolkit/note_taking_toolkit.py
@@ -15,12 +15,12 @@ class NoteTakingToolkit(BaseNoteTakingToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         agent_name: str | None = None,
         working_directory: str | None = None,
         timeout: float | None = None,
     ) -> None:
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         if agent_name is not None:
             self.agent_name = agent_name
         if working_directory is None:

--- a/backend/app/utils/toolkit/notion_mcp_toolkit.py
+++ b/backend/app/utils/toolkit/notion_mcp_toolkit.py
@@ -36,10 +36,10 @@ class NotionMCPToolkit(MCPToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         timeout: float | None = None,
     ):
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         if timeout is None:
             timeout = 120.0
         
@@ -61,7 +61,7 @@ class NotionMCPToolkit(MCPToolkit, AbstractToolkit):
         super().__init__(config_dict=config_dict, timeout=timeout)    
 
     @classmethod
-    async def get_can_use_tools(cls, api_task_id: str) -> list[FunctionTool]:
+    async def get_can_use_tools(cls, api_project_id: str) -> list[FunctionTool]:
         # Retry mechanism for remote MCP connection
         max_retries = 3
         retry_delay = 2  # seconds
@@ -72,7 +72,7 @@ class NotionMCPToolkit(MCPToolkit, AbstractToolkit):
             
             try:
                 # Create a fresh toolkit instance for each retry
-                toolkit = cls(api_task_id)
+                toolkit = cls(api_project_id)
                 logger.info(f"Attempting to connect to Notion MCP server (attempt {attempt + 1}/{max_retries})")
                 
                 await toolkit.connect()

--- a/backend/app/utils/toolkit/notion_toolkit.py
+++ b/backend/app/utils/toolkit/notion_toolkit.py
@@ -13,16 +13,16 @@ class NotionToolkit(BaseNotionToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         notion_token: str | None = None,
         timeout: float | None = None,
     ) -> None:
         super().__init__(notion_token, timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> List[FunctionTool]:
+    def get_can_use_tools(cls, api_project_id: str) -> List[FunctionTool]:
         if env("NOTION_TOKEN"):
-            return NotionToolkit(api_task_id).get_tools()
+            return NotionToolkit(api_project_id).get_tools()
         else:
             return []

--- a/backend/app/utils/toolkit/openai_image_toolkit.py
+++ b/backend/app/utils/toolkit/openai_image_toolkit.py
@@ -14,7 +14,7 @@ class OpenAIImageToolkit(BaseOpenAIImageToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         model: None | Literal["gpt-image-1"] | Literal["dall-e-3"] | Literal["dall-e-2"] = "gpt-image-1",
         timeout: float | None = None,
         api_key: str | None = None,
@@ -40,7 +40,7 @@ class OpenAIImageToolkit(BaseOpenAIImageToolkit, AbstractToolkit):
         style: None | Literal["vivid"] | Literal["natural"] = None,
         working_directory: str | None = None,
     ):
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         super().__init__(
             model, timeout, api_key, url, size, quality, response_format, background, style, working_directory
         )
@@ -60,5 +60,5 @@ class OpenAIImageToolkit(BaseOpenAIImageToolkit, AbstractToolkit):
 
     def _build_base_params(self, prompt: str, n: Optional[int] = None) -> dict:
         params = super()._build_base_params(prompt, n)
-        params["user"] = self.api_task_id  # support cloud key billing
+        params["user"] = self.api_project_id  # support cloud key billing
         return params

--- a/backend/app/utils/toolkit/pptx_toolkit.py
+++ b/backend/app/utils/toolkit/pptx_toolkit.py
@@ -15,11 +15,11 @@ class PPTXToolkit(BasePPTXToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         working_directory: str | None = None,
         timeout: float | None = None,
     ) -> None:
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         if working_directory is None:
             working_directory = env("file_save_path", os.path.expanduser("~/Downloads"))
         super().__init__(working_directory, timeout)
@@ -38,7 +38,7 @@ class PPTXToolkit(BasePPTXToolkit, AbstractToolkit):
         file_path = self._resolve_filepath(filename)
         res = super().create_presentation(content, filename, template)
         if "PowerPoint presentation successfully created" in res:
-            task_lock = get_task_lock(self.api_task_id)
+            task_lock = get_task_lock(self.api_project_id)
             # Capture ContextVar value before creating async task
             current_process_task_id = process_task.get("")
 

--- a/backend/app/utils/toolkit/pyautogui_toolkit.py
+++ b/backend/app/utils/toolkit/pyautogui_toolkit.py
@@ -14,11 +14,11 @@ class PyAutoGUIToolkit(BasePyAutoGUIToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         timeout: float | None = None,
         screenshots_dir: str | None = None,
     ):
         if screenshots_dir is None:
             screenshots_dir = env("file_save_path", os.path.expanduser("~/Downloads"))
         super().__init__(timeout, screenshots_dir)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id

--- a/backend/app/utils/toolkit/reddit_toolkit.py
+++ b/backend/app/utils/toolkit/reddit_toolkit.py
@@ -13,17 +13,17 @@ class RedditToolkit(BaseRedditToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         retries: int = 3,
         delay: float = 0,
         timeout: float | None = None,
     ):
         super().__init__(retries, delay, timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> list[FunctionTool]:
+    def get_can_use_tools(cls, api_project_id: str) -> list[FunctionTool]:
         if env("REDDIT_CLIENT_ID") and env("REDDIT_CLIENT_SECRET") and env("REDDIT_USER_AGENT"):
-            return RedditToolkit(api_task_id).get_tools()
+            return RedditToolkit(api_project_id).get_tools()
         else:
             return []

--- a/backend/app/utils/toolkit/screenshot_toolkit.py
+++ b/backend/app/utils/toolkit/screenshot_toolkit.py
@@ -11,8 +11,8 @@ from app.utils.toolkit.abstract_toolkit import AbstractToolkit
 class ScreenshotToolkit(BaseScreenshotToolkit, AbstractToolkit):
     agent_name: str = Agents.developer_agent
 
-    def __init__(self, api_task_id, working_directory: str | None = None, timeout: float | None = None):
-        self.api_task_id = api_task_id
+    def __init__(self, api_project_id, working_directory: str | None = None, timeout: float | None = None):
+        self.api_project_id = api_project_id
         if working_directory is None:
             working_directory = env("file_save_path", os.path.expanduser("~/Downloads"))
         super().__init__(working_directory, timeout)

--- a/backend/app/utils/toolkit/search_toolkit.py
+++ b/backend/app/utils/toolkit/search_toolkit.py
@@ -18,12 +18,12 @@ class SearchToolkit(BaseSearchToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         agent_name: str | None = None,
         timeout: float | None = None,
         exclude_domains: List[str] | None = None,
     ):
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         if agent_name is not None:
             self.agent_name = agent_name
         super().__init__(
@@ -338,8 +338,8 @@ class SearchToolkit(BaseSearchToolkit, AbstractToolkit):
     #     )
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> list[FunctionTool]:
-        search_toolkit = SearchToolkit(api_task_id)
+    def get_can_use_tools(cls, api_project_id: str) -> list[FunctionTool]:
+        search_toolkit = SearchToolkit(api_project_id)
         tools = [
             # FunctionTool(search_toolkit.search_wiki),
             # FunctionTool(search_toolkit.search_duckduckgo),

--- a/backend/app/utils/toolkit/slack_toolkit.py
+++ b/backend/app/utils/toolkit/slack_toolkit.py
@@ -13,14 +13,14 @@ logger = traceroot.get_logger("slack_toolkit")
 class SlackToolkit(BaseSlackToolkit, AbstractToolkit):
     agent_name: str = Agents.social_medium_agent
 
-    def __init__(self, api_task_id: str, timeout: float | None = None):
+    def __init__(self, api_project_id: str, timeout: float | None = None):
         super().__init__(timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> list[FunctionTool]:
+    def get_can_use_tools(cls, api_project_id: str) -> list[FunctionTool]:
         logger.debug(f"slack===={env('SLACK_BOT_TOKEN')}")
         if env("SLACK_BOT_TOKEN") or env("SLACK_USER_TOKEN"):
-            return SlackToolkit(api_task_id).get_tools()
+            return SlackToolkit(api_project_id).get_tools()
         else:
             return []

--- a/backend/app/utils/toolkit/terminal_toolkit.py
+++ b/backend/app/utils/toolkit/terminal_toolkit.py
@@ -24,7 +24,7 @@ class TerminalToolkit(BaseTerminalToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         agent_name: str | None = None,
         timeout: float | None = None,
         working_directory: str | None = None,
@@ -35,14 +35,14 @@ class TerminalToolkit(BaseTerminalToolkit, AbstractToolkit):
         allowed_commands: list[str] | None = None,
         clone_current_env: bool = False,
     ):
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         if agent_name is not None:
             self.agent_name = agent_name
         if working_directory is None:
             working_directory = env("file_save_path", os.path.expanduser("~/.eigent/terminal/"))
 
         logger.info("Initializing TerminalToolkit", extra={
-            "api_task_id": api_task_id,
+            "api_project_id": api_project_id,
             "agent_name": self.agent_name,
             "working_directory": working_directory,
             "safe_mode": safe_mode,
@@ -84,14 +84,14 @@ class TerminalToolkit(BaseTerminalToolkit, AbstractToolkit):
         # Convert ANSI escape sequences to plain text
         super()._write_to_log(log_file, content)
         logger.debug("Terminal output logged", extra={
-            "api_task_id": self.api_task_id,
+            "api_project_id": self.api_project_id,
             "log_file": log_file,
             "content_length": len(content)
         })
         self._update_terminal_output(_to_plain(content))
 
     def _update_terminal_output(self, output: str):
-        task_lock = get_task_lock(self.api_task_id)
+        task_lock = get_task_lock(self.api_project_id)
         process_task_id = process_task.get("")
 
         # Create the coroutine

--- a/backend/app/utils/toolkit/thinking_toolkit.py
+++ b/backend/app/utils/toolkit/thinking_toolkit.py
@@ -7,7 +7,7 @@ from app.utils.toolkit.abstract_toolkit import AbstractToolkit
 @auto_listen_toolkit(BaseThinkingToolkit)
 class ThinkingToolkit(BaseThinkingToolkit, AbstractToolkit):
 
-    def __init__(self, api_task_id: str, agent_name: str, timeout: float | None = None):
+    def __init__(self, api_project_id: str, agent_name: str, timeout: float | None = None):
         super().__init__(timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         self.agent_name = agent_name

--- a/backend/app/utils/toolkit/twitter_toolkit.py
+++ b/backend/app/utils/toolkit/twitter_toolkit.py
@@ -17,9 +17,9 @@ from app.utils.toolkit.abstract_toolkit import AbstractToolkit
 class TwitterToolkit(BaseTwitterToolkit, AbstractToolkit):
     agent_name: str = Agents.social_medium_agent
 
-    def __init__(self, api_task_id: str, timeout: float | None = None):
+    def __init__(self, api_project_id: str, timeout: float | None = None):
         super().__init__(timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
 
     @listen_toolkit(
         create_tweet,
@@ -64,13 +64,13 @@ class TwitterToolkit(BaseTwitterToolkit, AbstractToolkit):
         ]
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> List[FunctionTool]:
+    def get_can_use_tools(cls, api_project_id: str) -> List[FunctionTool]:
         if (
             env("TWITTER_CONSUMER_KEY")
             and env("TWITTER_CONSUMER_SECRET")
             and env("TWITTER_ACCESS_TOKEN")
             and env("TWITTER_ACCESS_TOKEN_SECRET")
         ):
-            return TwitterToolkit(api_task_id).get_tools()
+            return TwitterToolkit(api_project_id).get_tools()
         else:
             return []

--- a/backend/app/utils/toolkit/video_analysis_toolkit.py
+++ b/backend/app/utils/toolkit/video_analysis_toolkit.py
@@ -14,7 +14,7 @@ class VideoAnalysisToolkit(BaseVideoAnalysisToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         working_directory: str | None = None,
         model: BaseModelBackend | None = None,
         use_audio_transcription: bool = False,
@@ -24,7 +24,7 @@ class VideoAnalysisToolkit(BaseVideoAnalysisToolkit, AbstractToolkit):
         cookies_path: str | None = None,
         timeout: float | None = None,
     ) -> None:
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         if working_directory is None:
             working_directory = env("file_save_path", os.path.expanduser("~/Downloads"))
         super().__init__(

--- a/backend/app/utils/toolkit/video_download_toolkit.py
+++ b/backend/app/utils/toolkit/video_download_toolkit.py
@@ -15,7 +15,7 @@ class VideoDownloaderToolkit(BaseVideoDownloaderToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         working_directory: str | None = None,
         cookies_path: str | None = None,
         timeout: float | None = None,
@@ -23,4 +23,4 @@ class VideoDownloaderToolkit(BaseVideoDownloaderToolkit, AbstractToolkit):
         if working_directory is None:
             working_directory = env("file_save_path", os.path.expanduser("~/Downloads"))
         super().__init__(working_directory, cookies_path, timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id

--- a/backend/app/utils/toolkit/web_deploy_toolkit.py
+++ b/backend/app/utils/toolkit/web_deploy_toolkit.py
@@ -13,7 +13,7 @@ class WebDeployToolkit(BaseWebDeployToolkit, AbstractToolkit):
 
     def __init__(
         self,
-        api_task_id: str,
+        api_project_id: str,
         timeout: float | None = None,
         add_branding_tag: bool = True,
         logo_path: str = "../../../../public/favicon.png",
@@ -22,7 +22,7 @@ class WebDeployToolkit(BaseWebDeployToolkit, AbstractToolkit):
         remote_server_ip: str | None = "space.eigent.ai",
         remote_server_port: int = 8080,
     ):
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
         super().__init__(timeout, add_branding_tag, logo_path, tag_text, tag_url, remote_server_ip, remote_server_port)
 
     @listen_toolkit(BaseWebDeployToolkit.deploy_html_content)

--- a/backend/app/utils/toolkit/whatsapp_toolkit.py
+++ b/backend/app/utils/toolkit/whatsapp_toolkit.py
@@ -11,13 +11,13 @@ from app.utils.toolkit.abstract_toolkit import AbstractToolkit
 class WhatsAppToolkit(BaseWhatsAppToolkit, AbstractToolkit):
     agent_name: str = Agents.social_medium_agent
 
-    def __init__(self, api_task_id: str, timeout: float | None = None):
+    def __init__(self, api_project_id: str, timeout: float | None = None):
         super().__init__(timeout)
-        self.api_task_id = api_task_id
+        self.api_project_id = api_project_id
 
     @classmethod
-    def get_can_use_tools(cls, api_task_id: str) -> list[FunctionTool]:
+    def get_can_use_tools(cls, api_project_id: str) -> list[FunctionTool]:
         if env("WHATSAPP_ACCESS_TOKEN") and env("WHATSAPP_PHONE_NUMBER_ID"):
-            return WhatsAppToolkit(api_task_id).get_tools()
+            return WhatsAppToolkit(api_project_id).get_tools()
         else:
             return []

--- a/backend/tests/unit/utils/test_agent.py
+++ b/backend/tests/unit/utils/test_agent.py
@@ -37,7 +37,7 @@ class TestListenChatAgent:
     
     def test_listen_chat_agent_initialization(self):
         """Test ListenChatAgent initialization."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         agent_name = "TestAgent"
         
         with patch('app.utils.agent.get_task_lock') as mock_get_lock, \
@@ -53,7 +53,7 @@ class TestListenChatAgent:
             mock_create_model.return_value = mock_backend
             
             agent = ListenChatAgent(
-                api_task_id=api_task_id,
+                api_project_id=api_project_id,
                 agent_name=agent_name,
                 model="gpt-4",  # Use string instead of mock
                 system_message="You are a helpful assistant",
@@ -61,13 +61,13 @@ class TestListenChatAgent:
                 agent_id="test_agent_123"
             )
             
-            assert agent.api_task_id == api_task_id
+            assert agent.api_project_id == api_project_id
             assert agent.agent_name == agent_name
             assert isinstance(agent, ChatAgent)
 
     def test_listen_chat_agent_step_with_string_input(self, mock_task_lock):
         """Test ListenChatAgent step method with string input."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         agent_name = "TestAgent"
         
         with patch('app.utils.agent.get_task_lock', return_value=mock_task_lock), \
@@ -82,7 +82,7 @@ class TestListenChatAgent:
             mock_create_model.return_value = mock_backend
             
             agent = ListenChatAgent(
-                api_task_id=api_task_id,
+                api_project_id=api_project_id,
                 agent_name=agent_name,
                 model="gpt-4"
             )
@@ -107,7 +107,7 @@ class TestListenChatAgent:
 
     def test_listen_chat_agent_step_with_base_message_input(self, mock_task_lock):
         """Test ListenChatAgent step method with BaseMessage input."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         agent_name = "TestAgent"
         
         with patch('app.utils.agent.get_task_lock', return_value=mock_task_lock), \
@@ -122,7 +122,7 @@ class TestListenChatAgent:
             mock_create_model.return_value = mock_backend
             
             agent = ListenChatAgent(
-                api_task_id=api_task_id,
+                api_project_id=api_project_id,
                 agent_name=agent_name,
                 model="gpt-4"
             )
@@ -155,7 +155,7 @@ class TestListenChatAgent:
     @pytest.mark.asyncio
     async def test_listen_chat_agent_astep(self, mock_task_lock):
         """Test ListenChatAgent async step method."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         agent_name = "TestAgent"
         
         with patch('app.utils.agent.get_task_lock', return_value=mock_task_lock), \
@@ -170,7 +170,7 @@ class TestListenChatAgent:
             mock_create_model.return_value = mock_backend
             
             agent = ListenChatAgent(
-                api_task_id=api_task_id,
+                api_project_id=api_project_id,
                 agent_name=agent_name,
                 model="gpt-4"
             )
@@ -196,7 +196,7 @@ class TestListenChatAgent:
 
     def test_listen_chat_agent_execute_tool(self, mock_task_lock):
         """Test ListenChatAgent _execute_tool method."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         agent_name = "TestAgent"
         
         with patch('app.utils.agent.get_task_lock', return_value=mock_task_lock), \
@@ -211,7 +211,7 @@ class TestListenChatAgent:
             mock_create_model.return_value = mock_backend
             
             agent = ListenChatAgent(
-                api_task_id=api_task_id,
+                api_project_id=api_project_id,
                 agent_name=agent_name,
                 model="gpt-4"
             )
@@ -244,7 +244,7 @@ class TestListenChatAgent:
     @pytest.mark.asyncio
     async def test_listen_chat_agent_aexecute_tool(self, mock_task_lock):
         """Test ListenChatAgent _aexecute_tool method."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         agent_name = "TestAgent"
         
         with patch('app.utils.agent.get_task_lock', return_value=mock_task_lock), \
@@ -258,7 +258,7 @@ class TestListenChatAgent:
             mock_create_model.return_value = mock_backend
             
             agent = ListenChatAgent(
-                api_task_id=api_task_id,
+                api_project_id=api_project_id,
                 agent_name=agent_name,
                 model="gpt-4"
             )
@@ -288,7 +288,7 @@ class TestListenChatAgent:
 
     def test_listen_chat_agent_clone(self, mock_task_lock):
         """Test ListenChatAgent clone method."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         agent_name = "TestAgent"
         
         with patch('app.utils.agent.get_task_lock', return_value=mock_task_lock), \
@@ -310,7 +310,7 @@ class TestListenChatAgent:
             
             # First create the initial agent
             agent = ListenChatAgent(
-                api_task_id=api_task_id,
+                api_project_id=api_project_id,
                 agent_name=agent_name,
                 model="gpt-4"
             )
@@ -343,7 +343,7 @@ class TestListenChatAgent:
 
     def test_listen_chat_agent_with_tools(self, mock_task_lock):
         """Test ListenChatAgent with tools."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         agent_name = "TestAgent"
         
         # Mock tool
@@ -361,7 +361,7 @@ class TestListenChatAgent:
             mock_create_model.return_value = mock_backend
             
             agent = ListenChatAgent(
-                api_task_id=api_task_id,
+                api_project_id=api_project_id,
                 agent_name=agent_name,
                 model="gpt-4",
                 tools=tools
@@ -376,7 +376,7 @@ class TestListenChatAgent:
 
     def test_listen_chat_agent_with_pause_event(self, mock_task_lock):
         """Test ListenChatAgent with pause event."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         agent_name = "TestAgent"
         
         pause_event = asyncio.Event()
@@ -392,7 +392,7 @@ class TestListenChatAgent:
             mock_create_model.return_value = mock_backend
             
             agent = ListenChatAgent(
-                api_task_id=api_task_id,
+                api_project_id=api_project_id,
                 agent_name=agent_name,
                 model="gpt-4",
                 pause_event=pause_event
@@ -743,7 +743,7 @@ class TestToolkitFunctions:
         """Test get_toolkits with known tool names."""
         tools = ["search_toolkit", "terminal_toolkit", "file_write_toolkit"]
         agent_name = "TestAgent"
-        api_task_id = "test_task_123"
+        api_project_id = "test_task_123"
         
         with patch('app.utils.agent.SearchToolkit') as mock_search_toolkit, \
              patch('app.utils.agent.TerminalToolkit') as mock_terminal_toolkit, \
@@ -773,7 +773,7 @@ class TestToolkitFunctions:
             mock_terminal_toolkit.get_can_use_tools = MagicMock(return_value=mock_terminal_tools)
             mock_file_toolkit.get_can_use_tools = MagicMock(return_value=mock_file_tools)
             
-            result = await get_toolkits(tools, agent_name, api_task_id)
+            result = await get_toolkits(tools, agent_name, api_project_id)
             
             # The result should contain tools from the toolkits that match
             assert isinstance(result, list)
@@ -785,9 +785,9 @@ class TestToolkitFunctions:
         """Test get_toolkits with unknown tool name."""
         tools = ["unknown_tool"]
         agent_name = "TestAgent"
-        api_task_id = "test_task_123"
+        api_project_id = "test_task_123"
         
-        result = await get_toolkits(tools, agent_name, api_task_id)
+        result = await get_toolkits(tools, agent_name, api_project_id)
         
         # Should return empty list or handle unknown tools gracefully
         assert isinstance(result, list)
@@ -797,9 +797,9 @@ class TestToolkitFunctions:
         """Test get_toolkits with empty tools list."""
         tools = []
         agent_name = "TestAgent"
-        api_task_id = "test_task_123"
+        api_project_id = "test_task_123"
         
-        result = await get_toolkits(tools, agent_name, api_task_id)
+        result = await get_toolkits(tools, agent_name, api_project_id)
         
         assert result == []
 
@@ -872,11 +872,11 @@ class TestAgentIntegration:
         from app.service.task import task_locks
         
         options = Chat(**sample_chat_data)
-        api_task_id = options.task_id
+        api_project_id = options.task_id
         
         # Create task lock
         mock_task_lock = MagicMock()
-        task_locks[api_task_id] = mock_task_lock
+        task_locks[api_project_id] = mock_task_lock
         
         # Create agent
         with patch('app.utils.agent.ModelFactory.create') as mock_model_factory, \
@@ -886,13 +886,13 @@ class TestAgentIntegration:
             mock_model_factory.return_value = mock_model
             
             mock_agent_instance = MagicMock()
-            mock_agent_instance.api_task_id = api_task_id
+            mock_agent_instance.api_project_id = api_project_id
             mock_listen_agent.return_value = mock_agent_instance
 
             agent = agent_model("IntegrationAgent", "Test system prompt", options, [])
             
             assert agent is mock_agent_instance
-            assert agent.api_task_id == api_task_id
+            assert agent.api_project_id == api_project_id
             
             # Test step operation
             mock_response = MagicMock()
@@ -973,7 +973,7 @@ class TestAgentErrorCases:
     
     def test_listen_chat_agent_with_invalid_model(self):
         """Test ListenChatAgent with invalid model."""
-        api_task_id = "error_test_123"
+        api_project_id = "error_test_123"
         agent_name = "ErrorAgent"
         
         with patch('app.utils.agent.get_task_lock') as mock_get_lock, \
@@ -984,7 +984,7 @@ class TestAgentErrorCases:
             # Try to create agent with invalid model which should raise an error through ModelFactory
             with pytest.raises(ValueError):
                 ListenChatAgent(
-                    api_task_id=api_task_id,
+                    api_project_id=api_project_id,
                     agent_name=agent_name,
                     model="invalid_model_string"  # Invalid model type
                 )
@@ -1003,17 +1003,17 @@ class TestAgentErrorCases:
         """Test get_toolkits when toolkit initialization fails."""
         tools = ["search"]
         agent_name = "ErrorAgent"
-        api_task_id = "error_test_123"
+        api_project_id = "error_test_123"
         
         with patch('app.utils.agent.SearchToolkit', side_effect=Exception("Toolkit init failed")):
             # Should handle toolkit initialization errors
-            result = await get_toolkits(tools, agent_name, api_task_id)
+            result = await get_toolkits(tools, agent_name, api_project_id)
             # Should return what it can or empty list
             assert isinstance(result, list)
 
     def test_listen_chat_agent_step_with_task_lock_error(self):
         """Test ListenChatAgent step when task lock retrieval fails."""
-        api_task_id = "error_test_123"
+        api_project_id = "error_test_123"
         agent_name = "ErrorAgent"
         
         with patch('app.utils.agent.get_task_lock', side_effect=Exception("Task lock not found")), \
@@ -1027,7 +1027,7 @@ class TestAgentErrorCases:
             mock_create_model.return_value = mock_backend
             
             agent = ListenChatAgent(
-                api_task_id=api_task_id,
+                api_project_id=api_project_id,
                 agent_name=agent_name,
                 model="gpt-4"
             )

--- a/backend/tests/unit/utils/test_workforce.py
+++ b/backend/tests/unit/utils/test_workforce.py
@@ -19,22 +19,22 @@ class TestWorkforce:
     
     def test_workforce_initialization(self):
         """Test Workforce initialization with default settings."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         description = "Test workforce"
         
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description=description
         )
         
-        assert workforce.api_task_id == api_task_id
+        assert workforce.api_project_id == api_project_id
         assert workforce.description == description
 
     def test_eigent_make_sub_tasks_success(self):
         """Test eigent_make_sub_tasks successfully decomposes task."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -61,9 +61,9 @@ class TestWorkforce:
 
     def test_eigent_make_sub_tasks_with_streaming_decomposition(self):
         """Test eigent_make_sub_tasks with streaming decomposition result."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -91,9 +91,9 @@ class TestWorkforce:
 
     def test_eigent_make_sub_tasks_invalid_content(self):
         """Test eigent_make_sub_tasks with invalid task content."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -111,9 +111,9 @@ class TestWorkforce:
     @pytest.mark.asyncio
     async def test_eigent_start_success(self):
         """Test eigent_start successfully starts workforce."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -138,9 +138,9 @@ class TestWorkforce:
     @pytest.mark.asyncio
     async def test_eigent_start_with_exception(self):
         """Test eigent_start handles exceptions properly."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -158,9 +158,9 @@ class TestWorkforce:
     @pytest.mark.asyncio
     async def test_find_assignee_with_notifications(self, mock_task_lock):
         """Test _find_assignee sends proper task assignment notifications."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -193,9 +193,9 @@ class TestWorkforce:
     @pytest.mark.asyncio
     async def test_post_task_notification(self, mock_task_lock):
         """Test _post_task sends running state notification."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -224,9 +224,9 @@ class TestWorkforce:
 
     def test_add_single_agent_worker_success(self):
         """Test add_single_agent_worker successfully adds worker."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -251,9 +251,9 @@ class TestWorkforce:
 
     def test_add_single_agent_worker_while_running(self):
         """Test add_single_agent_worker raises error when workforce is running."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         workforce._state = WorkforceState.RUNNING
@@ -266,9 +266,9 @@ class TestWorkforce:
     @pytest.mark.asyncio
     async def test_handle_completed_task(self, mock_task_lock):
         """Test _handle_completed_task sends completion notification."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -297,9 +297,9 @@ class TestWorkforce:
     @pytest.mark.asyncio
     async def test_handle_failed_task(self, mock_task_lock):
         """Test _handle_failed_task sends failure notification."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -329,9 +329,9 @@ class TestWorkforce:
     @pytest.mark.asyncio
     async def test_stop_sends_end_notification(self, mock_task_lock):
         """Test stop method sends end notification."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -349,23 +349,23 @@ class TestWorkforce:
     @pytest.mark.asyncio
     async def test_cleanup_deletes_task_lock(self):
         """Test cleanup method deletes task lock."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
         with patch('app.service.task.delete_task_lock') as mock_delete:
             await workforce.cleanup()
             
-            mock_delete.assert_called_once_with(api_task_id)
+            mock_delete.assert_called_once_with(api_project_id)
 
     @pytest.mark.asyncio
     async def test_cleanup_handles_exception(self):
         """Test cleanup handles exceptions gracefully."""
-        api_task_id = "test_api_task_123"
+        api_project_id = "test_api_task_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Test workforce"
         )
         
@@ -391,15 +391,15 @@ class TestWorkforceIntegration:
     @pytest.mark.asyncio
     async def test_full_workforce_lifecycle(self):
         """Test complete workforce lifecycle from creation to cleanup."""
-        api_task_id = "integration_test_123"
+        api_project_id = "integration_test_123"
         
         # Create task lock
         from app.service.task import create_task_lock
-        task_lock = create_task_lock(api_task_id)
+        task_lock = create_task_lock(api_project_id)
         
         # Create workforce
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Integration test workforce"
         )
         
@@ -444,13 +444,13 @@ class TestWorkforceIntegration:
     @pytest.mark.asyncio
     async def test_workforce_with_multiple_workers(self):
         """Test workforce with multiple workers."""
-        api_task_id = "multi_worker_test_123"
+        api_project_id = "multi_worker_test_123"
         
         from app.service.task import create_task_lock
-        create_task_lock(api_task_id)
+        create_task_lock(api_project_id)
         
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Multi-worker test workforce"
         )
         
@@ -477,13 +477,13 @@ class TestWorkforceIntegration:
     @pytest.mark.asyncio
     async def test_workforce_task_state_tracking(self):
         """Test workforce properly tracks task state changes."""
-        api_task_id = "task_tracking_test_123"
+        api_project_id = "task_tracking_test_123"
         
         from app.service.task import create_task_lock
-        task_lock = create_task_lock(api_task_id)
+        task_lock = create_task_lock(api_project_id)
         
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Task tracking test workforce"
         )
         
@@ -533,9 +533,9 @@ class TestWorkforceErrorCases:
     
     def test_eigent_make_sub_tasks_with_none_task(self):
         """Test eigent_make_sub_tasks with None task."""
-        api_task_id = "error_test_123"
+        api_project_id = "error_test_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Error test workforce"
         )
         
@@ -544,9 +544,9 @@ class TestWorkforceErrorCases:
 
     def test_eigent_make_sub_tasks_with_malformed_task(self):
         """Test eigent_make_sub_tasks with malformed task object."""
-        api_task_id = "error_test_123"
+        api_project_id = "error_test_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Error test workforce"
         )
         
@@ -562,9 +562,9 @@ class TestWorkforceErrorCases:
     @pytest.mark.asyncio
     async def test_eigent_start_with_empty_subtasks(self):
         """Test eigent_start with empty subtasks list."""
-        api_task_id = "empty_test_123"
+        api_project_id = "empty_test_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Empty test workforce"
         )
         
@@ -579,9 +579,9 @@ class TestWorkforceErrorCases:
 
     def test_add_single_agent_worker_with_invalid_worker(self):
         """Test add_single_agent_worker with invalid worker object."""
-        api_task_id = "invalid_worker_test_123"
+        api_project_id = "invalid_worker_test_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Invalid worker test workforce"
         )
         
@@ -595,9 +595,9 @@ class TestWorkforceErrorCases:
     @pytest.mark.asyncio
     async def test_find_assignee_with_get_task_lock_failure(self):
         """Test _find_assignee when get_task_lock fails after parent method succeeds."""
-        api_task_id = "lock_fail_test_123"
+        api_project_id = "lock_fail_test_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Lock fail test workforce"
         )
         
@@ -616,9 +616,9 @@ class TestWorkforceErrorCases:
     @pytest.mark.asyncio
     async def test_cleanup_with_nonexistent_task_lock(self):
         """Test cleanup when task lock doesn't exist."""
-        api_task_id = "nonexistent_lock_test_123"
+        api_project_id = "nonexistent_lock_test_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Nonexistent lock test workforce"
         )
         
@@ -635,12 +635,12 @@ class TestWorkforceErrorCases:
         """Test that Workforce properly inherits from BaseWorkforce."""
         from camel.societies.workforce.workforce import Workforce as BaseWorkforce
         
-        api_task_id = "inheritance_test_123"
+        api_project_id = "inheritance_test_123"
         workforce = Workforce(
-            api_task_id=api_task_id,
+            api_project_id=api_project_id,
             description="Inheritance test workforce"
         )
         
         assert isinstance(workforce, BaseWorkforce)
-        assert hasattr(workforce, 'api_task_id')
-        assert workforce.api_task_id == api_task_id
+        assert hasattr(workforce, 'api_project_id')
+        assert workforce.api_project_id == api_project_id


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
- just a ghost update to what we introduced in #498 and others (Mainly in Workforce.py and agent.py)
- Just a reminder that options.task_id is immutable between tasks in multiturn, so I introduced the current_task_id in the task lock.

```python
# sync_step.py // Added to make sure to store each step history thread with its own task id
if chat is not None:
    task_lock = get_task_lock_if_exists(chat.project_id)
    if task_lock is not None:
        task_id = task_lock.current_task_id \
            if hasattr(task_lock, 'current_task_id') and task_lock.current_task_id else chat.task_id
    else:
        logger.warning(f"Task lock not found for project_id {chat.project_id}, using chat.task_id")
        task_id = chat.task_id
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
