### PR TITLE
fix: restore replay task elapsed time

### DIFF
--- a/server/app/domains/chat/api/share_controller.py
+++ b/server/app/domains/chat/api/share_controller.py
@@ -70,6 +70,7 @@ async def share_playback(token: str, db_session: Session = Depends(session), del
                 "task_id": s.task_id,
                 "step": s.step,
                 "data": s.data,
+                "timestamp": s.timestamp,
                 "created_at": s.created_at.isoformat() if s.created_at else None,
             }
             yield f"data: {json.dumps(step_data)}\n\n"

--- a/server/app/domains/chat/api/step_controller.py
+++ b/server/app/domains/chat/api/step_controller.py
@@ -83,6 +83,7 @@ async def share_playback(
                 "task_id": s.task_id,
                 "step": s.step,
                 "data": s.data,
+                "timestamp": s.timestamp,
                 "created_at": s.created_at.isoformat() if s.created_at else None,
             }
             yield f"data: {json.dumps(step_data)}\n\n"

--- a/src/components/ChatBox/MessageItem/TaskWorkLogAccordion.tsx
+++ b/src/components/ChatBox/MessageItem/TaskWorkLogAccordion.tsx
@@ -17,7 +17,11 @@ import { agentMap, type WorkflowAgentType } from '@/components/WorkFlow/agents';
 import { MarkDown } from '@/components/WorkFlow/MarkDown';
 import { cn } from '@/lib/utils';
 import type { VanillaChatStore } from '@/store/chatStore';
-import { AgentStep, ChatTaskStatus } from '@/types/constants';
+import {
+  AgentStep,
+  ChatTaskStatus,
+  type ChatTaskStatusType,
+} from '@/types/constants';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import {
@@ -51,8 +55,12 @@ function normalizeToolkitMessage(value: unknown): string {
 }
 
 /** Matches `getFormattedTaskTime` / task timer fields on the chat task. */
-function getTaskElapsedMs(task: { taskTime: number; elapsed: number }): number {
-  if (task.taskTime !== 0) {
+function getTaskElapsedMs(task: {
+  status: ChatTaskStatusType;
+  taskTime: number;
+  elapsed: number;
+}): number {
+  if (task.status === ChatTaskStatus.RUNNING && task.taskTime !== 0) {
     return Math.max(0, Date.now() - task.taskTime + task.elapsed);
   }
   return Math.max(0, task.elapsed);

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -95,6 +95,24 @@ function includesBrowserAgent(workerList: Agent[]): boolean {
   });
 }
 
+function getPersistedStepTimeMs(message: AgentMessage): number | null {
+  if (
+    typeof message.timestamp === 'number' &&
+    Number.isFinite(message.timestamp)
+  ) {
+    return message.timestamp < 1_000_000_000_000
+      ? message.timestamp * 1000
+      : message.timestamp;
+  }
+
+  if (message.created_at) {
+    const parsed = Date.parse(message.created_at);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  return null;
+}
+
 async function resolveCdpBrowsersForRequest(
   shouldEnsureBrowser: boolean
 ): Promise<{
@@ -1036,6 +1054,8 @@ const chatStore = (initial?: Partial<ChatStore>) =>
       let historyId: string | null = projectStore.getHistoryId(project_id);
       let snapshots: any = [];
       let skipFirstConfirm = true;
+      let playbackFirstStepTimeMs: number | null = null;
+      let playbackLastStepTimeMs: number | null = null;
 
       // replay or share request
       if (type) {
@@ -1297,6 +1317,14 @@ const chatStore = (initial?: Partial<ChatStore>) =>
               content: `**System Error**: Failed to parse server message. The connection may be unstable.\n\nPlease try again or contact support if this persists.`,
             });
             return;
+          }
+
+          if (type) {
+            const stepTimeMs = getPersistedStepTimeMs(agentMessages);
+            if (stepTimeMs !== null) {
+              playbackFirstStepTimeMs ??= stepTimeMs;
+              playbackLastStepTimeMs = stepTimeMs;
+            }
           }
 
           if (
@@ -2823,8 +2851,15 @@ const chatStore = (initial?: Partial<ChatStore>) =>
             const task = tasks[currentTaskId];
             let taskTime = task.taskTime;
             let elapsed = task.elapsed;
-            // if task is running, compute current time
-            if (taskTime !== 0) {
+            const playbackElapsed =
+              type &&
+              playbackFirstStepTimeMs !== null &&
+              playbackLastStepTimeMs !== null
+                ? Math.max(0, playbackLastStepTimeMs - playbackFirstStepTimeMs)
+                : null;
+            if (playbackElapsed !== null) {
+              elapsed = playbackElapsed;
+            } else if (taskTime !== 0) {
               const currentTime = Date.now();
               elapsed += currentTime - taskTime;
             }

--- a/src/types/chatbox.d.ts
+++ b/src/types/chatbox.d.ts
@@ -120,6 +120,8 @@ declare global {
   }
 
   interface AgentMessage {
+    timestamp?: number | null;
+    created_at?: string | null;
     step: AgentStepType;
     data: {
       project_id?: string;


### PR DESCRIPTION
Use persisted chat step timestamps during playback so completed task work logs show the original duration instead of restarting or falling back to zero.

Made-with: Cursor

<!-- Thank you for contributing! -->

### Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

Closes #

### Description

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

### Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->
<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->
<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [ ] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
