### PR TITLE
fix wrapper version for npm

### DIFF
--- a/electron/main/utils/process.ts
+++ b/electron/main/utils/process.ts
@@ -943,7 +943,8 @@ export function ensureNpmWrappersForBrowserToolkit(
   const eigentBinDir = path.join(os.homedir(), '.eigent', 'bin');
   fs.mkdirSync(eigentBinDir, { recursive: true });
 
-  const wrapperVersion = '1';
+  // Store wrapper target so wrappers are recreated when venv path changes (e.g. app upgrade)
+  const wrapperVersion = `wrapper:${pythonPath}`;
   const versionFile = path.join(eigentBinDir, '.npm_wrapper_version');
   const storedVersion = fs.existsSync(versionFile)
     ? fs.readFileSync(versionFile, 'utf-8').trim()
@@ -958,10 +959,14 @@ export function ensureNpmWrappersForBrowserToolkit(
     process.platform === 'win32' ? 'npx.cmd' : 'npx'
   );
 
+  // Recreate wrappers when: version changed, wrappers missing, or existing shebang points to wrong Python
   const needsUpdate =
     storedVersion !== wrapperVersion ||
     !fs.existsSync(npmWrapper) ||
-    !fs.existsSync(npxWrapper);
+    !fs.existsSync(npxWrapper) ||
+    (process.platform !== 'win32' &&
+      fs.existsSync(npmWrapper) &&
+      !fs.readFileSync(npmWrapper, 'utf-8').startsWith(`#!${pythonPath}`));
 
   if (needsUpdate) {
     try {


### PR DESCRIPTION
### Related Issue

Store wrapper target (pythonPath) in version file instead of static "1".
When users upgrade (e.g. 0.0.85 → 0.0.86), venv path changes but
wrappers still pointed to old Python. Now we detect path change and
recreate wrappers automatically.

### Description

### Testing Evidence (REQUIRED)

- [x] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [x] No frontend/UI changes in this PR.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)

<img width="3020" height="1892" alt="image" src="https://github.com/user-attachments/assets/2daf5f02-cc42-49e1-8f87-41c5a52ea3ae" />
<img width="411" height="77" alt="CleanShot 2026-03-06 at 01 55 39" src="https://github.com/user-attachments/assets/2375e4fe-50ce-4a28-a386-8ee6c635692c" />

### after fix

<img width="465" height="79" alt="CleanShot 2026-03-06 at 01 56 32" src="https://github.com/user-attachments/assets/42c70429-5ab4-40d0-90e3-2796c2de6f70" />

