### PR TITLE
chore: fix replay when self host

### DIFF
--- a/electron/main/init.ts
+++ b/electron/main/init.ts
@@ -36,38 +36,50 @@ import {
 
 const execAsync = promisify(exec);
 
-const DEFAULT_SERVER_URL = "https://dev.eigent.ai/api";
+const DEFAULT_SERVER_URL = 'https://dev.eigent.ai/api';
 
 function readEnvValue(filePath: string, key: string): string | undefined {
-    try {
-        if (!fs.existsSync(filePath)) return undefined;
-        const content = fs.readFileSync(filePath, 'utf-8');
-        const lines = content.split(/\r?\n/);
-        const line = lines.find((l) => {
-            const trimmed = l.trim();
-            return trimmed && !trimmed.startsWith('#') && trimmed.startsWith(`${key}=`);
-        });
-        if (!line) return undefined;
-        let value = line.trim().slice(key.length + 1).trim();
-        // Strip surrounding quotes (single or double)
-        if ((value.startsWith('"') && value.endsWith('"')) ||
-            (value.startsWith("'") && value.endsWith("'"))) {
-            value = value.slice(1, -1);
-        }
-        return value;
-    } catch (error) {
-        log.warn(`Failed to read ${key} from ${filePath}:`, error);
-        return undefined;
+  try {
+    if (!fs.existsSync(filePath)) return undefined;
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const lines = content.split(/\r?\n/);
+    const line = lines.find((l) => {
+      let trimmed = l.trim();
+      if (!trimmed || trimmed.startsWith('#')) return false;
+      // Handle lines with 'export' prefix (e.g. export SERVER_URL=value)
+      if (trimmed.startsWith('export ')) {
+        trimmed = trimmed.slice(7).trim();
+      }
+      return trimmed.startsWith(`${key}=`);
+    });
+    if (!line) return undefined;
+    let raw = line.trim();
+    // Strip 'export ' prefix before extracting value
+    if (raw.startsWith('export ')) {
+      raw = raw.slice(7).trim();
     }
+    let value = raw.slice(key.length + 1).trim();
+    // Strip surrounding quotes (single or double)
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    return value;
+  } catch (error) {
+    log.warn(`Failed to read ${key} from ${filePath}:`, error);
+    return undefined;
+  }
 }
 
 function buildLocalServerUrl(proxyUrl: string | undefined): string | undefined {
-    if (!proxyUrl) return undefined;
-    const trimmed = proxyUrl.trim().replace(/\/+$/, '');
-    if (!trimmed) return undefined;
-    // Avoid double /api suffix
-    if (trimmed.endsWith('/api')) return trimmed;
-    return `${trimmed}/api`;
+  if (!proxyUrl) return undefined;
+  const trimmed = proxyUrl.trim().replace(/\/+$/, '');
+  if (!trimmed) return undefined;
+  // Avoid double /api suffix
+  if (trimmed.endsWith('/api')) return trimmed;
+  return `${trimmed}/api`;
 }
 
 // helper function to get main window
@@ -227,7 +239,11 @@ export async function startBackend(
 
   if (envProxyEnabled) {
     resolvedServerUrl = buildLocalServerUrl(envProxyUrl);
-    resolvedSource = 'process.env VITE_*';
+    if (resolvedServerUrl) {
+      resolvedSource = 'process.env VITE_*';
+    } else {
+      log.warn('VITE_USE_LOCAL_PROXY is true but VITE_PROXY_URL is empty or invalid, ignoring');
+    }
   }
 
   const devServerUrl = process.env.VITE_DEV_SERVER_URL;
@@ -237,7 +253,11 @@ export async function startBackend(
     const devProxyUrl = readEnvValue(devEnvPath, 'VITE_PROXY_URL');
     if (devProxyEnabled) {
       resolvedServerUrl = buildLocalServerUrl(devProxyUrl);
-      resolvedSource = `dev env file (${devEnvPath})`;
+      if (resolvedServerUrl) {
+        resolvedSource = `dev env file (${devEnvPath})`;
+      } else {
+        log.warn(`VITE_USE_LOCAL_PROXY is true in ${devEnvPath} but VITE_PROXY_URL is empty or invalid, ignoring`);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## 🐞 Root Cause

The local Electron app always **overwrote `SERVER_URL`** when spawning the backend,
forcing it to: https://dev.eigent.ai/api

As a result:

- Step events were **synced to the cloud** instead of the local server
- The local server had **no step data**
- Local replay **got stuck with no steps to replay**

---

## ✅ Fix

Updated the Electron backend launcher to:

- Read `SERVER_URL` from `~/.eigent/.env` **or existing environment variables**
- **Only fall back to the cloud URL** if `SERVER_URL` is not provided

After restarting the app and running a new task:

- Step events are **stored locally**
- Local replay **works as expected**


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
