### PR TITLE
fix(backend): restrict CORS to configurable origins and explicit methods/headers

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -2,6 +2,12 @@
 uv run uvicorn main:api --port 5001
 ```
 
+### CORS
+
+CORS is restricted to avoid allowing arbitrary origins. Configure allowed browser origins in `~/.eigent/.env`:
+
+- **`CORS_ORIGINS`** (optional): Comma-separated list of origins, e.g. `http://localhost:5173,http://localhost:3000`. In development, if unset, common localhost origins are allowed; in production, no origins are allowed until you set this.
+
 i18n operation process: https://github.com/Anbarryprojects/fastapi-babel
 
 ```bash

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -12,17 +12,55 @@
 # limitations under the License.
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import logging
+import os
+
+from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
+# Load env so CORS_ORIGINS is available when this module is imported (before main runs).
+load_dotenv(dotenv_path=os.path.join(os.path.expanduser("~"), ".eigent", ".env"))
+
+logger = logging.getLogger(__name__)
 
 # Initialize FastAPI with title
 api = FastAPI(title="Eigent Multi-Agent System API")
 
-# Add CORS middleware
-api.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+
+def _get_cors_origins() -> list[str]:
+    """
+    CORS allowed origins. Avoids overly permissive '*' to prevent unwanted origins.
+    Set CORS_ORIGINS (comma-separated) in ~/.eigent/.env or environment;
+    in development only, defaults to common localhost origins if unset.
+    """
+    raw = os.environ.get("CORS_ORIGINS")
+    if raw is not None and raw.strip():
+        origins = [o.strip() for o in raw.split(",") if o.strip()]
+        if origins:
+            return origins
+    if os.environ.get("ENVIRONMENT", "development").lower() == "development":
+        return [
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+        ]
+    return []
+
+
+_cors_origins = _get_cors_origins()
+if _cors_origins:
+    api.add_middleware(
+        CORSMiddleware,
+        allow_origins=_cors_origins,
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization", "x-stack-auth"],
+    )
+    logger.info("CORS enabled for origins: %s", _cors_origins)
+else:
+    logger.info(
+        "CORS disabled (no CORS_ORIGINS set in non-development). "
+        "Set CORS_ORIGINS (comma-separated) to allow browser origins."
+    )


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Related Issue
CORS configuration: missing or overly permissive CORS can allow unwanted origins.
<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->
<!-- Example: Closes #123 or Fixes #456 -->

Closes #1260

### Description
Replace permissive CORS (allow_origins=["*"] with allow_credentials=True and
allow_methods/allow_headers=["*"]) with a safe, configurable setup:

- Origins: read from CORS_ORIGINS (comma-separated) in ~/.eigent/.env or env.
  In development, if unset, allow only http://localhost:5173, 127.0.0.1:5173,
  and ports 3000. In non-development, allow no origins until CORS_ORIGINS is set.
- Methods: GET, POST, PUT, DELETE, OPTIONS only.
- Headers: Content-Type, Authorization, x-stack-auth only.

Document CORS_ORIGINS in backend README. Ensures credentials work correctly
(no wildcard origin with credentials) and reduces risk of unwanted origins
calling the API from the browser.
<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

### Why?
- Security: Overly permissive CORS lets any website send credentialed requests to your API from the browser; restricting to an explicit origin list and to the methods/headers the app uses reduces that risk.
- Correctness: Using allow_origins=["*"] with allow_credentials=True is invalid per the CORS spec; browsers may ignore or mishandle it. Using a concrete list of origins with credentials is valid and predictable.
- Operability: Development keeps working with default localhost origins; production stays strict until CORS_ORIGINS is set, and the README explains how to configure it.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
