### PR TITLE
enhance: enhance cdp

### DIFF
--- a/backend/app/agent/factory/browser.py
+++ b/backend/app/agent/factory/browser.py
@@ -42,16 +42,22 @@ class CdpBrowserPoolManager:
 
     def __init__(self):
         self._occupied_ports: dict[int, str] = {}
+        self._session_to_port: dict[str, int] = {}
+        self._session_to_task: dict[str, str | None] = {}
         self._lock = threading.Lock()
 
     def acquire_browser(
-        self, cdp_browsers: list[dict], session_id: str
+        self,
+        cdp_browsers: list[dict],
+        session_id: str,
+        task_id: str | None = None,
     ) -> dict | None:
         """Acquire an available browser from the pool.
 
         Args:
             cdp_browsers: List of browser configurations.
             session_id: Unique session identifier.
+            task_id: Optional task identifier for ownership tracking.
 
         Returns:
             Browser configuration dict or None if all occupied.
@@ -61,6 +67,8 @@ class CdpBrowserPoolManager:
                 port = browser.get("port")
                 if port and port not in self._occupied_ports:
                     self._occupied_ports[port] = session_id
+                    self._session_to_port[session_id] = port
+                    self._session_to_task[session_id] = task_id
                     logger.info(
                         f"Acquired browser on port {port} for session "
                         f"{session_id}. Occupied: "
@@ -81,11 +89,48 @@ class CdpBrowserPoolManager:
                 and self._occupied_ports[port] == session_id
             ):
                 del self._occupied_ports[port]
+                self._session_to_port.pop(session_id, None)
+                self._session_to_task.pop(session_id, None)
                 logger.info(
                     f"Released browser on port {port} from session "
                     f"{session_id}. Occupied: "
                     f"{list(self._occupied_ports.keys())}"
                 )
+            else:
+                logger.warning(
+                    f"Attempted to release browser on port {port} "
+                    f"but it was not occupied by {session_id}"
+                )
+
+    def release_by_task(self, task_id: str) -> list[int]:
+        """Release all browsers associated with a task_id.
+
+        Returns:
+            List of released ports.
+        """
+        released_ports = []
+        with self._lock:
+            sessions = [
+                s for s, t in self._session_to_task.items()
+                if t == task_id
+            ]
+            for session_id in sessions:
+                port = self._session_to_port.get(session_id)
+                if (
+                    port is not None
+                    and self._occupied_ports.get(port) == session_id
+                ):
+                    del self._occupied_ports[port]
+                    released_ports.append(port)
+                self._session_to_port.pop(session_id, None)
+                self._session_to_task.pop(session_id, None)
+            if released_ports:
+                logger.info(
+                    f"Released {len(released_ports)} browser(s) for "
+                    f"task {task_id}. Occupied: "
+                    f"{list(self._occupied_ports.keys())}"
+                )
+        return released_ports
 
     def get_occupied_ports(self) -> list[int]:
         """Get list of currently occupied ports."""
@@ -116,7 +161,7 @@ def browser_agent(options: Chat):
 
     if options.cdp_browsers:
         selected_browser = _cdp_pool_manager.acquire_browser(
-            options.cdp_browsers, toolkit_session_id
+            options.cdp_browsers, toolkit_session_id, options.task_id
         )
         if selected_browser:
             selected_port = selected_browser.get(
@@ -256,7 +301,7 @@ def browser_agent(options: Chat):
             return
         session_id = str(uuid.uuid4())[:8]
         selected = _cdp_pool_manager.acquire_browser(
-            options.cdp_browsers, session_id
+            options.cdp_browsers, session_id, options.task_id
         )
         if selected:
             agent_instance._cdp_port = selected.get(
@@ -287,6 +332,7 @@ def browser_agent(options: Chat):
     agent._cdp_release_callback = release_cdp_from_agent
     agent._cdp_port = selected_port
     agent._cdp_session_id = toolkit_session_id
+    agent._cdp_task_id = options.task_id
     agent._cdp_options = options
     agent._browser_toolkit = web_toolkit_for_agent_registration
 

--- a/backend/app/model/chat.py
+++ b/backend/app/model/chat.py
@@ -64,7 +64,7 @@ class Chat(BaseModel):
     language: str = "en"
     browser_port: int = 9222
     use_external_cdp: bool = False
-    cdp_browsers: list[dict] = []
+    cdp_browsers: list[dict] = Field(default_factory=list)
     max_retries: int = 3
     allow_local_system: bool = False
     installed_mcp: McpServers = {"mcpServers": {}}

--- a/backend/app/utils/workforce.py
+++ b/backend/app/utils/workforce.py
@@ -968,7 +968,32 @@ class Workforce(BaseWorkforce):
         try:
             from app.agent.factory.browser import _cdp_pool_manager
 
-            _cdp_pool_manager._occupied_ports.clear()
+            task_ids = set()
+            if hasattr(self, '_children') and self._children:
+                for child in self._children:
+                    if hasattr(child, 'worker_agent') and hasattr(child.worker_agent, '_cdp_task_id'):
+                        task_ids.add(child.worker_agent._cdp_task_id)
+                    if hasattr(child, 'agent_pool') and child.agent_pool:
+                        for agent in list(child.agent_pool._available_agents):
+                            if hasattr(agent, '_cdp_task_id'):
+                                task_ids.add(agent._cdp_task_id)
+            if hasattr(self, 'coordinator_agent') and self.coordinator_agent and hasattr(self.coordinator_agent, '_cdp_task_id'):
+                task_ids.add(self.coordinator_agent._cdp_task_id)
+
+            if not task_ids:
+                logger.warning("[WF-CLEANUP] No task_id found for CDP release; skipping pool cleanup")
+                return
+
+            logger.info(f"[WF-CLEANUP] Force releasing CDP resources for task_ids: {sorted(task_ids)}")
+            occupied_before = _cdp_pool_manager.get_occupied_ports().copy()
+            logger.info(f"[WF-CLEANUP] CDP ports occupied before force release: {occupied_before}")
+
+            released_ports = []
+            for task_id in task_ids:
+                released_ports.extend(_cdp_pool_manager.release_by_task(task_id))
+
+            logger.info(f"[WF-CLEANUP] ✅ Force released {len(released_ports)} CDP browser(s)")
+            logger.info(f"[WF-CLEANUP] CDP ports after force release: {_cdp_pool_manager.get_occupied_ports()}")
         except Exception as e:
             logger.error(f"[WF-CLEANUP] Error clearing CDP pool: {e}")
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

- Problem: CDP port occupancy is tracked in a global pool and workforce shutdown
    clears the entire pool, causing parallel tasks to reuse the same port; clone
    temporarily mutates the parent toolkit’s CDP config without guaranteed restoration
    and leaks pre-acquired ports on failure; cdp_browsers uses a mutable default and
    can leak state across requests.
- Fix: Track session/task ownership in the CDP pool and release by task instead of
  clearing globally; wrap clone mutation in try/finally with cleanup on failure;
  switch cdp_browsers to Field(default_factory=list).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
