### PR TITLE
fix(backend): default max_tokens for Anthropic model validation

### DIFF
--- a/backend/app/agent/agent_model.py
+++ b/backend/app/agent/agent_model.py
@@ -136,11 +136,11 @@ def agent_model(
             )
             model_platform_enum = None
 
-    if (
-        effective_config["model_platform"].lower() == "anthropic"
-        and model_config.get("cache_control") is None
-    ):
-        model_config["cache_control"] = "5m"
+    if effective_config["model_platform"].lower() == "anthropic":
+        if model_config.get("cache_control") is None:
+            model_config["cache_control"] = "5m"
+        if model_config.get("max_tokens") is None:
+            model_config["max_tokens"] = 64000
 
     model = ModelFactory.create(
         model_platform=effective_config["model_platform"],

--- a/backend/app/component/model_validation.py
+++ b/backend/app/component/model_validation.py
@@ -228,10 +228,9 @@ def create_agent(
     if platform is None:
         raise ValueError(f"Invalid model_platform: {model_platform}")
     if str(platform).lower() == "anthropic":
-        model_config_dict = {
-            **(model_config_dict or {}),
-            "max_tokens": 4096,  # 4096 is enough for validation
-        }
+        model_config_dict = dict(model_config_dict or {})
+        if model_config_dict.get("max_tokens") is None:
+            model_config_dict["max_tokens"] = 4096
     model = ModelFactory.create(
         model_platform=platform,
         model_type=mtype,
@@ -332,10 +331,9 @@ def validate_model_with_details(
             extra={"platform": model_platform, "model_type": model_type},
         )
         if str(model_platform).lower() == "anthropic":
-            model_config_dict = {
-                **(model_config_dict or {}),
-                "max_tokens": 4096,
-            }
+            model_config_dict = dict(model_config_dict or {})
+            if model_config_dict.get("max_tokens") is None:
+                model_config_dict["max_tokens"] = 4096
         model = ModelFactory.create(
             model_platform=model_platform,
             model_type=model_type,

--- a/backend/app/component/model_validation.py
+++ b/backend/app/component/model_validation.py
@@ -21,61 +21,9 @@ from camel.models import ModelFactory, ModelProcessingError
 
 logger = logging.getLogger("model_validation")
 
-# Anthropic Messages API requires a positive integer max_tokens on every request.
-# BYOK UI does not expose this field, so validation must supply a default.
-_DEFAULT_ANTHROPIC_VALIDATION_MAX_TOKENS = 4096
 
 # Expected result from tool execution for validation
 EXPECTED_TOOL_RESULT = "Tool execution completed successfully for https://www.camel-ai.org, Website Content: Welcome to CAMEL AI!"
-
-
-def _to_positive_int_max_tokens(value: object) -> int | None:
-    """Parse max_tokens from UI/extra_params; return None if unusable."""
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value if value > 0 else None
-    if isinstance(value, float):
-        iv = int(value)
-        return iv if iv > 0 else None
-    if isinstance(value, str):
-        s = value.strip()
-        if not s:
-            return None
-        try:
-            iv = int(s)
-            return iv if iv > 0 else None
-        except ValueError:
-            return None
-    return None
-
-
-def _ensure_model_config_for_platform(
-    model_platform: str,
-    model_config_dict: dict | None,
-    kwargs: dict[str, object],
-) -> tuple[dict | None, dict[str, object]]:
-    """Merge config for ModelFactory.create; Anthropic always gets valid max_tokens."""
-    cfg = dict(model_config_dict) if model_config_dict else {}
-    kw = dict(kwargs)
-
-    if str(model_platform).lower() != "anthropic":
-        return (cfg or None), kw
-
-    raw = cfg.get("max_tokens", kw.get("max_tokens"))
-    resolved = _to_positive_int_max_tokens(raw)
-    if resolved is None:
-        resolved = _DEFAULT_ANTHROPIC_VALIDATION_MAX_TOKENS
-        logger.debug(
-            "Anthropic model validation: using default max_tokens=%s",
-            resolved,
-            extra={"model_platform": model_platform},
-        )
-    cfg["max_tokens"] = resolved
-    kw.pop("max_tokens", None)
-    return cfg, kw
 
 
 class ValidationStage(str, Enum):
@@ -280,17 +228,19 @@ def create_agent(
         raise ValueError(f"Invalid model_type: {model_type}")
     if platform is None:
         raise ValueError(f"Invalid model_platform: {model_platform}")
-    cfg, kw = _ensure_model_config_for_platform(
-        platform, model_config_dict, kwargs
-    )
+    if str(platform).lower() == "anthropic":
+        model_config_dict = {
+            **(model_config_dict or {}),
+            "max_tokens": 4096,  # 4096 is enough for validation
+        }
     model = ModelFactory.create(
         model_platform=platform,
         model_type=mtype,
         api_key=api_key,
         url=url,
         timeout=60,  # 1 minute for validation
-        model_config_dict=cfg,
-        **kw,
+        model_config_dict=model_config_dict,
+        **kwargs,
     )
     agent = ChatAgent(
         system_message="You are a helpful assistant that must use the tool get_website_content to get the content of a website.",
@@ -382,17 +332,19 @@ def validate_model_with_details(
             "Creating model",
             extra={"platform": model_platform, "model_type": model_type},
         )
-        cfg, kw = _ensure_model_config_for_platform(
-            model_platform, model_config_dict, kwargs
-        )
+        if str(model_platform).lower() == "anthropic":
+            model_config_dict = {
+                **(model_config_dict or {}),
+                "max_tokens": 4096,
+            }
         model = ModelFactory.create(
             model_platform=model_platform,
             model_type=model_type,
             api_key=api_key,
             url=url,
             timeout=60,  # 1 minute for validation
-            model_config_dict=cfg,
-            **kw,
+            model_config_dict=model_config_dict,
+            **kwargs,
         )
         result.validation_stages[ValidationStage.MODEL_CREATION] = True
         result.successful_stages.append(ValidationStage.MODEL_CREATION)

--- a/backend/app/component/model_validation.py
+++ b/backend/app/component/model_validation.py
@@ -21,8 +21,61 @@ from camel.models import ModelFactory, ModelProcessingError
 
 logger = logging.getLogger("model_validation")
 
+# Anthropic Messages API requires a positive integer max_tokens on every request.
+# BYOK UI does not expose this field, so validation must supply a default.
+_DEFAULT_ANTHROPIC_VALIDATION_MAX_TOKENS = 4096
+
 # Expected result from tool execution for validation
 EXPECTED_TOOL_RESULT = "Tool execution completed successfully for https://www.camel-ai.org, Website Content: Welcome to CAMEL AI!"
+
+
+def _to_positive_int_max_tokens(value: object) -> int | None:
+    """Parse max_tokens from UI/extra_params; return None if unusable."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        iv = int(value)
+        return iv if iv > 0 else None
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        try:
+            iv = int(s)
+            return iv if iv > 0 else None
+        except ValueError:
+            return None
+    return None
+
+
+def _ensure_model_config_for_platform(
+    model_platform: str,
+    model_config_dict: dict | None,
+    kwargs: dict[str, object],
+) -> tuple[dict | None, dict[str, object]]:
+    """Merge config for ModelFactory.create; Anthropic always gets valid max_tokens."""
+    cfg = dict(model_config_dict) if model_config_dict else {}
+    kw = dict(kwargs)
+
+    if str(model_platform).lower() != "anthropic":
+        return (cfg or None), kw
+
+    raw = cfg.get("max_tokens", kw.get("max_tokens"))
+    resolved = _to_positive_int_max_tokens(raw)
+    if resolved is None:
+        resolved = _DEFAULT_ANTHROPIC_VALIDATION_MAX_TOKENS
+        logger.debug(
+            "Anthropic model validation: using default max_tokens=%s",
+            resolved,
+            extra={"model_platform": model_platform},
+        )
+    cfg["max_tokens"] = resolved
+    kw.pop("max_tokens", None)
+    return cfg, kw
 
 
 class ValidationStage(str, Enum):
@@ -227,14 +280,17 @@ def create_agent(
         raise ValueError(f"Invalid model_type: {model_type}")
     if platform is None:
         raise ValueError(f"Invalid model_platform: {model_platform}")
+    cfg, kw = _ensure_model_config_for_platform(
+        platform, model_config_dict, kwargs
+    )
     model = ModelFactory.create(
         model_platform=platform,
         model_type=mtype,
         api_key=api_key,
         url=url,
         timeout=60,  # 1 minute for validation
-        model_config_dict=model_config_dict,
-        **kwargs,
+        model_config_dict=cfg,
+        **kw,
     )
     agent = ChatAgent(
         system_message="You are a helpful assistant that must use the tool get_website_content to get the content of a website.",
@@ -326,14 +382,17 @@ def validate_model_with_details(
             "Creating model",
             extra={"platform": model_platform, "model_type": model_type},
         )
+        cfg, kw = _ensure_model_config_for_platform(
+            model_platform, model_config_dict, kwargs
+        )
         model = ModelFactory.create(
             model_platform=model_platform,
             model_type=model_type,
             api_key=api_key,
             url=url,
             timeout=60,  # 1 minute for validation
-            model_config_dict=model_config_dict,
-            **kwargs,
+            model_config_dict=cfg,
+            **kw,
         )
         result.validation_stages[ValidationStage.MODEL_CREATION] = True
         result.successful_stages.append(ValidationStage.MODEL_CREATION)

--- a/backend/app/component/model_validation.py
+++ b/backend/app/component/model_validation.py
@@ -21,7 +21,6 @@ from camel.models import ModelFactory, ModelProcessingError
 
 logger = logging.getLogger("model_validation")
 
-
 # Expected result from tool execution for validation
 EXPECTED_TOOL_RESULT = "Tool execution completed successfully for https://www.camel-ai.org, Website Content: Welcome to CAMEL AI!"
 

--- a/backend/tests/app/component/test_model_validation.py
+++ b/backend/tests/app/component/test_model_validation.py
@@ -22,7 +22,6 @@ from app.component.model_validation import (
     ValidationErrorType,
     ValidationResult,
     ValidationStage,
-    _ensure_model_config_for_platform,
     categorize_error,
     create_agent,
     format_raw_error,
@@ -389,31 +388,6 @@ def test_validation_success_with_tool_calls(
         result.validation_stages[ValidationStage.TOOL_CALL_EXECUTION] is True
     )
     assert ValidationStage.TOOL_CALL_EXECUTION in result.successful_stages
-
-
-@pytest.mark.unit
-def test_ensure_anthropic_injects_default_max_tokens():
-    cfg, kw = _ensure_model_config_for_platform("anthropic", None, {})
-    assert cfg is not None
-    assert cfg["max_tokens"] == 4096
-    assert "max_tokens" not in kw
-
-
-@pytest.mark.unit
-def test_ensure_anthropic_keeps_valid_user_max_tokens():
-    cfg, kw = _ensure_model_config_for_platform(
-        "anthropic",
-        {"max_tokens": 8192},
-        {},
-    )
-    assert cfg["max_tokens"] == 8192
-
-
-@pytest.mark.unit
-def test_ensure_non_anthropic_unchanged():
-    cfg, kw = _ensure_model_config_for_platform("openai", None, {})
-    assert cfg is None
-    assert kw == {}
 
 
 @pytest.mark.unit

--- a/backend/tests/app/component/test_model_validation.py
+++ b/backend/tests/app/component/test_model_validation.py
@@ -22,6 +22,7 @@ from app.component.model_validation import (
     ValidationErrorType,
     ValidationResult,
     ValidationStage,
+    _ensure_model_config_for_platform,
     categorize_error,
     create_agent,
     format_raw_error,
@@ -388,6 +389,31 @@ def test_validation_success_with_tool_calls(
         result.validation_stages[ValidationStage.TOOL_CALL_EXECUTION] is True
     )
     assert ValidationStage.TOOL_CALL_EXECUTION in result.successful_stages
+
+
+@pytest.mark.unit
+def test_ensure_anthropic_injects_default_max_tokens():
+    cfg, kw = _ensure_model_config_for_platform("anthropic", None, {})
+    assert cfg is not None
+    assert cfg["max_tokens"] == 4096
+    assert "max_tokens" not in kw
+
+
+@pytest.mark.unit
+def test_ensure_anthropic_keeps_valid_user_max_tokens():
+    cfg, kw = _ensure_model_config_for_platform(
+        "anthropic",
+        {"max_tokens": 8192},
+        {},
+    )
+    assert cfg["max_tokens"] == 8192
+
+
+@pytest.mark.unit
+def test_ensure_non_anthropic_unchanged():
+    cfg, kw = _ensure_model_config_for_platform("openai", None, {})
+    assert cfg is None
+    assert kw == {}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Anthropic Messages API requires a positive integer max_tokens. The BYOK form does not expose this field, so validation could send an invalid or missing value and Anthropic returned 400.

Ensure validate_model_with_details and create_agent merge model_config_dict with a default of 4096 for platform anthropic when max_tokens is absent or invalid.

<!-- Thank you for contributing! -->

### Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

Closes #

### Description

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

### Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->
<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->
<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [ ] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
