### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Built on [CAMEL-AI][camel-site]'s acclaimed open-source project, our system intr
 - ✅ **Zero Setup** - No technical configuration required
 - ✅ **Multi-Agent Coordination** - Handle complex multi-agent workflows
 - ✅ **Enterprise Feature** - SSO/Access control
-- ✅ **Local Deploymen**t
+- ✅ **Local Deployment**
 - ✅ **Open Source**
 - ✅ **Custom Model Support**
 - ✅ **MCP Integration**
@@ -70,7 +70,7 @@ Built on [CAMEL-AI][camel-site]'s acclaimed open-source project, our system intr
 - [🗺️ Roadmap - Open Source Cowork](#%EF%B8%8F-roadmap---open-source-Cowork)
 - [📖 Contributing](#-contributing)
   - [Main Contributors](#main-contributors)
-  - [Distinguished amabssador](#distinguished-amabssador)
+  - [Distinguished ambassador](#distinguished-ambassador)
 - [Ecosystem](#ecosystem)
 - [📄 Open Source License](#-open-source-license)
 - [🌐 Community & contact](#-community--contact)


### PR DESCRIPTION
Fix typos in README:

1. Fix bold formatting for "Local Deployment" - the "t" was outside the bold markers
2. Fix spelling typo "amabssador" to "ambassador"