### PR TITLE
fix: align workspace component export names

### DIFF
--- a/src/components/BrowserAgentWorkspace/index.tsx
+++ b/src/components/BrowserAgentWorkspace/index.tsx
@@ -31,7 +31,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TaskState } from '../TaskState';
 import { Button } from '../ui/button';
 
-export default function Home() {
+export default function BrowserAgentWorkspace() {
   //Get Chatstore for the active project's task
   const { chatStore, projectStore } = useChatStoreAdapter();
 

--- a/src/components/TerminalAgentWorkspace/index.tsx
+++ b/src/components/TerminalAgentWorkspace/index.tsx
@@ -32,7 +32,7 @@ import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '../ui/button';
 
-export default function TerminalAgentWrokSpace() {
+export default function TerminalAgentWorkspace() {
   //Get Chatstore for the active project's task
   const { chatStore, projectStore } = useChatStoreAdapter();
   const { t } = useTranslation();


### PR DESCRIPTION
align workspace component export names