### PR TITLE
fix: comprehensive security hardening and bug fixes across all codebases

### DIFF
--- a/backend/app/component/environment.py
+++ b/backend/app/component/environment.py
@@ -57,10 +57,12 @@ def sanitize_env_path(env_path: str | None) -> str | None:
         # Convert to Path object for safe manipulation
         user_path = Path(env_path)
 
-        # Reject absolute paths outside our control
+        # Reject absolute paths — they should always be relative to env_base_dir
         if user_path.is_absolute():
-            # Check if it's already within env_base_dir
-            resolved_path = user_path.resolve()
+            logger.warning(
+                f"Security: Rejected absolute env_path. Path: {env_path}"
+            )
+            return None
         else:
             # Join relative path to base directory
             resolved_path = (Path(env_base_dir) / user_path).resolve()

--- a/backend/app/controller/tool_controller.py
+++ b/backend/app/controller/tool_controller.py
@@ -481,7 +481,7 @@ async def uninstall_tool(tool: str):
                         "Cancelled ongoing Google Calendar authorization"
                     )
                 # Clear the state completely to remove cached credentials
-                oauth_state_manager._states.pop("google_calendar", None)
+                oauth_state_manager.remove_state("google_calendar")
                 logger.info("Cleared Google Calendar OAuth state cache")
 
             return {

--- a/backend/app/utils/cookie_manager.py
+++ b/backend/app/utils/cookie_manager.py
@@ -16,6 +16,7 @@ import logging
 import os
 import shutil
 import sqlite3
+import tempfile
 from datetime import datetime
 from typing import Any
 
@@ -60,7 +61,10 @@ class CookieManager:
             )
             return None
 
-        temp_db_path = self.cookies_db_path + ".tmp"
+        fd, temp_db_path = tempfile.mkstemp(
+            suffix=".tmp", dir=os.path.dirname(self.cookies_db_path)
+        )
+        os.close(fd)
         conn = None
         try:
             shutil.copy2(self.cookies_db_path, temp_db_path)

--- a/backend/app/utils/oauth_state_manager.py
+++ b/backend/app/utils/oauth_state_manager.py
@@ -110,6 +110,11 @@ class OAuthStateManager:
                     state.completed_at = datetime.now()
                 logger.info(f"Updated {provider} OAuth status to {status}")
 
+    def remove_state(self, provider: str) -> None:
+        """Remove the state for a provider under lock"""
+        with self._lock:
+            self._states.pop(provider, None)
+
 
 # Global instance
 oauth_state_manager = OAuthStateManager()

--- a/backend/tests/app/component/test_environment.py
+++ b/backend/tests/app/component/test_environment.py
@@ -39,11 +39,13 @@ def test_valid_relative_path():
     assert result.endswith("project1.env")
 
 
-def test_valid_absolute_path_within_base_dir():
-    """Test that absolute path within base directory is accepted."""
+def test_absolute_path_within_base_dir_rejected():
+    """Test that absolute paths are always rejected for security."""
     valid_path = os.path.join(env_base_dir, "valid.env")
     result = sanitize_env_path(valid_path)
-    assert result == os.path.abspath(valid_path)
+    assert result is None, (
+        "Absolute paths should be rejected — callers must use relative paths"
+    )
 
 
 def test_path_traversal_attack_rejected():

--- a/backend/tests/app/service/test_task_lock_mutex.py
+++ b/backend/tests/app/service/test_task_lock_mutex.py
@@ -1,0 +1,78 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import threading
+
+import pytest
+
+from app.service.task import (
+    _task_locks_mutex,
+    create_task_lock,
+    delete_task_lock,
+    get_or_create_task_lock,
+    task_locks,
+)
+
+
+@pytest.mark.unit
+class TestTaskLockMutex:
+    """Tests verifying the _task_locks_mutex protects task_locks from races."""
+
+    def setup_method(self):
+        """Clean up task_locks before each test."""
+        with _task_locks_mutex:
+            task_locks.clear()
+
+    def teardown_method(self):
+        """Clean up task_locks after each test."""
+        with _task_locks_mutex:
+            task_locks.clear()
+
+    def test_create_task_lock_is_thread_safe(self):
+        """Concurrent create_task_lock calls should not corrupt task_locks."""
+        errors = []
+        barrier = threading.Barrier(10)
+
+        def worker(idx):
+            try:
+                barrier.wait(timeout=5)
+                create_task_lock(f"task_{idx}")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Unexpected errors: {errors}"
+        with _task_locks_mutex:
+            assert len(task_locks) == 10
+
+    def test_get_or_create_is_idempotent(self):
+        """get_or_create_task_lock called twice returns the same lock."""
+        lock1 = get_or_create_task_lock("same_id")
+        lock2 = get_or_create_task_lock("same_id")
+        assert lock1 is lock2
+
+    def test_create_task_lock_raises_on_duplicate(self):
+        """create_task_lock should raise for an existing id."""
+        create_task_lock("dup_id")
+        with pytest.raises(Exception):
+            create_task_lock("dup_id")
+
+    def test_mutex_attribute_exists(self):
+        """_task_locks_mutex should be a threading.Lock instance."""
+        assert isinstance(_task_locks_mutex, type(threading.Lock()))

--- a/backend/tests/app/utils/test_cookie_manager.py
+++ b/backend/tests/app/utils/test_cookie_manager.py
@@ -1,0 +1,70 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import os
+import tempfile
+
+import pytest
+
+from app.utils.cookie_manager import CookieManager
+
+
+@pytest.mark.unit
+class TestCookieManagerTempFile:
+    """Tests verifying cookie_manager uses unique temp files via mkstemp."""
+
+    def test_get_cookies_connection_creates_unique_temp(self, tmp_path):
+        """_get_cookies_connection should create a uniquely-named temp copy."""
+        # Create a minimal SQLite database to act as the cookies DB
+        import sqlite3
+
+        cookies_db = tmp_path / "Cookies"
+        conn = sqlite3.connect(str(cookies_db))
+        conn.execute(
+            "CREATE TABLE cookies ("
+            "host_key TEXT, name TEXT, value TEXT, path TEXT, "
+            "expires_utc INTEGER, is_secure INTEGER, is_httponly INTEGER, "
+            "last_access_utc INTEGER)"
+        )
+        conn.commit()
+        conn.close()
+
+        manager = CookieManager(str(tmp_path))
+        result_conn = manager._get_cookies_connection()
+        assert result_conn is not None
+
+        # The temp file should NOT be the predictable ".tmp" suffix
+        # but a unique mkstemp-generated file
+        predictable_tmp = str(cookies_db) + ".tmp"
+        # The actual temp file is in the same directory
+        temp_files = [
+            f
+            for f in os.listdir(str(tmp_path))
+            if f.endswith(".tmp") and f != "Cookies.tmp"
+        ]
+        assert len(temp_files) >= 1, (
+            "mkstemp temp file not found — still using predictable .tmp suffix?"
+        )
+
+        result_conn.close()
+        # Cleanup temp files
+        for f in temp_files:
+            full = os.path.join(str(tmp_path), f)
+            if os.path.exists(full):
+                os.remove(full)
+
+    def test_missing_cookies_db_returns_none(self, tmp_path):
+        """_get_cookies_connection should return None for missing DB."""
+        manager = CookieManager(str(tmp_path / "nonexistent"))
+        assert manager._get_cookies_connection() is None

--- a/backend/tests/app/utils/test_oauth_state_manager.py
+++ b/backend/tests/app/utils/test_oauth_state_manager.py
@@ -1,0 +1,67 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import pytest
+
+from app.utils.oauth_state_manager import OAuthStateManager
+
+
+@pytest.mark.unit
+class TestOAuthStateManager:
+    """Tests for OAuthStateManager including the new remove_state method."""
+
+    def setup_method(self):
+        self.manager = OAuthStateManager()
+
+    def test_create_and_get_state(self):
+        """create_state should return a retrievable state object."""
+        state = self.manager.create_state("google")
+        assert state.provider == "google"
+        assert state.status == "pending"
+        retrieved = self.manager.get_state("google")
+        assert retrieved is state
+
+    def test_remove_state_cleans_up(self):
+        """remove_state should remove the provider's state under lock."""
+        self.manager.create_state("github")
+        assert self.manager.get_state("github") is not None
+        self.manager.remove_state("github")
+        assert self.manager.get_state("github") is None
+
+    def test_remove_state_nonexistent_does_not_raise(self):
+        """remove_state on a missing provider should not raise."""
+        self.manager.remove_state("nonexistent")
+
+    def test_update_status_sets_completed_at(self):
+        """Updating to a terminal status should set completed_at."""
+        self.manager.create_state("slack")
+        self.manager.update_status("slack", "success")
+        state = self.manager.get_state("slack")
+        assert state.status == "success"
+        assert state.completed_at is not None
+
+    def test_create_state_cancels_previous_pending(self):
+        """Creating a new state for the same provider cancels the old one."""
+        old = self.manager.create_state("google")
+        assert old.status == "pending"
+        _new = self.manager.create_state("google")
+        assert old.status == "cancelled"
+
+    def test_to_dict(self):
+        """to_dict should include all expected keys."""
+        state = self.manager.create_state("test")
+        d = state.to_dict()
+        assert set(d.keys()) == {"provider", "status", "error", "started_at", "completed_at"}
+        assert d["provider"] == "test"
+        assert d["status"] == "pending"

--- a/electron/main/fileReader.ts
+++ b/electron/main/fileReader.ts
@@ -23,6 +23,15 @@ import * as unzipper from 'unzipper';
 import { URL } from 'url';
 import { parseStringPromise } from 'xml2js';
 
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 interface FileInfo {
   path: string;
   name: string;
@@ -225,7 +234,7 @@ export class FileReader {
             const cellValue = cell
               ? this.getCellValue(cell, sharedStrings)
               : '';
-            html += `<td>${cellValue}</td>`;
+            html += `<td>${escapeHtml(String(cellValue))}</td>`;
           }
 
           html += '</tr>';
@@ -343,7 +352,7 @@ export class FileReader {
             for (const run of runs) {
               const text = run?.['a:t']?.[0];
               if (text) {
-                html += `<li>${text}</li>`;
+                html += `<li>${escapeHtml(String(text))}</li>`;
               }
             }
           }
@@ -378,7 +387,7 @@ export class FileReader {
         // Header row
         html += '<thead><tr style="background-color: #f5f5f5;">';
         headers.forEach((header) => {
-          html += `<th style="border: 1px solid #ddd; padding: 8px; text-align: left;">${header}</th>`;
+          html += `<th style="border: 1px solid #ddd; padding: 8px; text-align: left;">${escapeHtml(String(header))}</th>`;
         });
         html += '</tr></thead>';
 
@@ -387,7 +396,7 @@ export class FileReader {
         result.data.forEach((row: any) => {
           html += '<tr>';
           headers.forEach((header) => {
-            html += `<td style="border: 1px solid #ddd; padding: 8px;">${row[header] || ''}</td>`;
+            html += `<td style="border: 1px solid #ddd; padding: 8px;">${escapeHtml(String(row[header] || ''))}</td>`;
           });
           html += '</tr>';
         });

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -261,13 +261,13 @@ function processProtocolUrl(url: string) {
       log.info('oauth');
       const provider = urlObj.searchParams.get('provider');
       const code = urlObj.searchParams.get('code');
-      log.info('protocol oauth', provider, code);
+      log.info('protocol oauth', provider, '[REDACTED]');
       win.webContents.send('oauth-authorized', { provider, code });
       return;
     }
 
     if (code) {
-      log.error('protocol code:', code);
+      log.info('protocol code received, length:', code?.length);
       win.webContents.send('auth-code-received', code);
     }
 
@@ -852,7 +852,7 @@ function registerIpcHandlers() {
         .stat(filePath.replace(/\/$/, ''))
         .catch(() => null);
       if (stats && stats.isDirectory()) {
-        shell.openPath(filePath);
+        shell.showItemInFolder(filePath + path.sep);
       } else {
         shell.showItemInFolder(filePath);
       }

--- a/electron/main/update.ts
+++ b/electron/main/update.ts
@@ -24,7 +24,7 @@ const { autoUpdater } = createRequire(import.meta.url)('electron-updater');
 
 export function update(win: Electron.BrowserWindow) {
   // When set to false, the update download will be triggered through the API
-  autoUpdater.verifyUpdateCodeSignature = false;
+  autoUpdater.verifyUpdateCodeSignature = true;
   autoUpdater.autoDownload = false;
   autoUpdater.disableWebInstaller = false;
   autoUpdater.allowDowngrade = false;
@@ -147,10 +147,12 @@ function startDownload(
   callback: (error: Error | null, info: ProgressInfo | null) => void,
   complete: (event: UpdateDownloadedEvent) => void
 ) {
+  autoUpdater.removeAllListeners('download-progress');
+  autoUpdater.removeAllListeners('update-downloaded');
   autoUpdater.on('download-progress', (info: ProgressInfo) =>
     callback(null, info)
   );
-  autoUpdater.on('error', (error: Error) => callback(error, null));
-  autoUpdater.on('update-downloaded', complete);
+  autoUpdater.once('error', (error: Error) => callback(error, null));
+  autoUpdater.once('update-downloaded', complete);
   autoUpdater.downloadUpdate();
 }

--- a/server/app/component/auth.py
+++ b/server/app/component/auth.py
@@ -89,11 +89,15 @@ async def auth(
 
 
 async def auth_must(
-    token: str = Depends(oauth2_scheme),
+    token: str | None = Depends(oauth2_scheme),
     session: Session = Depends(session),
 ) -> Auth:
+    if token is None:
+        raise TokenException(code.token_invalid, _("Authentication required"))
     model = Auth.decode_token(token)
     user = session.get(User, model.id)
+    if not user:
+        raise TokenException(code.token_invalid, _("User not found"))
     model._user = user
     return model
 

--- a/server/app/controller/chat/history_controller.py
+++ b/server/app/controller/chat/history_controller.py
@@ -121,6 +121,7 @@ def list_grouped_chat_history(
             "tasks": [],
             "total_completed_tasks": 0,
             "total_ongoing_tasks": 0,
+            "total_failed_tasks": 0,
             "average_tokens_per_task": 0,
         }
     )

--- a/server/app/controller/mcp/mcp_controller.py
+++ b/server/app/controller/mcp/mcp_controller.py
@@ -184,9 +184,9 @@ async def install(mcp_id: int, session: Session = Depends(session), auth: Auth =
             mcp_desc=mcp.description,
             type=mcp.type,
             status=Status.enable,
-            command=install_command["command"],
-            args=install_command["args"],
-            env=install_command["env"],
+            command=install_command.get("command"),
+            args=install_command.get("args", []),
+            env=install_command.get("env", {}),
             server_url=None,
         )
         mcp_user.save()

--- a/server/app/controller/redirect_controller.py
+++ b/server/app/controller/redirect_controller.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import html
 import json
 
 from fastapi import APIRouter, Request
@@ -24,6 +25,8 @@ router = APIRouter(tags=["Redirect"])
 def redirect_callback(code: str, request: Request):
     cookies = request.cookies
     cookies_json = json.dumps(cookies)
+
+    safe_code = html.escape(code, quote=True)
 
     html_content = f"""
     <!DOCTYPE html>
@@ -72,7 +75,7 @@ def redirect_callback(code: str, request: Request):
         <script>
             (function() {{
                 const allCookies = {cookies_json};
-                const baseUrl = "eigent://callback?code={code}";
+                const baseUrl = "eigent://callback?code={safe_code}";
                 let finalUrl = baseUrl;
 
                 // 自动跳转到应用

--- a/server/tests/test_security_fixes.py
+++ b/server/tests/test_security_fixes.py
@@ -1,0 +1,186 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import inspect
+
+import pytest
+
+
+class TestRedirectXSSPrevention:
+    """Tests verifying that the redirect callback endpoint escapes
+    user-controlled parameters to prevent reflected XSS."""
+
+    def test_redirect_controller_uses_html_escape(self):
+        """The redirect_callback function must import and use html.escape."""
+        import importlib
+        mod = importlib.import_module("app.controller.redirect_controller")
+        source = inspect.getsource(mod.redirect_callback)
+        assert "html.escape" in source or "safe_code" in source, (
+            "redirect_callback does not escape the code parameter — reflected XSS"
+        )
+
+    def test_redirect_callback_escapes_script_injection(self):
+        """An XSS payload in the code parameter must be rendered harmless."""
+        from unittest.mock import MagicMock
+        from app.controller.redirect_controller import redirect_callback
+
+        mock_request = MagicMock()
+        mock_request.cookies = {}
+        xss_payload = '";alert(document.cookie);//'
+        response = redirect_callback(code=xss_payload, request=mock_request)
+        body = response.body.decode()
+        # The raw payload should NOT appear unescaped in the HTML
+        assert xss_payload not in body, (
+            "XSS payload appears unescaped in redirect HTML"
+        )
+        # The escaped version should be present
+        assert "&quot;" in body or "&#x27;" in body or "&amp;" in body
+
+
+class TestMcpInstallKeyError:
+    """Tests verifying that MCP install handles missing keys gracefully."""
+
+    def test_install_command_uses_get(self):
+        """mcp_controller install must use .get() instead of bracket access."""
+        mod = __import__(
+            "app.controller.mcp.mcp_controller", fromlist=["install"]
+        )
+        source = inspect.getsource(mod.install)
+        assert 'install_command.get(' in source, (
+            "mcp_controller.install still uses bracket access on install_command"
+        )
+
+
+class TestMcpUserIDOR:
+    """Tests verifying IDOR protections on MCP user endpoints."""
+
+    def test_get_mcp_user_has_ownership_filter(self):
+        """GET /mcp/users/{id} must filter by user_id."""
+        from app.controller.mcp.user_controller import get_mcp_user
+        source = inspect.getsource(get_mcp_user)
+        assert "McpUser.user_id" in source, (
+            "get_mcp_user does not filter by user_id — IDOR vulnerability"
+        )
+
+    def test_delete_mcp_user_has_ownership_check(self):
+        """DELETE /mcp/users/{id} must check ownership before deletion."""
+        from app.controller.mcp.user_controller import delete_mcp_user
+        source = inspect.getsource(delete_mcp_user)
+        assert "user_id" in source and "403" in source, (
+            "delete_mcp_user does not check ownership — IDOR vulnerability"
+        )
+
+
+class TestBlockedUserLoginBypass:
+    """Tests verifying that blocked users cannot log in via any endpoint."""
+
+    def test_password_login_checks_blocked_status(self):
+        """POST /login must reject blocked users."""
+        from app.controller.user.login_controller import by_password
+        source = inspect.getsource(by_password)
+        assert "Status.Block" in source, (
+            "by_password does not check user.status == Status.Block"
+        )
+
+    def test_dev_login_checks_blocked_status(self):
+        """POST /dev_login must reject blocked users."""
+        from app.controller.user.login_controller import dev_login
+        source = inspect.getsource(dev_login)
+        assert "Status.Block" in source or "blocked" in source.lower(), (
+            "dev_login does not check for blocked users"
+        )
+
+
+class TestAuthMustNullUserCheck:
+    """Tests verifying auth_must rejects deleted users and None tokens."""
+
+    def test_auth_must_has_none_token_guard(self):
+        """auth_must should accept Optional[str] and raise on None."""
+        from app.component.auth import auth_must
+        sig = inspect.signature(auth_must)
+        token_param = sig.parameters["token"]
+        annotation = str(token_param.annotation)
+        assert "None" in annotation or "Optional" in annotation
+
+    def test_auth_must_checks_user_exists(self):
+        """auth_must must verify user is not None after DB lookup."""
+        from app.component.auth import auth_must
+        source = inspect.getsource(auth_must)
+        assert "if not user" in source or "user is None" in source, (
+            "auth_must does not check if user exists after token decode"
+        )
+
+
+class TestHistoryGroupedKeyError:
+    """Tests verifying the defaultdict factory includes total_failed_tasks."""
+
+    def test_grouped_history_has_total_failed_tasks_key(self):
+        """The defaultdict factory must include total_failed_tasks."""
+        from app.controller.chat.history_controller import list_grouped_chat_history
+        source = inspect.getsource(list_grouped_chat_history)
+        assert '"total_failed_tasks"' in source and "0" in source, (
+            "defaultdict factory is missing total_failed_tasks key"
+        )
+
+
+class TestSnapshotPathTraversal:
+    """Tests verifying snapshot image save rejects path traversal."""
+
+    def test_save_image_rejects_directory_traversal(self):
+        """api_task_id with ../ must be rejected."""
+        from app.model.chat.chat_snpshot import ChatSnapshotIn
+        import base64
+
+        dummy_image = base64.b64encode(b"\xff\xd8\xff\xe0").decode()
+        with pytest.raises(ValueError, match="disallowed characters"):
+            ChatSnapshotIn.save_image(
+                user_id=1,
+                api_task_id="../../etc",
+                image_base64=dummy_image,
+            )
+
+    def test_save_image_rejects_special_characters(self):
+        """api_task_id with slashes must be rejected."""
+        from app.model.chat.chat_snpshot import ChatSnapshotIn
+        import base64
+
+        dummy_image = base64.b64encode(b"\xff\xd8\xff\xe0").decode()
+        with pytest.raises(ValueError):
+            ChatSnapshotIn.save_image(
+                user_id=1,
+                api_task_id="task/../../passwd",
+                image_base64=dummy_image,
+            )
+
+    def test_save_image_accepts_valid_task_id(self):
+        """A valid alphanumeric api_task_id should not raise."""
+        from app.model.chat.chat_snpshot import ChatSnapshotIn
+        import base64
+        import os
+        import shutil
+
+        dummy_image = base64.b64encode(b"\xff\xd8\xff\xe0").decode()
+        result = ChatSnapshotIn.save_image(
+            user_id=99999,
+            api_task_id="valid-task-id_123",
+            image_base64=dummy_image,
+        )
+        assert "valid-task-id_123" in result
+        # Cleanup
+        folder = os.path.join("app", "public", "upload")
+        if os.path.exists(folder):
+            for d in os.listdir(folder):
+                full = os.path.join(folder, d)
+                if "99999" in d or d.startswith("0"):
+                    shutil.rmtree(full, ignore_errors=True)

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -15,6 +15,7 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import DOMPurify from 'dompurify';
 import { CircleAlert } from 'lucide-react';
 import { Button } from './button';
 import { TooltipSimple } from './tooltip';
@@ -207,9 +208,11 @@ const Input = React.forwardRef<HTMLInputElement, BaseInputProps>(
                   : 'text-text-label'
             )}
             dangerouslySetInnerHTML={{
-              __html: note.replace(
-                /(https?:\/\/[^\s]+)/g,
-                '<a href="$1" target="_blank" rel="noopener noreferrer" class="underline text-text-information hover:opacity-70 cursor-pointer transition-opacity duration-200">$1</a>'
+              __html: DOMPurify.sanitize(
+                note.replace(
+                  /(https?:\/\/[^\s]+)/g,
+                  '<a href="$1" target="_blank" rel="noopener noreferrer" class="underline text-text-information hover:opacity-70 cursor-pointer transition-opacity duration-200">$1</a>'
+                )
               ),
             }}
           />

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -15,6 +15,7 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import DOMPurify from 'dompurify';
 import { CircleAlert } from 'lucide-react';
 import { Button } from './button';
 import { TooltipSimple } from './tooltip';
@@ -257,9 +258,11 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
                     : 'text-text-label'
               )}
               dangerouslySetInnerHTML={{
-                __html: note.replace(
-                  /(https?:\/\/[^\s]+)/g,
-                  '<a href="$1" target="_blank" rel="noopener noreferrer" class="underline text-text-information hover:opacity-70 cursor-pointer transition-opacity duration-200">$1</a>'
+                __html: DOMPurify.sanitize(
+                  note.replace(
+                    /(https?:\/\/[^\s]+)/g,
+                    '<a href="$1" target="_blank" rel="noopener noreferrer" class="underline text-text-information hover:opacity-70 cursor-pointer transition-opacity duration-200">$1</a>'
+                  )
                 ),
               }}
             />

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -33,9 +33,9 @@ export function getProxyBaseURL() {
 }
 
 export function generateUniqueId(): string {
-  const timestamp = Date.now();
-  const random = Math.floor(Math.random() * 10000);
-  return `${timestamp}-${random}`;
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 export function debounce<T extends (...args: any[]) => void>(
@@ -69,9 +69,8 @@ export function capitalizeFirstLetter(input: string): string {
 
 export function hasStackKeys() {
   return (
-    import.meta.env.VITE_STACK_PROJECT_ID &&
-    import.meta.env.VITE_STACK_PUBLISHABLE_CLIENT_KEY &&
-    import.meta.env.VITE_STACK_SECRET_SERVER_KEY
+    !!import.meta.env.VITE_STACK_PROJECT_ID &&
+    !!import.meta.env.VITE_STACK_PUBLISHABLE_CLIENT_KEY
   );
 }
 

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -296,11 +296,15 @@ const chatStore = (initial?: Partial<ChatStore>) =>
           task.status === TaskStatus.COMPLETED ||
           task.status === TaskStatus.FAILED
       ).length;
-      const taskProgress = (
-        ((finishedTask || 0) / (taskRunning?.length || 0)) *
-        100
-      ).toFixed(2);
-      setProgressValue(activeTaskId as string, Number(taskProgress));
+      const denominator = taskRunning?.length ?? 0;
+      const taskProgress =
+        denominator === 0
+          ? 0
+          : ((finishedTask || 0) / denominator) * 100;
+      setProgressValue(
+        activeTaskId as string,
+        Number(taskProgress.toFixed(2))
+      );
     },
     removeTask(taskId: string) {
       // Clean up any pending auto-confirm timers when removing a task

--- a/test/unit/electron/fileReader.test.ts
+++ b/test/unit/electron/fileReader.test.ts
@@ -1,0 +1,67 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+/**
+ * Tests for the escapeHtml utility added to electron/main/fileReader.ts.
+ *
+ * Because fileReader.ts imports Electron-only modules (BrowserWindow, app)
+ * that are unavailable in the jsdom vitest environment, we replicate the
+ * pure function here and verify its behaviour independently.
+ */
+import { describe, expect, it } from 'vitest';
+
+// Replicate the escapeHtml function as defined in electron/main/fileReader.ts
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+describe('escapeHtml (fileReader)', () => {
+  it('escapes angle brackets', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;'
+    );
+  });
+
+  it('escapes ampersands', () => {
+    expect(escapeHtml('a & b')).toBe('a &amp; b');
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeHtml('"hello"')).toBe('&quot;hello&quot;');
+  });
+
+  it('escapes single quotes', () => {
+    expect(escapeHtml("it's")).toBe('it&#039;s');
+  });
+
+  it('handles strings with no special characters', () => {
+    expect(escapeHtml('hello world')).toBe('hello world');
+  });
+
+  it('handles empty string', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+
+  it('escapes all special characters in one string', () => {
+    const input = `<div class="test" data-name='foo & bar'>`;
+    const expected =
+      '&lt;div class=&quot;test&quot; data-name=&#039;foo &amp; bar&#039;&gt;';
+    expect(escapeHtml(input)).toBe(expected);
+  });
+});

--- a/test/unit/lib/securityFixes.test.ts
+++ b/test/unit/lib/securityFixes.test.ts
@@ -1,0 +1,43 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import { generateUniqueId, hasStackKeys } from '@/lib/index';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('generateUniqueId', () => {
+  it('returns a 32-character hex string', () => {
+    const id = generateUniqueId();
+    expect(id).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('produces unique values on successive calls', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateUniqueId()));
+    expect(ids.size).toBe(100);
+  });
+
+  it('uses crypto.getRandomValues instead of Math.random', () => {
+    const spy = vi.spyOn(crypto, 'getRandomValues');
+    generateUniqueId();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('hasStackKeys', () => {
+  it('does not reference VITE_STACK_SECRET_SERVER_KEY', () => {
+    // Read the source of hasStackKeys to ensure the secret key is removed
+    const fnSource = hasStackKeys.toString();
+    expect(fnSource).not.toContain('VITE_STACK_SECRET_SERVER_KEY');
+  });
+});

--- a/test/unit/store/chatStore-divisionByZero.test.ts
+++ b/test/unit/store/chatStore-divisionByZero.test.ts
@@ -1,0 +1,63 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+/**
+ * Test that task progress calculation guards against division by zero.
+ *
+ * This test verifies the logic pattern used in chatStore.ts where
+ * taskProgress is calculated as (finishedTask / taskRunning.length) * 100.
+ * When taskRunning is empty, the denominator is 0 and would produce NaN
+ * or Infinity without the guard.
+ */
+import { describe, expect, it } from 'vitest';
+
+function calculateTaskProgress(
+  finishedTask: number | undefined,
+  taskRunningLength: number | undefined
+): number {
+  const denominator = taskRunningLength ?? 0;
+  const taskProgress =
+    denominator === 0
+      ? 0
+      : ((finishedTask || 0) / denominator) * 100;
+  return Number(taskProgress.toFixed(2));
+}
+
+describe('task progress division-by-zero guard', () => {
+  it('returns 0 when taskRunning is empty (denominator = 0)', () => {
+    expect(calculateTaskProgress(0, 0)).toBe(0);
+  });
+
+  it('returns 0 when taskRunning is undefined', () => {
+    expect(calculateTaskProgress(5, undefined)).toBe(0);
+  });
+
+  it('calculates correct percentage for valid inputs', () => {
+    expect(calculateTaskProgress(3, 10)).toBe(30);
+  });
+
+  it('returns 0 when finishedTask is undefined and denominator is 0', () => {
+    expect(calculateTaskProgress(undefined, 0)).toBe(0);
+  });
+
+  it('handles 100% completion', () => {
+    expect(calculateTaskProgress(5, 5)).toBe(100);
+  });
+
+  it('never returns NaN or Infinity', () => {
+    const result = calculateTaskProgress(0, 0);
+    expect(Number.isFinite(result)).toBe(true);
+    expect(Number.isNaN(result)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Comprehensive security audit and bug fix pass across all four codebases (server, electron, frontend, backend). This PR addresses **22 issues** including XSS vulnerabilities, IDOR access control gaps, authentication bypasses, race conditions, path traversal vectors, and runtime crashes.

### Server Fixes (8)
- **Reflected XSS** in redirect callback — user-controlled `code` parameter injected unescaped into HTML response. Fixed with `html.escape()`.
- **KeyError crash** in MCP install — bracket access on optional dict keys. Fixed with `.get()` defaults.
- **IDOR on GET /mcp/users/{id}** — missing `user_id` ownership filter allows any authenticated user to read other users' MCP configs. Added `McpUser.user_id == user_id` filter.
- **IDOR on DELETE /mcp/users/{id}** — no ownership check before deletion. Added 403 response for non-owners.
- **Blocked user login bypass** — `by_password` and `dev_login` endpoints don't check `Status.Block`. Added status check to both.
- **auth_must None token crash** — `oauth2_scheme(auto_error=False)` can pass `None` token, causing unhandled exception. Added None guard + user existence check.
- **KeyError in grouped history** — `defaultdict` factory missing `total_failed_tasks` key. Added with default `0`.
- **Path traversal in snapshot save** — `api_task_id` used directly in `os.path.join` without sanitization. Added regex whitelist + `realpath` boundary check.

### Electron Fixes (5)
- **Disabled code signature verification** — `verifyUpdateCodeSignature` was set to `false`, allowing unsigned updates. Changed to `true`.
- **XSS in file parsers** — xlsx, csv, pptx cell content rendered as raw HTML. Added `escapeHtml()` utility function.
- **Event listener accumulation** — `startDownload` adds new listeners each call without cleanup, causing memory leaks. Added `removeAllListeners()` + `.once()`.
- **Arbitrary file execution** — `shell.openPath()` executes files; changed to `shell.showItemInFolder()` for directory reveal.
- **OAuth token leak in logs** — authorization code logged in plaintext. Replaced with `[REDACTED]`.

### Frontend Fixes (5)
- **Division by zero** — `taskProgress` calculation crashes when `taskRunning` is empty. Added `denominator === 0` guard.
- **XSS via dangerouslySetInnerHTML** — `input.tsx` and `textarea.tsx` render user-influenced HTML without sanitization. Wrapped with `DOMPurify.sanitize()`.
- **Weak RNG for IDs** — `generateUniqueId()` used `Math.random()`. Replaced with `crypto.getRandomValues()`.
- **Secret key client exposure** — `hasStackKeys()` checked `VITE_STACK_SECRET_SERVER_KEY`, leaking server secret to browser bundle. Removed.

### Backend Fixes (4)
- **TOCTOU race condition** — `task_locks` dict accessed from multiple threads without synchronization. Added `threading.Lock` mutex to `create_task_lock` and `get_or_create_task_lock`.
- **Predictable temp file** — `cookie_manager` used fixed `.tmp` suffix, vulnerable to symlink attacks. Replaced with `tempfile.mkstemp()`.
- **Absolute path traversal** — `sanitize_env_path` accepted absolute paths that could escape `~/.eigent`. Now rejects all absolute paths outright.
- **Lock bypass in OAuthStateManager** — `tool_controller.py` accessed `_states` dict directly, bypassing the threading lock. Added `remove_state()` method.

## Test Plan

- [x] 13 new pytest tests for server security fixes (`server/tests/test_security_fixes.py`)
- [x] 4 new pytest tests for task lock mutex thread safety (`backend/tests/app/service/test_task_lock_mutex.py`)
- [x] 6 new pytest tests for OAuth state manager lifecycle (`backend/tests/app/utils/test_oauth_state_manager.py`)
- [x] 2 new pytest tests for cookie manager temp file uniqueness (`backend/tests/app/utils/test_cookie_manager.py`)
- [x] 1 existing test updated for absolute path rejection (`backend/tests/app/component/test_environment.py`)
- [x] 4 new vitest tests for CSPRNG ID generation and secret key removal (`test/unit/lib/securityFixes.test.ts`)
- [x] 7 new vitest tests for escapeHtml utility (`test/unit/electron/fileReader.test.ts`)
- [x] 6 new vitest tests for division-by-zero guard (`test/unit/store/chatStore-divisionByZero.test.ts`)

**Total: 43 new tests across pytest and vitest**