### PR TITLE
Fix Consistent Font Rendering for HTML Content (#1032)

### DIFF
--- a/src/components/ChatBox/MessageItem/MarkDown.tsx
+++ b/src/components/ChatBox/MessageItem/MarkDown.tsx
@@ -15,6 +15,7 @@
 import { useState, useEffect, memo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { isHtmlDocument } from "@/lib/htmlFontStyles";
 
 export const MarkDown = memo(
 	({
@@ -72,12 +73,6 @@ export const MarkDown = memo(
 
 			return () => clearInterval(timer);
 		}, [content, speed, enableTypewriter]);
-
-		// Check if content is pure HTML document
-		const isHtmlDocument = (text: string) => {
-			const trimmed = text.trim();
-			return /^<!doctype\s+html/i.test(trimmed) || /^<html/i.test(trimmed);
-		};
 
 		// If content is a pure HTML document, render in a styled pre block
 		if (isHtmlDocument(content)) {

--- a/src/components/ChatBox/MessageItem/SummaryMarkDown.tsx
+++ b/src/components/ChatBox/MessageItem/SummaryMarkDown.tsx
@@ -14,6 +14,7 @@
 
 import { useState, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
+import { isHtmlDocument } from "@/lib/htmlFontStyles";
 
 export const SummaryMarkDown = ({
 	content,
@@ -55,12 +56,6 @@ export const SummaryMarkDown = ({
 
 		return () => clearInterval(timer);
 	}, [content, speed, onTyping]);
-
-	// Check if content is pure HTML document
-	const isHtmlDocument = (text: string) => {
-		const trimmed = text.trim();
-		return /^<!doctype\s+html/i.test(trimmed) || /^<html/i.test(trimmed);
-	};
 
 	// If content is a pure HTML document, render in a styled pre block
 	if (isHtmlDocument(content)) {

--- a/src/components/Folder/FolderComponent.tsx
+++ b/src/components/Folder/FolderComponent.tsx
@@ -14,6 +14,7 @@
 
 import React, { useMemo } from "react";
 import DOMPurify from "dompurify";
+import { injectFontStyles } from "@/lib/htmlFontStyles";
 
 type Props = {
 	selectedFile: {
@@ -46,16 +47,6 @@ export default function FolderComponent({ selectedFile }: Props) {
 				return "";
 			}
 		}
-
-		// Inject consistent font styles to ensure clean rendering
-		const fontStyleTag = `<style data-eigent-fonts>
-			*, *::before, *::after {
-				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif !important;
-			}
-			code, pre, kbd, samp {
-				font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace !important;
-			}
-		</style>`;
 
 		const sanitized = DOMPurify.sanitize(raw, {
 			USE_PROFILES: { html: true },
@@ -128,8 +119,8 @@ export default function FolderComponent({ selectedFile }: Props) {
 			KEEP_CONTENT: false,
 		});
 
-		// Prepend font styles to sanitized HTML
-		return fontStyleTag + sanitized;
+		// Inject font styles into sanitized HTML
+		return injectFontStyles(sanitized);
 	}, [selectedFile?.content]);
 
 	return (

--- a/src/components/Folder/index.tsx
+++ b/src/components/Folder/index.tsx
@@ -34,6 +34,7 @@ import { useTranslation } from 'react-i18next';
 import useChatStoreAdapter from '@/hooks/useChatStoreAdapter';
 import { ZoomControls } from './ZoomControls';
 import { containsDangerousContent } from '@/lib/htmlSanitization';
+import { injectFontStyles } from '@/lib/htmlFontStyles';
 
 // Type definitions
 interface FileTreeNode {
@@ -781,7 +782,7 @@ function HtmlRenderer({
 
       // Skip image processing if file is remote (we can't resolve relative paths for remote files)
       if (selectedFile.isRemote) {
-        setProcessedHtml(html);
+        setProcessedHtml(injectFontStyles(html));
         return;
       }
 
@@ -916,30 +917,6 @@ function HtmlRenderer({
         setProcessedHtml('');
         return;
       }
-
-      // Inject consistent font styles to ensure clean rendering
-      const fontStyleTag = `<style data-eigent-fonts>
-        *, *::before, *::after {
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif !important;
-        }
-        code, pre, kbd, samp {
-          font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace !important;
-        }
-      </style>`;
-
-      // Helper to inject font styles into HTML
-      const injectFontStyles = (html: string): string => {
-        // If HTML has <head>, inject after <head>
-        if (/<head[^>]*>/i.test(html)) {
-          return html.replace(/(<head[^>]*>)/i, `$1${fontStyleTag}`);
-        }
-        // If HTML has <html>, inject after <html>
-        if (/<html[^>]*>/i.test(html)) {
-          return html.replace(/(<html[^>]*>)/i, `$1${fontStyleTag}`);
-        }
-        // Otherwise prepend to content
-        return fontStyleTag + html;
-      };
 
       // Set the processed HTML with font styles - iframe sandbox provides security
       setProcessedHtml(injectFontStyles(processedHtmlContent));

--- a/src/components/WorkFlow/MarkDown.tsx
+++ b/src/components/WorkFlow/MarkDown.tsx
@@ -15,6 +15,7 @@
 import { useState, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { isHtmlDocument } from "@/lib/htmlFontStyles";
 
 export const MarkDown = ({
 	content,
@@ -60,12 +61,6 @@ export const MarkDown = ({
 	// process line breaks, convert \n to <br> tag
 	const processContent = (text: string) => {
 		return text.replace(/\\n/g, "  \n "); // add two spaces before \n, so ReactMarkdown will recognize it as a line break
-	};
-
-	// Check if content is pure HTML document
-	const isHtmlDocument = (text: string) => {
-		const trimmed = text.trim();
-		return /^<!doctype\s+html/i.test(trimmed) || /^<html/i.test(trimmed);
 	};
 
 	// If content is a pure HTML document, render in a styled pre block

--- a/src/lib/htmlFontStyles.ts
+++ b/src/lib/htmlFontStyles.ts
@@ -1,0 +1,55 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+/**
+ * Consistent font style tag for HTML content rendering.
+ * Uses system fonts with !important to override inline styles.
+ */
+export const FONT_STYLE_TAG = `<style data-eigent-fonts>
+  *, *::before, *::after {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif !important;
+  }
+  code, pre, kbd, samp {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace !important;
+  }
+</style>`;
+
+/**
+ * Injects font styles into HTML content.
+ * Smart injection that handles different HTML structures:
+ * - Injects after <head> if present
+ * - Injects after <html> if no <head>
+ * - Prepends to content otherwise
+ */
+export function injectFontStyles(html: string): string {
+  // If HTML has <head>, inject after <head>
+  if (/<head[^>]*>/i.test(html)) {
+    return html.replace(/(<head[^>]*>)/i, `$1${FONT_STYLE_TAG}`);
+  }
+  // If HTML has <html>, inject after <html>
+  if (/<html[^>]*>/i.test(html)) {
+    return html.replace(/(<html[^>]*>)/i, `$1${FONT_STYLE_TAG}`);
+  }
+  // Otherwise prepend to content
+  return FONT_STYLE_TAG + html;
+}
+
+/**
+ * Checks if content is a pure HTML document (starts with <!DOCTYPE html> or <html>).
+ * Used to determine if content should be rendered as raw HTML vs markdown.
+ */
+export function isHtmlDocument(text: string): boolean {
+  const trimmed = text.trim();
+  return /^<!doctype\s+html/i.test(trimmed) || /^<html/i.test(trimmed);
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1032 

## Problem
When Eigent generates HTML content (reports, documents), the rendered output displays inconsistent fonts. This happens because:
1. Generated HTML contains various inline `font-family` CSS styles
2. iframe rendering doesn't inherit parent application styles
3. Different browsers apply different default fonts

## Solution
Inject a `<style>` tag with consistent font styles (using `!important` to override inline styles) into all HTML content before rendering.

```css
*, *::before, *::after {
  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif !important;
}
code, pre, kbd, samp {
  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace !important;
}
```

The style injection is smart:
- Injects after `<head>` if present
- Injects after `<html>` if no `<head>`
- Prepends to content otherwise

## Files Changed
| File | Change |
|------|--------|
| `src/components/Folder/index.tsx` | Inject font styles into iframe and div HTML rendering (HtmlRenderer) |
| `src/components/Folder/FolderComponent.tsx` | Inject font styles into office document HTML rendering |

<img width="371" height="1045" alt="Image" src="https://github.com/user-attachments/assets/6cb7ab78-5643-497a-b2f1-5fb7966b0029" />

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
