### PR TITLE
enhance: browser_external_cdp PR696

### DIFF
--- a/src/pages/Dashboard/Browser.tsx
+++ b/src/pages/Dashboard/Browser.tsx
@@ -233,11 +233,20 @@ export default function Browser() {
 
       // Port is alive — add to CDP pool
       if (window.electronAPI?.addCdpBrowser) {
-        await window.electronAPI.addCdpBrowser(
+        const addResult = await window.electronAPI.addCdpBrowser(
           portNum,
           true,
           `External Browser (${portNum})`
         );
+        if (!addResult?.success) {
+          setConnectError(
+            addResult?.error || t('layout.failed-to-add-browser')
+          );
+          return;
+        }
+      } else {
+        setConnectError(t('layout.failed-to-add-browser'));
+        return;
       }
 
       toast.success(t('layout.connected-browser', { port: portNum }));


### PR DESCRIPTION
 two fixs:

Health-check now probes a snapshot of the pool and removes dead entries by id instead of array index, this avoids race issues when IPC add/remove operations happen while health-check is awaiting network probes

The UI now checks the result of addCdpBrowser before showing success, if adding to the pool fails, it shows the error instead of incorrectly showing a success state