### PR TITLE
Fix frozen TaskFailedEvent mutation in workforce failure handling

### DIFF
--- a/backend/app/utils/telemetry/workforce_metrics.py
+++ b/backend/app/utils/telemetry/workforce_metrics.py
@@ -74,6 +74,7 @@ ATTR_TASK_QUALITY_SCORE = "eigent.task.quality_score"
 ATTR_TASK_TIMESTAMP = "eigent.task.timestamp"
 ATTR_TASK_DEPENDENCIES = "eigent.task.dependencies"
 ATTR_TASK_SUBTASK_IDS = "eigent.task.subtask_ids"
+ATTR_TASK_FAILURE_COUNT = "eigent.task.failure_count"
 
 # Attribute keys for eigent.worker namespace
 ATTR_WORKER_ID = "eigent.worker.id"
@@ -534,6 +535,10 @@ class WorkforceMetricsCallback(WorkforceMetrics):
                 span.set_attribute(ATTR_TASK_PARENT_ID, event.parent_task_id)
             if event.worker_id:
                 span.set_attribute(ATTR_WORKER_ID, event.worker_id)
+            if event.metadata and isinstance(event.metadata.get("failure_count"),
+                                             int):
+                span.set_attribute(ATTR_TASK_FAILURE_COUNT,
+                                   event.metadata["failure_count"])
 
             span.set_status(Status(StatusCode.ERROR, event.error_message))
             span.end()

--- a/backend/app/utils/workforce.py
+++ b/backend/app/utils/workforce.py
@@ -819,19 +819,17 @@ class Workforce(BaseWorkforce):
 
         if metrics_callbacks:
             error_msg = error_message or str(task.result or "Unknown error")
-            # Pass all values during construction since TaskFailedEvent is frozen
-            worker_id = (
-                task.assigned_worker_id
-                if hasattr(task, "assigned_worker_id")
-                else None
-            )
+            worker_id = getattr(task, "assigned_worker_id", None)
             event = TaskFailedEvent(
                 task_id=task.id,
                 error_message=error_msg,
                 worker_id=worker_id,
                 metadata={"failure_count": task.failure_count},
             )
-            metrics_callbacks[0].log_task_failed(event)
+            for callback in metrics_callbacks:
+                log_task_failed = getattr(callback, "log_task_failed", None)
+                if callable(log_task_failed):
+                    log_task_failed(event)
 
         return result
 

--- a/backend/app/utils/workforce.py
+++ b/backend/app/utils/workforce.py
@@ -22,7 +22,6 @@ from camel.societies.workforce.events import (
     TaskAssignedEvent,
     TaskCompletedEvent,
     TaskCreatedEvent,
-    TaskFailedEvent,
     WorkerCreatedEvent,
 )
 from camel.societies.workforce.prompts import TASK_DECOMPOSE_PROMPT
@@ -829,19 +828,6 @@ class Workforce(BaseWorkforce):
                 }
             )
         )
-
-        if metrics_callbacks:
-            worker_id = getattr(task, "assigned_worker_id", None)
-            event = TaskFailedEvent(
-                task_id=task.id,
-                error_message=resolved_error_message,
-                worker_id=worker_id,
-                metadata={"failure_count": task.failure_count},
-            )
-            for callback in metrics_callbacks:
-                log_task_failed = getattr(callback, "log_task_failed", None)
-                if callable(log_task_failed):
-                    log_task_failed(event)
 
         return result
 

--- a/backend/app/utils/workforce.py
+++ b/backend/app/utils/workforce.py
@@ -14,7 +14,7 @@
 
 import asyncio
 import logging
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 
 from camel.agents import ChatAgent
 from camel.societies.workforce.base import BaseNode
@@ -801,6 +801,8 @@ class Workforce(BaseWorkforce):
                 continue
 
             for entry in reversed(log_entries):
+                if not isinstance(entry, Mapping):
+                    continue
                 if (
                     entry.get("event_type") == "task_failed"
                     and entry.get("task_id") == task.id

--- a/backend/app/utils/workforce.py
+++ b/backend/app/utils/workforce.py
@@ -829,6 +829,7 @@ class Workforce(BaseWorkforce):
                 task_id=task.id,
                 error_message=error_msg,
                 worker_id=worker_id,
+                metadata={"failure_count": task.failure_count},
             )
             metrics_callbacks[0].log_task_failed(event)
 

--- a/backend/tests/app/utils/test_workforce.py
+++ b/backend/tests/app/utils/test_workforce.py
@@ -455,6 +455,7 @@ async def test_handle_failed_task_logs_all_metrics_callbacks(mock_task_lock):
             return {}
 
     callback_one = DummyMetrics()
+    callback_one.log_entries = [object()]
     callback_two = DummyMetrics()
     callback_two.log_entries = [
         {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
  This PR fixes a runtime error caused by mutating a `Pydantic frozen` event model. In `Workforce._handle_failed_task`, we created a `TaskFailedEvent` and then attempted to set worker_id and failure_count afterward. CAMEL’s event models are ConfigDict(frozen=True, extra='forbid'), so post‑creation assignment raises ValidationError: Instance is frozen.

  The fix passes worker_id directly in the constructor and moves failure_count into metadata, which is an allowed field. This keeps the event immutable and avoids the validation error during failure handling.

```
[error] BACKEND: 2026-02-02 22:09:29,434 - camel.camel.societies.workforce.workforce - ERROR - Error handling failed task 1770041310698-1927.1: 1 validation error for TaskFailedEvent
worker_id
  Instance is frozen [type=frozen_instance, input_value='3796b026-9380-46c9-bc42-86ad673fdee2', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/frozen_instance
Traceback (most recent call last):
  File "/Users/Luopc/.eigent/venvs/backend-0.0.82/lib/python3.10/site-packages/camel/societies/workforce/workforce.py", line 5473, in _listen_to_channel
    halt = await self._handle_failed_task(returned_task)
  File "/Users/Luopc/Documents/Development/MyLLMs/eigent/backend/app/utils/workforce.py", line 698, in _handle_failed_task
    event.worker_id = task.assigned_worker_id
  File "/Users/Luopc/.eigent/venvs/backend-0.0.82/lib/python3.10/site-packages/pydantic/main.py", line 1032, in __setattr__
    elif (setattr_handler := self._setattr_handler(name, value)) is not None:
  File "/Users/Luopc/.eigent/venvs/backend-0.0.82/lib/python3.10/site-packages/pydantic/main.py", line 1068, in _setattr_handler
    _check_frozen(cls, name, value)
  File "/Users/Luopc/.eigent/venvs/backend-0.0.82/lib/python3.10/site-packages/pydantic/main.py", line 89, in _check_frozen
    raise ValidationError.from_exception_data(
pydantic_core._pydantic_core.ValidationError: 1 validation error for TaskFailedEvent
worker_id
  Instance is frozen [type=frozen_instance, input_value='3796b026-9380-46c9-bc42-86ad673fdee2', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/frozen_instance
```
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
