### PR TITLE
fix:  tool result information's background is transparent

### DIFF
--- a/src/components/ChatBox/MessageItem/AgentMessageCard.tsx
+++ b/src/components/ChatBox/MessageItem/AgentMessageCard.tsx
@@ -65,7 +65,7 @@ export function AgentMessageCard({
   return (
     <div
       key={id}
-      className={`bg-white-0% relative w-full rounded-xl border px-sm py-3 ${className || ''} group overflow-hidden`}
+      className={`relative w-full rounded-xl border bg-message-fill-default px-sm py-3 ${className || ''} group overflow-hidden`}
     >
       <div className="absolute bottom-[0px] right-1 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
         <Button onClick={handleCopy} variant="ghost" size="icon">

--- a/src/components/WorkFlow/node.tsx
+++ b/src/components/WorkFlow/node.tsx
@@ -21,7 +21,6 @@ import {
   ChatTaskStatus,
   TaskStatus,
 } from '@/types/constants';
-import { TooltipContent } from '@radix-ui/react-tooltip';
 import { Handle, NodeResizer, Position, useReactFlow } from '@xyflow/react';
 import {
   Bird,
@@ -52,7 +51,7 @@ import {
   PopoverTrigger,
 } from '../ui/popover';
 import ShinyText from '../ui/ShinyText/ShinyText';
-import { Tooltip, TooltipTrigger } from '../ui/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { MarkDown } from './MarkDown';
 
 interface NodeProps {
@@ -908,7 +907,11 @@ export function Node({ id, data }: NodeProps) {
                         {toolkit.message && (
                           <TooltipContent
                             align="start"
-                            className="scrollbar pointer-events-auto !fixed z-[9999] max-h-[200px] w-[200px] select-text overflow-y-auto text-wrap break-words rounded-sm border border-solid border-task-border-default bg-white-100% p-2 text-xs"
+                            className="scrollbar pointer-events-auto !fixed z-[9999] max-h-[200px] w-[200px] select-text overflow-y-auto text-wrap break-words rounded-sm border border-solid border-task-border-default p-2 text-xs"
+                            style={{
+                              backgroundColor: 'var(--surface-tertiary)',
+                              backdropFilter: 'none',
+                            }}
                             side="left"
                             sideOffset={200}
                           >

--- a/src/style/markdown-styles.css
+++ b/src/style/markdown-styles.css
@@ -215,7 +215,7 @@
 
 /* Ensure compatibility with your app's theme */
 .markdown-body {
-  background-color: transparent !important;
+  background-color: inherit;
   font-family:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !important;


### PR DESCRIPTION
   - Fix tool result information having transparent background causing overlap with content behind it

   ## Changes
   - `AgentMessageCard.tsx`: Use `bg-message-fill-default` instead of `bg-white-0%` for solid background
   - `node.tsx`: Import `TooltipContent` from local UI component and add inline style to ensure opaque background
   - `markdown-styles.css`: Change `background-color: transparent !important` to `inherit` so markdown inherits parent
   background

   Fixes #1149