### PR TITLE
 fix: use WithinWindow blending mode for macOS vibrancy effect

### DIFF
--- a/electron/main/native/macos-window.ts
+++ b/electron/main/native/macos-window.ts
@@ -129,7 +129,7 @@ if (os.platform() === 'darwin') {
           objc_msgSend_long(
             visualEffectView,
             selSetBlendingMode,
-            NSVisualEffectBlendingMode.BehindWindow
+            NSVisualEffectBlendingMode.WithinWindow
           );
           objc_msgSend_long(visualEffectView, selSetState, 1);
           objc_msgSend_long(visualEffectView, selSetAutoresizingMask, 18);


### PR DESCRIPTION
### Description

 Fix white screen issue caused by incorrect `NSVisualEffectBlendingMode` in macOS native vibrancy implementation (#1110)

### Testing Evidence

- [x] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
