### PR TITLE
Fix EPIPE crash on shutdown and llvmlite LLVM version mismatch

### DIFF
--- a/electron/main/install-deps.ts
+++ b/electron/main/install-deps.ts
@@ -406,6 +406,8 @@ class InstallLogs {
         '--no-dev',
         '--cache-dir',
         getCachePath('uv_cache'),
+        '--no-build-isolation-package',
+        'llvmlite',
         ...extraArgs,
       ],
       {


### PR DESCRIPTION
## Summary
- Fix uncaught EPIPE errors that crash the app during shutdown when electron-log's console transport writes to a closed stdout pipe
- Fix llvmlite build failure caused by cmake finding LLVM 14 instead of the required LLVM 20, and uv's build isolation stripping the `CMAKE_ARGS` env var

## Changes

### EPIPE Fix (`electron/main/index.ts`)
- Added stream error handlers on `process.stdout`/`process.stderr` to silently catch broken pipe writes
- Added `uncaughtException` handler that ignores EPIPE errors
- Disabled console log transport in `window-all-closed` and `before-quit` handlers before window destruction

### llvmlite/LLVM Fix (`electron/main/utils/process.ts` + `electron/main/install-deps.ts`)
- `getUvEnv()` discovers LLVM 20 and sets `CMAKE_ARGS` with `-DLLVM_DIR` and `LLVM_CONFIG`
- Enhanced PATH to include LLVM 20 bin directories
- Added `--no-build-isolation-package llvmlite` to `uv sync` args so `CMAKE_ARGS` reaches the build subprocess

## Test plan
- [x] App launches without EPIPE crash
- [x] All 218 backend packages install successfully (including llvmlite)
- [x] Backend starts on port 5001 with all routers loaded
- [x] Health check passes
- [x] Zero EPIPE errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)