### PR TITLE
fix(cookie_manager): robustness — None-safe value, search_cookies domain, temp DB cleanup

### DIFF
--- a/backend/app/utils/cookie_manager.py
+++ b/backend/app/utils/cookie_manager.py
@@ -53,6 +53,7 @@ class CookieManager:
             return None
 
         temp_db_path = self.cookies_db_path + ".tmp"
+        conn = None
         try:
             shutil.copy2(self.cookies_db_path, temp_db_path)
             conn = sqlite3.connect(temp_db_path)
@@ -60,6 +61,11 @@ class CookieManager:
             return conn
         except Exception as e:
             logger.error(f"Error connecting to cookies database: {e}")
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
             try:
                 if os.path.exists(temp_db_path):
                     os.remove(temp_db_path)


### PR DESCRIPTION
## Summary
- get_cookies_for_domain: handle None row value to avoid TypeError when Chrome has NULL cookie values
- search_cookies: guard domain when None to avoid AttributeError on .lower()
- _get_cookies_connection: clean up temp DB file on connect failure
- Any type hint for cookie domain dicts