### PR TITLE
feat: update Minimax cloud model to M2.7

### DIFF
--- a/src/i18n/locales/ar/setting.json
+++ b/src/i18n/locales/ar/setting.json
@@ -182,7 +182,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
 
   "account": "حساب",
   "you-are-currently-signed-in-with": "{{email}} أنت مسجل الدخول حاليًا باستخدام",

--- a/src/i18n/locales/de/setting.json
+++ b/src/i18n/locales/de/setting.json
@@ -242,7 +242,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "Netzwerk-Proxy",
   "network-proxy-description": "Konfigurieren Sie einen Proxy-Server für Netzwerkanfragen. Dies ist nützlich, wenn Sie über einen Proxy auf externe APIs zugreifen müssen.",
   "proxy-placeholder": "http://127.0.0.1:7890",

--- a/src/i18n/locales/en-us/setting.json
+++ b/src/i18n/locales/en-us/setting.json
@@ -210,7 +210,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
 
   "account": "Account",
   "you-are-currently-signed-in-with": "You are currently signed in with {{email}}",

--- a/src/i18n/locales/es/setting.json
+++ b/src/i18n/locales/es/setting.json
@@ -242,7 +242,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "Proxy de red",
   "network-proxy-description": "Configure un servidor proxy para las solicitudes de red. Esto es útil si necesita acceder a APIs externas a través de un proxy.",
   "proxy-placeholder": "http://127.0.0.1:7890",

--- a/src/i18n/locales/fr/setting.json
+++ b/src/i18n/locales/fr/setting.json
@@ -225,7 +225,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "Proxy réseau",
   "network-proxy-description": "Configurez un serveur proxy pour les requêtes réseau. Utile si vous devez accéder à des API externes via un proxy.",
   "proxy-placeholder": "http://127.0.0.1:7890",

--- a/src/i18n/locales/it/setting.json
+++ b/src/i18n/locales/it/setting.json
@@ -242,7 +242,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "Proxy di rete",
   "network-proxy-description": "Configura un server proxy per le richieste di rete. Utile se devi accedere ad API esterne tramite un proxy.",
   "proxy-placeholder": "http://127.0.0.1:7890",

--- a/src/i18n/locales/ja/setting.json
+++ b/src/i18n/locales/ja/setting.json
@@ -243,7 +243,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "ネットワークプロキシ",
   "network-proxy-description": "ネットワークリクエスト用のプロキシサーバーを設定します。プロキシ経由で外部APIにアクセスする必要がある場合に便利です。",
   "proxy-placeholder": "http://127.0.0.1:7890",

--- a/src/i18n/locales/ko/setting.json
+++ b/src/i18n/locales/ko/setting.json
@@ -243,7 +243,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "네트워크 프록시",
   "network-proxy-description": "네트워크 요청을 위한 프록시 서버를 구성합니다. 프록시를 통해 외부 API에 접근해야 하는 경우 유용합니다.",
   "proxy-placeholder": "http://127.0.0.1:7890",

--- a/src/i18n/locales/ru/setting.json
+++ b/src/i18n/locales/ru/setting.json
@@ -242,7 +242,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "Сетевой прокси",
   "network-proxy-description": "Настройте прокси-сервер для сетевых запросов. Это полезно, если вам нужен доступ к внешним API через прокси.",
   "proxy-placeholder": "http://127.0.0.1:7890",

--- a/src/i18n/locales/zh-Hans/setting.json
+++ b/src/i18n/locales/zh-Hans/setting.json
@@ -200,7 +200,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
 
   "preferred-ide": "首选 IDE",
   "preferred-ide-description": "选择打开智能体项目文件夹时使用的应用程序。",

--- a/src/i18n/locales/zh-Hant/setting.json
+++ b/src/i18n/locales/zh-Hant/setting.json
@@ -171,7 +171,7 @@
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
-  "minimax-m2-5-name": "Minimax M2.5",
+  "minimax-m2-7-name": "Minimax M2.7",
 
   "network-proxy": "網路代理",
   "network-proxy-description": "設定網路請求的代理伺服器。如果您需要透過代理存取外部 API，這將非常有用。",

--- a/src/pages/Agents/Models.tsx
+++ b/src/pages/Agents/Models.tsx
@@ -501,7 +501,7 @@ export default function SettingModels() {
     { id: 'claude-opus-4-6', name: 'Claude Opus 4.6' },
     { id: 'claude-opus-4-7', name: 'Claude Opus 4.7' },
     { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
-    { id: 'minimax_m2_5', name: 'Minimax M2.5' },
+    { id: 'minimax_m2_7', name: 'Minimax M2.7' },
   ];
 
   const handleVerify = async (idx: number) => {
@@ -1288,8 +1288,8 @@ export default function SettingModels() {
                   <SelectItem value="deepseek-v4-pro">
                     {t('setting.deepseek-v4-pro-name')}
                   </SelectItem>
-                  <SelectItem value="minimax_m2_5">
-                    {t('setting.minimax-m2-5-name')}
+                  <SelectItem value="minimax_m2_7">
+                    {t('setting.minimax-m2-7-name')}
                   </SelectItem>
                 </SelectContent>
               </Select>

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -32,7 +32,7 @@ export type CloudModelType =
   | 'gpt-5.5'
   | 'gpt-5-mini'
   | 'deepseek-v4-pro'
-  | 'minimax_m2_5';
+  | 'minimax_m2_7';
 
 // auth info interface
 interface AuthInfo {

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -215,7 +215,7 @@ const CLOUD_MODEL_PLATFORM_MAP: Record<CloudModelType, CloudModelPlatform> = {
   'gpt-5.5': 'azure',
   'gpt-5-mini': 'azure',
   'deepseek-v4-pro': 'deepseek',
-  'minimax_m2_5': 'minimax',
+  'minimax_m2_7': 'minimax',
 };
 
 export function getCloudModelPlatform(

--- a/test/unit/store/chatStore.test.ts
+++ b/test/unit/store/chatStore.test.ts
@@ -236,7 +236,7 @@ describe('ChatStore - Core Functionality', () => {
         'aws-bedrock-converse'
       );
       expect(getCloudModelPlatform('deepseek-v4-pro')).toBe('deepseek');
-      expect(getCloudModelPlatform('minimax_m2_5')).toBe('minimax');
+      expect(getCloudModelPlatform('minimax_m2_7')).toBe('minimax');
     });
   });
 


### PR DESCRIPTION
Closes #1586.

## Summary
Updates the cloud Minimax model option from M2.5 to M2.7.

## Changes
- Replace `minimax_m2_5` with `minimax_m2_7`.
- Rename the locale key to `minimax-m2-7-name`.
- Update the UI display to `Minimax M2.7`.
- Keep the cloud model platform mapping on `minimax`.
- Update unit test coverage for the mapping.

## Validation
- `npx vitest run test/unit/store/chatStore.test.ts test/unit/electron/main/domReadyHandlers.test.ts`
- `npx eslint src/store/authStore.ts src/store/chatStore.ts src/pages/Agents/Models.tsx test/unit/store/chatStore.test.ts --no-warn-ignored`
- `npm run type-check`
- `npx prettier --check src/store/chatStore.ts src/i18n/locales/en-us/setting.json src/i18n/locales/zh-Hans/setting.json src/pages/Agents/Models.tsx`