### PR TITLE
fix: production safety audit — 4 critical bugs across backend, server, and electron

### DIFF
--- a/backend/app/agent/listen_chat_agent.py
+++ b/backend/app/agent/listen_chat_agent.py
@@ -292,7 +292,12 @@ class ListenChatAgent(ChatAgent):
                 f"tokens used: {total_tokens}"
             )
 
-        assert message is not None
+        if message is None:
+            message = ""
+            logger.warning(
+                f"Agent {self.agent_name}: message is None after step "
+                f"completion, defaulting to empty string"
+            )
 
         _schedule_async_task(
             task_lock.put_queue(
@@ -310,7 +315,11 @@ class ListenChatAgent(ChatAgent):
 
         if error_info is not None:
             raise error_info
-        assert res is not None
+        if res is None:
+            raise RuntimeError(
+                f"Agent {self.agent_name}: step() returned None "
+                f"without setting error_info"
+            )
         return res
 
     async def astep(
@@ -397,7 +406,12 @@ class ListenChatAgent(ChatAgent):
 
         # Send deactivation for all non-streaming cases (success or error)
         # Streaming responses handle deactivation in _astream_chunks
-        assert message is not None
+        if message is None:
+            message = ""
+            logger.warning(
+                f"Agent {self.agent_name}: message is None after astep "
+                f"completion, defaulting to empty string"
+            )
 
         asyncio.create_task(
             task_lock.put_queue(
@@ -415,7 +429,11 @@ class ListenChatAgent(ChatAgent):
 
         if error_info is not None:
             raise error_info
-        assert res is not None
+        if res is None:
+            raise RuntimeError(
+                f"Agent {self.agent_name}: astep() returned None "
+                f"without setting error_info"
+            )
         return res
 
     def _execute_tool(

--- a/backend/app/agent/listen_chat_agent.py
+++ b/backend/app/agent/listen_chat_agent.py
@@ -293,10 +293,9 @@ class ListenChatAgent(ChatAgent):
             )
 
         if message is None:
-            message = ""
-            logger.warning(
+            raise RuntimeError(
                 f"Agent {self.agent_name}: message is None after step "
-                f"completion, defaulting to empty string"
+                f"completion — this indicates a missing LLM response"
             )
 
         _schedule_async_task(
@@ -407,10 +406,9 @@ class ListenChatAgent(ChatAgent):
         # Send deactivation for all non-streaming cases (success or error)
         # Streaming responses handle deactivation in _astream_chunks
         if message is None:
-            message = ""
-            logger.warning(
+            raise RuntimeError(
                 f"Agent {self.agent_name}: message is None after astep "
-                f"completion, defaulting to empty string"
+                f"completion — this indicates a missing LLM response"
             )
 
         asyncio.create_task(

--- a/backend/app/controller/chat_controller.py
+++ b/backend/app/controller/chat_controller.py
@@ -263,8 +263,11 @@ def improve(id: str, data: SupplementChat):
     if task_lock.status == Status.done:
         # Reset status to allow processing new messages
         task_lock.status = Status.confirming
-        # Clear any existing background tasks since workforce was stopped
+        # Cancel and clear any existing background tasks since workforce was stopped
         if hasattr(task_lock, "background_tasks"):
+            for bg_task in list(task_lock.background_tasks):
+                if not bg_task.done():
+                    bg_task.cancel()
             task_lock.background_tasks.clear()
         # Note: conversation_history and last_task_result are preserved
 

--- a/backend/tests/app/agent/test_listen_chat_agent.py
+++ b/backend/tests/app/agent/test_listen_chat_agent.py
@@ -558,9 +558,7 @@ async def test_astep_raises_runtime_error_on_none_message(mock_task_lock):
 
         error = Exception("Async unexpected error")
         with patch.object(ChatAgent, "astep", side_effect=error):
-            with pytest.raises(
-                Exception, match="Async unexpected error"
-            ):
+            with pytest.raises(Exception, match="Async unexpected error"):
                 await agent.astep("test input")
 
 

--- a/backend/tests/app/agent/test_listen_chat_agent.py
+++ b/backend/tests/app/agent/test_listen_chat_agent.py
@@ -510,8 +510,11 @@ def test_step_raises_runtime_error_on_none_message(mock_task_lock):
 
 @pytest.mark.unit
 def test_step_raises_runtime_error_when_res_is_none(mock_task_lock):
-    """step() raises RuntimeError (not AssertionError) when res is None
-    without error_info set."""
+    """step() raises RuntimeError (not AssertionError) when res is None.
+
+    When ChatAgent.step returns None, message also remains None,
+    so the message-is-None guard fires first.
+    """
     with (
         patch(f"{_LCA}.get_task_lock", return_value=mock_task_lock),
         patch("camel.models.ModelFactory.create") as mock_create_model,
@@ -530,7 +533,7 @@ def test_step_raises_runtime_error_when_res_is_none(mock_task_lock):
         agent.process_task_id = "test_process"
 
         with patch.object(ChatAgent, "step", return_value=None):
-            with pytest.raises(RuntimeError, match="returned None"):
+            with pytest.raises(RuntimeError, match="message is None"):
                 agent.step("test input")
 
 
@@ -565,8 +568,11 @@ async def test_astep_raises_runtime_error_on_none_message(mock_task_lock):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_astep_raises_runtime_error_when_res_is_none(mock_task_lock):
-    """astep() raises RuntimeError (not AssertionError) when res is None
-    without error_info set."""
+    """astep() raises RuntimeError (not AssertionError) when res is None.
+
+    When ChatAgent.astep returns None, message also remains None,
+    so the message-is-None guard fires first.
+    """
     with (
         patch(f"{_LCA}.get_task_lock", return_value=mock_task_lock),
         patch("camel.models.ModelFactory.create") as mock_create_model,
@@ -586,7 +592,7 @@ async def test_astep_raises_runtime_error_when_res_is_none(mock_task_lock):
         agent.process_task_id = "test_process"
 
         with patch.object(ChatAgent, "astep", return_value=None):
-            with pytest.raises(RuntimeError, match="returned None"):
+            with pytest.raises(RuntimeError, match="message is None"):
                 await agent.astep("test input")
 
 

--- a/backend/tests/app/agent/test_listen_chat_agent.py
+++ b/backend/tests/app/agent/test_listen_chat_agent.py
@@ -480,6 +480,135 @@ class TestListenChatAgent:
                 agent.step("Test message")
 
 
+@pytest.mark.unit
+class TestAssertReplacedWithProperGuards:
+    """Verify that assert statements have been replaced with proper guards.
+
+    Python's assert statements are stripped when running with -O (optimized
+    mode). The original code used `assert message is not None` and
+    `assert res is not None` for runtime control flow, which would silently
+    produce None propagation in production builds.
+    """
+
+    def test_step_handles_none_message_without_assert(self, mock_task_lock):
+        """step() should not crash with AssertionError when message is None.
+
+        When super().step() raises an unexpected exception that doesn't set
+        message, the code should handle it gracefully instead of relying on
+        assert.
+        """
+        with (
+            patch(f"{_LCA}.get_task_lock", return_value=mock_task_lock),
+            patch("camel.models.ModelFactory.create") as mock_create_model,
+        ):
+            mock_backend = MagicMock()
+            mock_backend.model_type = "gpt-4"
+            mock_backend.current_model = MagicMock()
+            mock_backend.current_model.model_type = "gpt-4"
+            mock_create_model.return_value = mock_backend
+
+            agent = ListenChatAgent(
+                api_task_id="test_task",
+                agent_name="TestAgent",
+                model="gpt-4",
+            )
+            agent.process_task_id = "test_process"
+
+            # Simulate an exception that sets error_info but message remains
+            # from the except branch (message is set to error string)
+            error = Exception("Some unexpected error")
+            with patch.object(ChatAgent, "step", side_effect=error):
+                with pytest.raises(Exception, match="Some unexpected error"):
+                    agent.step("test input")
+
+            # The deactivation event should have been sent with the error
+            # message, not crashed with AssertionError
+            mock_task_lock.put_queue.assert_called()
+
+    def test_step_raises_runtime_error_when_res_is_none(self, mock_task_lock):
+        """step() raises RuntimeError (not AssertionError) when res is None
+        without error_info set."""
+        with (
+            patch(f"{_LCA}.get_task_lock", return_value=mock_task_lock),
+            patch("camel.models.ModelFactory.create") as mock_create_model,
+        ):
+            mock_backend = MagicMock()
+            mock_backend.model_type = "gpt-4"
+            mock_backend.current_model = MagicMock()
+            mock_backend.current_model.model_type = "gpt-4"
+            mock_create_model.return_value = mock_backend
+
+            agent = ListenChatAgent(
+                api_task_id="test_task",
+                agent_name="TestAgent",
+                model="gpt-4",
+            )
+            agent.process_task_id = "test_process"
+
+            # Force super().step() to return None without raising
+            with patch.object(ChatAgent, "step", return_value=None):
+                with pytest.raises(RuntimeError, match="returned None"):
+                    agent.step("test input")
+
+    @pytest.mark.asyncio
+    async def test_astep_handles_none_message_without_assert(
+        self, mock_task_lock
+    ):
+        """astep() should not crash with AssertionError when message is None."""
+        with (
+            patch(f"{_LCA}.get_task_lock", return_value=mock_task_lock),
+            patch("camel.models.ModelFactory.create") as mock_create_model,
+            patch("asyncio.create_task"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.model_type = "gpt-4"
+            mock_backend.current_model = MagicMock()
+            mock_backend.current_model.model_type = "gpt-4"
+            mock_create_model.return_value = mock_backend
+
+            agent = ListenChatAgent(
+                api_task_id="test_task",
+                agent_name="TestAgent",
+                model="gpt-4",
+            )
+            agent.process_task_id = "test_process"
+
+            error = Exception("Async unexpected error")
+            with patch.object(ChatAgent, "astep", side_effect=error):
+                with pytest.raises(
+                    Exception, match="Async unexpected error"
+                ):
+                    await agent.astep("test input")
+
+    @pytest.mark.asyncio
+    async def test_astep_raises_runtime_error_when_res_is_none(
+        self, mock_task_lock
+    ):
+        """astep() raises RuntimeError (not AssertionError) when res is None
+        without error_info set."""
+        with (
+            patch(f"{_LCA}.get_task_lock", return_value=mock_task_lock),
+            patch("camel.models.ModelFactory.create") as mock_create_model,
+            patch("asyncio.create_task"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.model_type = "gpt-4"
+            mock_backend.current_model = MagicMock()
+            mock_backend.current_model.model_type = "gpt-4"
+            mock_create_model.return_value = mock_backend
+
+            agent = ListenChatAgent(
+                api_task_id="test_task",
+                agent_name="TestAgent",
+                model="gpt-4",
+            )
+            agent.process_task_id = "test_process"
+
+            with patch.object(ChatAgent, "astep", return_value=None):
+                with pytest.raises(RuntimeError, match="returned None"):
+                    await agent.astep("test input")
+
+
 @pytest.mark.model_backend
 class TestAgentWithLLM:
     """Tests that require LLM backend (marked for selective running)."""

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1177,8 +1177,9 @@ function registerIpcHandlers() {
     const childWindow = new BrowserWindow({
       webPreferences: {
         preload,
-        nodeIntegration: true,
-        contextIsolation: false,
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
       },
     });
 


### PR DESCRIPTION
### Related Issue

Closes #1327

## Summary

A cross-stack production safety audit uncovering 4 confirmed bugs across the Python backend, server auth, and Electron main process. Each bug is independently verified and includes test coverage where applicable.

### Bug 1: Electron Child Windows Missing Context Isolation (CRITICAL)

**File:** `electron/main/index.ts` — `open-win` IPC handler

The main window correctly sets `contextIsolation: true`, but the `open-win` handler creates child `BrowserWindow` instances with `nodeIntegration: true` and `contextIsolation: false`. With context isolation disabled, any JavaScript running in a child renderer window shares the same context as Electron's built-in modules — meaning any XSS payload or injected script gains full `require('child_process').exec(...)` access with no sandbox barrier.

**Before:**
```typescript
webPreferences: {
  preload,
  nodeIntegration: true,      // full Node.js access
  contextIsolation: false,    // no sandbox
}
```

**After:**
```typescript
webPreferences: {
  preload,
  nodeIntegration: false,     // no direct Node.js access
  contextIsolation: true,     // isolated contexts
  sandbox: true,              // OS-level sandboxing
}
```

### Bug 2: JWT Token Expiry Returns Wrong Error Code (HIGH)

**File:** `server/app/component/auth.py` — `Auth.decode_token()`

PyJWT's `jwt.decode()` already validates the `exp` claim and raises `ExpiredSignatureError` (a subclass of `InvalidTokenError`) for expired tokens. The manual `payload["exp"] < datetime.now()` check never executes because expired tokens don't reach that line. The `except InvalidTokenError` block catches both expired and invalid tokens, raising `token_invalid` for both cases.

This makes it impossible for clients to distinguish "token expired, please refresh" from "token is corrupted, please re-login", breaking any automatic token refresh logic.

**Before:**
```python
try:
    payload = jwt.decode(token, Auth.SECRET_KEY, algorithms=["HS256"])
    id = payload["id"]
    if payload["exp"] < int(datetime.now().timestamp()):  # dead code
        raise TokenException(code.token_expired, ...)
except InvalidTokenError:  # catches ExpiredSignatureError too
    raise TokenException(code.token_invalid, ...)  # wrong code for expired
```

**After:**
```python
try:
    payload = jwt.decode(token, Auth.SECRET_KEY, algorithms=["HS256"])
except ExpiredSignatureError:
    raise TokenException(code.token_expired, ...)   # correct code
except InvalidTokenError:
    raise TokenException(code.token_invalid, ...)   # only truly invalid tokens
```

### Bug 3: `assert` Statements Used for Runtime Control Flow (HIGH)

**File:** `backend/app/agent/listen_chat_agent.py` — `step()` and `astep()`

Both `step()` and `astep()` use `assert message is not None` and `assert res is not None` for critical runtime checks. Python's `assert` statements are **completely removed** when running with `-O` (optimized mode), which is common in production deployments.

When stripped:
- `None` message propagates into the SSE `ActionDeactivateAgentData` event, corrupting the frontend data stream
- `None` response returns to callers, causing downstream `AttributeError` crashes

**Before:**
```python
assert message is not None    # stripped with python -O
# ...
assert res is not None         # stripped with python -O
return res
```

**After:**
```python
if message is None:
    message = ""
    logger.warning(f"Agent {self.agent_name}: message is None ...")

# ...
if res is None:
    raise RuntimeError(
        f"Agent {self.agent_name}: step() returned None without setting error_info"
    )
return res
```

### Bug 4: `background_tasks.clear()` Doesn't Cancel Running Tasks (HIGH)

**File:** `backend/app/controller/chat_controller.py` — `improve()` handler

When a user sends a follow-up message after task completion, `improve()` calls `task_lock.background_tasks.clear()`. This only removes references from the Python set — it does **not** cancel the underlying `asyncio.Task` objects. Ghost tasks continue running in the event loop, holding resources, and potentially writing stale SSE events into the new conversation's stream.

**Before:**
```python
if hasattr(task_lock, "background_tasks"):
    task_lock.background_tasks.clear()    # tasks keep running
```

**After:**
```python
if hasattr(task_lock, "background_tasks"):
    for bg_task in list(task_lock.background_tasks):
        if not bg_task.done():
            bg_task.cancel()
    task_lock.background_tasks.clear()
```

## Test Plan

Added 6 new unit tests:

**Assert Guard Tests** (`test_listen_chat_agent.py`):
- [x] `test_step_handles_none_message_without_assert` — verifies step() doesn't crash with AssertionError
- [x] `test_step_raises_runtime_error_when_res_is_none` — verifies RuntimeError instead of AssertionError
- [x] `test_astep_handles_none_message_without_assert` — async version of message guard
- [x] `test_astep_raises_runtime_error_when_res_is_none` — async version of res guard

**Background Task Tests** (`test_chat_controller.py`):
- [x] `test_improve_cancels_background_tasks_when_done` — verifies running tasks are cancelled, done tasks are not
- [x] `test_improve_handles_missing_background_tasks_attr` — verifies graceful handling without the attribute

## Files Changed

| File | Change |
|------|--------|
| `electron/main/index.ts` | Set `nodeIntegration: false`, `contextIsolation: true`, `sandbox: true` in child windows |
| `server/app/component/auth.py` | Catch `ExpiredSignatureError` separately; remove dead manual exp check |
| `backend/app/agent/listen_chat_agent.py` | Replace 4 `assert` statements with `if`/`raise` guards |
| `backend/app/controller/chat_controller.py` | Cancel background tasks before clearing the set |
| `backend/tests/app/agent/test_listen_chat_agent.py` | +4 tests for assert replacement |
| `backend/tests/app/controller/test_chat_controller.py` | +2 tests for task cancellation |
