### PR TITLE
fix: validate browser process before reporting launch success

### DIFF
--- a/src/pages/Browser/Cookies.tsx
+++ b/src/pages/Browser/Cookies.tsx
@@ -89,7 +89,7 @@ export default function Cookies() {
       );
 
       const response = await fetchPost('/browser/login');
-      if (response) {
+      if (response?.success) {
         toast.success('Browser opened successfully for login');
         const checkInterval = setInterval(async () => {
           try {
@@ -124,6 +124,8 @@ export default function Cookies() {
             await handleLoadCookies();
           }
         }, 500);
+      } else if (response) {
+        toast.error(response.error || 'Failed to open browser');
       }
     } catch (error: any) {
       toast.error(error?.message || 'Failed to open browser');
@@ -220,26 +222,26 @@ export default function Cookies() {
         confirmVariant="information"
       />
 
-      <div className="px-6 pb-6 pt-8 flex w-full items-center justify-between">
+      <div className="flex w-full items-center justify-between px-6 pb-6 pt-8">
         <div className="text-heading-sm font-bold text-text-heading">
           {t('layout.browser-cookie-management')}
         </div>
       </div>
 
-      <div className="gap-4 flex flex-col">
-        <div className="rounded-xl border-border-disabled bg-surface-secondary p-6 relative flex w-full flex-col border">
-          <div className="right-6 top-6 absolute">
+      <div className="flex flex-col gap-4">
+        <div className="relative flex w-full flex-col rounded-xl border border-border-disabled bg-surface-secondary p-6">
+          <div className="absolute right-6 top-6">
             <Button
               variant="information"
               size="xs"
               onClick={handleRestartApp}
-              className="gap-0 ease-in-out justify-center overflow-hidden rounded-full transition-all duration-300"
+              className="justify-center gap-0 overflow-hidden rounded-full transition-all duration-300 ease-in-out"
             >
               <RefreshCw className="flex-shrink-0" />
               <span
-                className={`ease-in-out overflow-hidden transition-all duration-300 ${
+                className={`overflow-hidden transition-all duration-300 ease-in-out ${
                   hasUnsavedChanges
-                    ? 'pl-2 max-w-[150px] opacity-100'
+                    ? 'max-w-[150px] pl-2 opacity-100'
                     : 'ml-0 max-w-0 opacity-0'
                 }`}
               >
@@ -247,12 +249,12 @@ export default function Cookies() {
               </span>
             </Button>
           </div>
-          <div className="text-body-sm text-text-label max-w-[600px]">
+          <div className="max-w-[600px] text-body-sm text-text-label">
             {t('layout.browser-cookies-description')}
           </div>
-          <div className="mt-4 gap-3 border-border-secondary pt-3 flex w-full flex-col border-[0.5px] border-x-0 border-b-0 border-solid">
-            <div className="py-2 flex flex-row items-center justify-between">
-              <div className="gap-2 flex flex-row items-center justify-start">
+          <div className="mt-4 flex w-full flex-col gap-3 border-[0.5px] border-x-0 border-b-0 border-solid border-border-secondary pt-3">
+            <div className="flex flex-row items-center justify-between py-2">
+              <div className="flex flex-row items-center justify-start gap-2">
                 <div className="text-body-base font-bold text-text-body">
                   {t('layout.cookie-domains')}
                 </div>
@@ -263,14 +265,14 @@ export default function Cookies() {
                 )}
               </div>
 
-              <div className="gap-2 flex items-center">
+              <div className="flex items-center gap-2">
                 {cookieDomains.length > 0 && (
                   <Button
                     variant="ghost"
                     size="sm"
                     onClick={handleDeleteAll}
                     disabled={deletingAll}
-                    className="!text-text-cuation uppercase"
+                    className="uppercase !text-text-cuation"
                   >
                     {deletingAll
                       ? t('layout.deleting')
@@ -302,14 +304,14 @@ export default function Cookies() {
             </div>
 
             {cookieDomains.length > 0 ? (
-              <div className="gap-2 flex flex-col">
+              <div className="flex flex-col gap-2">
                 {groupDomainsByMain(cookieDomains).map((group, index) => (
                   <div
                     key={index}
-                    className="rounded-xl border-border-disabled bg-surface-tertiary px-4 py-2 flex items-center justify-between border-solid"
+                    className="flex items-center justify-between rounded-xl border-solid border-border-disabled bg-surface-tertiary px-4 py-2"
                   >
                     <div className="flex w-full flex-col items-start justify-start">
-                      <span className="text-body-sm font-bold text-text-body truncate">
+                      <span className="truncate text-body-sm font-bold text-text-body">
                         {group.mainDomain}
                       </span>
                       <span className="mt-1 text-label-xs text-text-label">
@@ -335,12 +337,12 @@ export default function Cookies() {
                 ))}
               </div>
             ) : (
-              <div className="px-4 py-8 flex flex-col items-center justify-center">
+              <div className="flex flex-col items-center justify-center px-4 py-8">
                 <Cookie className="mb-4 h-12 w-12 text-icon-secondary opacity-50" />
-                <div className="text-body-base font-bold text-text-label text-center">
+                <div className="text-body-base text-center font-bold text-text-label">
                   {t('layout.no-cookies-saved-yet')}
                 </div>
-                <p className="text-label-xs font-medium text-text-label text-center">
+                <p className="text-center text-label-xs font-medium text-text-label">
                   {t('layout.no-cookies-saved-yet-description')}
                 </p>
               </div>
@@ -348,7 +350,7 @@ export default function Cookies() {
           </div>
         </div>
 
-        <div className="text-label-xs text-text-label w-full text-center">
+        <div className="w-full text-center text-label-xs text-text-label">
           For more information, check out our
           <a
             href="https://www.eigent.ai/privacy-policy"


### PR DESCRIPTION
## Summary

Fixes #1377 — `POST /browser/login` returned `"success": true` even when the Electron process exited immediately (e.g., sandbox misconfiguration, `npx` not found). The frontend (`Cookies.tsx`) also polled `GET /browser/status` which didn't exist, causing silent 404s.

### Changes

**Backend (`tool_controller.py`)**
- Add `_login_browser_process` module-level variable to track the subprocess
- Add `_wait_for_cdp_ready()` helper that polls both process liveness and CDP port availability
- Rewrite `open_browser_login()` to validate process state instead of blind `asyncio.sleep(3)`
- Catch `FileNotFoundError` when `npx` is missing on PATH
- Use `run_in_executor` for blocking `readline()` to avoid stalling the event loop
- Add `GET /browser/status` endpoint the frontend already expects

**Frontend (`Cookies.tsx`)**
- Check `response?.success` instead of just `response` (object is truthy even when `success: false`)
- Show `toast.error` with the backend error message on failure

## Before / After Proof

### BEFORE (old behavior on `main`)

The old code blindly awaited `asyncio.sleep(3)` then returned success unconditionally:

```python
# old code (main branch)
await asyncio.sleep(3)
return {
    "success": True,   # <-- always true, even if process crashed
    "pid": process.pid,
    ...
}
```

`GET /browser/status` did not exist → frontend polls got **silent 404 errors**.

### AFTER (this PR)

Tested locally with `uv run uvicorn main:api --port 5001`:

```
=== TEST 1: GET /browser/status (no browser launched yet) ===
{"is_open":false}                                              ✅ New endpoint works

=== TEST 2: POST /browser/login (Electron crashes) ===
{"success":false,"error":"Browser process exited before CDP    ✅ Correctly reports failure
 became ready. Exit code: 1"}

=== TEST 3: GET /browser/status (after failed launch) ===
{"is_open":false}                                              ✅ Clean state after crash

=== TEST 4: POST /browser/login (retry) ===
{"success":false,"error":"Browser process exited before CDP    ✅ Consistent on retry
 became ready. Exit code: 1"}
```

**Backend logs** showing the process crash is detected and reported:

```
13:44:52 - tool_controller - INFO - [PROFILE USER LOGIN] Launching Electron browser with CDP on port 9223
13:44:52 - tool_controller - INFO - [ELECTRON OUTPUT] npm warn Unknown project config "shamefully-hoist"...
13:44:52 - tool_controller - INFO - [ELECTRON OUTPUT] [721291:...] FATAL:setuid_sandbox_host.cc(163)
  The SUID sandbox helper binary was found, but is not configured correctly...
13:44:53 - tool_controller - INFO - [ELECTRON OUTPUT] electron exited with signal SIGTRAP
13:44:53 - tool_controller - ERROR - [PROFILE USER LOGIN] Electron process exited with code: 1
```

## Test plan

- [x] `cd backend && uv run pytest` — 402 passed, 11 skipped
- [x] TypeScript type-check — no new errors (pre-existing ones in `skillsStore.ts` only)
- [x] Manual: `POST /browser/login` returns `success: false` when Electron is unavailable
- [x] Manual: `GET /browser/status` returns `{"is_open": false}` when no browser is running
- [x] Manual: Retry after failure returns consistent results
- [ ] Manual: With working Electron, `success: true` only after CDP port opens or process is confirmed alive