### PR TITLE
add auto preload for project and mcp list

### DIFF
--- a/src/components/AddWorker/ToolSelect.tsx
+++ b/src/components/AddWorker/ToolSelect.tsx
@@ -30,6 +30,7 @@ import { useHost } from '@/host';
 import { capitalizeFirstLetter, getProxyBaseURL } from '@/lib';
 import { cn } from '@/lib/utils';
 import { useAuthStore } from '@/store/authStore';
+import type { TFunction } from 'i18next';
 import { CircleAlert, X } from 'lucide-react';
 import {
   forwardRef,
@@ -63,6 +64,187 @@ interface ToolSelectProps {
   onShowEnvConfig?: (mcp: McpItem) => void;
   onSelectedToolsChange?: (tools: McpItem[]) => void;
   initialSelectedTools?: McpItem[];
+}
+
+type ToolSelectAddOption = (item: McpItem, isLocal?: boolean) => void;
+
+type ToolSelectCatalogSnapshot = {
+  email: string | null;
+  configInfo: Record<string, any> | null;
+  userMcps: any[];
+  hasUserMcps: boolean;
+};
+
+/** Session cache so Add Worker tool list + user MCPs show immediately when reopening. */
+let toolSelectCatalogSnapshot: ToolSelectCatalogSnapshot | null = null;
+
+function buildIntegrationsFromConfigInfo(
+  res: unknown,
+  keyword: string | undefined,
+  t: TFunction,
+  addOption: ToolSelectAddOption
+): any[] {
+  if (!res || typeof res !== 'object' || (res as any).error) {
+    return [];
+  }
+  const body = res as Record<string, any>;
+  const baseURL = getProxyBaseURL();
+
+  return Object.entries(body)
+    .filter(([key]) => {
+      if (!keyword) return true;
+      return key.toLowerCase().includes(keyword.toLowerCase());
+    })
+    .map(([key, value]: [string, any]) => {
+      let onInstall: IntegrationItem['onInstall'] | null = null;
+
+      if (key.toLowerCase() === 'notion') {
+        onInstall = async () => {
+          try {
+            const response = await fetchPost('/install/tool/notion');
+            if (response.success) {
+              if (response.warning) {
+                console.warn(
+                  'Notion MCP connection warning:',
+                  response.warning
+                );
+              }
+              await proxyFetchPost('/api/v1/configs', {
+                config_group: 'Notion',
+                config_name: 'MCP_REMOTE_CONFIG_DIR',
+                config_value: response.toolkit_name || 'NotionMCPToolkit',
+              });
+              console.log('Notion MCP installed successfully');
+              const notionItem = {
+                id: 0,
+                key: key,
+                name: key,
+                description:
+                  'Notion workspace integration for reading and managing Notion pages',
+                toolkit: 'notion_mcp_toolkit',
+                isLocal: true,
+              };
+              addOption(notionItem, true);
+            } else {
+              console.error(
+                'Failed to install Notion MCP:',
+                response.error || 'Unknown error'
+              );
+              throw new Error(response.error || 'Failed to install Notion MCP');
+            }
+          } catch (error: any) {
+            console.error('Failed to install Notion MCP:', error.message);
+            throw error;
+          }
+        };
+      } else if (key.toLowerCase() === 'google calendar') {
+        onInstall = async () => {
+          try {
+            const response = await fetchPost('/install/tool/google_calendar');
+            if (response.success) {
+              if (response.warning) {
+                console.warn(
+                  'Google Calendar connection warning:',
+                  response.warning
+                );
+              }
+              try {
+                const existingConfigs = await proxyFetchGet('/api/v1/configs');
+                const existing = Array.isArray(existingConfigs)
+                  ? existingConfigs.find(
+                      (c: any) =>
+                        c.config_group?.toLowerCase() === 'google calendar' &&
+                        c.config_name === 'GOOGLE_REFRESH_TOKEN'
+                    )
+                  : null;
+
+                const configPayload = {
+                  config_group: 'Google Calendar',
+                  config_name: 'GOOGLE_REFRESH_TOKEN',
+                  config_value: 'exists',
+                };
+
+                if (existing) {
+                  await proxyFetchPut(
+                    `/api/v1/configs/${existing.id}`,
+                    configPayload
+                  );
+                } else {
+                  await proxyFetchPost('/api/v1/configs', configPayload);
+                }
+              } catch (configError) {
+                console.warn(
+                  'Failed to persist Google Calendar config',
+                  configError
+                );
+              }
+              console.log('Google Calendar installed successfully');
+              const calendarItem = {
+                id: 0,
+                key: key,
+                name: key,
+                description:
+                  'Google Calendar integration for managing events and schedules',
+                toolkit: 'google_calendar_toolkit',
+                isLocal: true,
+              };
+              addOption(calendarItem, true);
+            } else if (response.status === 'authorizing') {
+              console.log(
+                'Google Calendar authorization in progress. Please complete in browser.'
+              );
+              if (response.message) {
+                console.log(response.message);
+              }
+            } else {
+              console.error(
+                'Failed to install Google Calendar:',
+                response.error || 'Unknown error'
+              );
+              throw new Error(
+                response.error || 'Failed to install Google Calendar'
+              );
+            }
+            return response;
+          } catch (error: any) {
+            if (!error.message?.includes('authorization')) {
+              console.error(
+                'Failed to install Google Calendar:',
+                error.message
+              );
+              throw error;
+            }
+            return null;
+          }
+        };
+      } else {
+        onInstall = () => {
+          window.open(
+            `${baseURL}/api/v1/oauth/${key.toLowerCase()}/login`,
+            '_blank',
+            'width=600,height=700'
+          );
+        };
+      }
+
+      return {
+        key: key,
+        name: key,
+        env_vars: value.env_vars,
+        toolkit: value.toolkit,
+        desc:
+          value.env_vars && value.env_vars.length > 0
+            ? `${t('layout.environmental-variables-required')} ${value.env_vars.join(
+                ', '
+              )}`
+            : key.toLowerCase() === 'notion'
+              ? t('layout.notion-workspace-integration')
+              : key.toLowerCase() === 'google calendar'
+                ? t('layout.google-calendar-integration')
+                : '',
+        onInstall,
+      };
+    });
 }
 
 const ToolSelect = forwardRef<
@@ -107,185 +289,36 @@ const ToolSelect = forwardRef<
   );
 
   const fetchIntegrationsData = useCallback(
-    (keyword?: string) => {
+    (keyword?: string, opts?: { force?: boolean }) => {
+      const u = email ?? null;
+      const snap = toolSelectCatalogSnapshot;
+      if (!opts?.force && snap && snap.email === u && snap.configInfo) {
+        setIntegrations(
+          buildIntegrationsFromConfigInfo(
+            snap.configInfo,
+            keyword,
+            t,
+            addOption
+          )
+        );
+        return;
+      }
+
       proxyFetchGet('/api/v1/config/info')
         .then((res) => {
-          if (res && typeof res === 'object' && !res.error) {
-            const baseURL = getProxyBaseURL();
-
-            const list = Object.entries(res)
-              .filter(([key]) => {
-                if (!keyword) return true;
-                return key.toLowerCase().includes(keyword.toLowerCase());
-              })
-              .map(([key, value]: [string, any]) => {
-                let onInstall = null;
-
-                // Special handling for Notion MCP
-                if (key.toLowerCase() === 'notion') {
-                  onInstall = async () => {
-                    try {
-                      const response = await fetchPost('/install/tool/notion');
-                      if (response.success) {
-                        // Check if there's a warning (connection failed but installation marked as complete)
-                        if (response.warning) {
-                          console.warn(
-                            'Notion MCP connection warning:',
-                            response.warning
-                          );
-                          // Still proceed but log the warning
-                        }
-                        // Save to config to mark as installed
-                        await proxyFetchPost('/api/v1/configs', {
-                          config_group: 'Notion',
-                          config_name: 'MCP_REMOTE_CONFIG_DIR',
-                          config_value:
-                            response.toolkit_name || 'NotionMCPToolkit',
-                        });
-                        console.log('Notion MCP installed successfully');
-                        // After successful installation, add to selected tools
-                        const notionItem = {
-                          id: 0, // Use 0 for integration items
-                          key: key,
-                          name: key,
-                          description:
-                            'Notion workspace integration for reading and managing Notion pages',
-                          toolkit: 'notion_mcp_toolkit', // Add the toolkit name
-                          isLocal: true,
-                        };
-                        addOption(notionItem, true);
-                      } else {
-                        console.error(
-                          'Failed to install Notion MCP:',
-                          response.error || 'Unknown error'
-                        );
-                        throw new Error(
-                          response.error || 'Failed to install Notion MCP'
-                        );
-                      }
-                    } catch (error: any) {
-                      console.error(
-                        'Failed to install Notion MCP:',
-                        error.message
-                      );
-                      throw error;
-                    }
-                  };
-                } else if (key.toLowerCase() === 'google calendar') {
-                  onInstall = async () => {
-                    try {
-                      const response = await fetchPost(
-                        '/install/tool/google_calendar'
-                      );
-                      if (response.success) {
-                        if (response.warning) {
-                          console.warn(
-                            'Google Calendar connection warning:',
-                            response.warning
-                          );
-                        }
-                        try {
-                          const existingConfigs =
-                            await proxyFetchGet('/api/v1/configs');
-                          const existing = Array.isArray(existingConfigs)
-                            ? existingConfigs.find(
-                                (c: any) =>
-                                  c.config_group?.toLowerCase() ===
-                                    'google calendar' &&
-                                  c.config_name === 'GOOGLE_REFRESH_TOKEN'
-                              )
-                            : null;
-
-                          const configPayload = {
-                            config_group: 'Google Calendar',
-                            config_name: 'GOOGLE_REFRESH_TOKEN',
-                            config_value: 'exists',
-                          };
-
-                          if (existing) {
-                            await proxyFetchPut(
-                              `/api/v1/configs/${existing.id}`,
-                              configPayload
-                            );
-                          } else {
-                            await proxyFetchPost(
-                              '/api/v1/configs',
-                              configPayload
-                            );
-                          }
-                        } catch (configError) {
-                          console.warn(
-                            'Failed to persist Google Calendar config',
-                            configError
-                          );
-                        }
-                        console.log('Google Calendar installed successfully');
-                        const calendarItem = {
-                          id: 0, // Use 0 for integration items
-                          key: key,
-                          name: key,
-                          description:
-                            'Google Calendar integration for managing events and schedules',
-                          toolkit: 'google_calendar_toolkit', // Add the toolkit name
-                          isLocal: true,
-                        };
-                        addOption(calendarItem, true);
-                      } else if (response.status === 'authorizing') {
-                        console.log(
-                          'Google Calendar authorization in progress. Please complete in browser.'
-                        );
-                        if (response.message) {
-                          console.log(response.message);
-                        }
-                      } else {
-                        console.error(
-                          'Failed to install Google Calendar:',
-                          response.error || 'Unknown error'
-                        );
-                        throw new Error(
-                          response.error || 'Failed to install Google Calendar'
-                        );
-                      }
-                      return response;
-                    } catch (error: any) {
-                      if (!error.message?.includes('authorization')) {
-                        console.error(
-                          'Failed to install Google Calendar:',
-                          error.message
-                        );
-                        throw error;
-                      }
-                      return null; // Return null on authorization flow errors
-                    }
-                  };
-                } else {
-                  onInstall = () =>
-                    window.open(
-                      `${baseURL}/api/v1/oauth/${key.toLowerCase()}/login`,
-                      '_blank',
-                      'width=600,height=700'
-                    );
-                }
-
-                return {
-                  key: key,
-                  name: key,
-                  env_vars: value.env_vars,
-                  toolkit: value.toolkit,
-                  desc:
-                    value.env_vars && value.env_vars.length > 0
-                      ? `${t('layout.environmental-variables-required')} ${value.env_vars.join(
-                          ', '
-                        )}`
-                      : key.toLowerCase() === 'notion'
-                        ? t('layout.notion-workspace-integration')
-                        : key.toLowerCase() === 'google calendar'
-                          ? t('layout.google-calendar-integration')
-                          : '',
-                  onInstall,
-                };
-              });
-            setIntegrations(list);
+          if (res && typeof res === 'object' && !(res as any).error) {
+            const info = res as Record<string, any>;
+            const prev = toolSelectCatalogSnapshot;
+            const sameUser = prev?.email === u;
+            toolSelectCatalogSnapshot = {
+              email: u,
+              configInfo: info,
+              userMcps: sameUser ? (prev?.userMcps ?? []) : [],
+              hasUserMcps: sameUser ? (prev?.hasUserMcps ?? false) : false,
+            };
+            setIntegrations(
+              buildIntegrationsFromConfigInfo(info, keyword, t, addOption)
+            );
           } else {
             console.error('Failed to fetch integrations:', res);
             setIntegrations([]);
@@ -296,25 +329,43 @@ const ToolSelect = forwardRef<
           setIntegrations([]);
         });
     },
-    [addOption, t]
+    [addOption, email, t]
   );
 
-  const fetchInstalledMcps = useCallback(() => {
-    proxyFetchGet('/api/v1/mcp/users')
-      .then((res) => {
-        let dataList: any[] = [];
-        if (Array.isArray(res)) {
-          dataList = res;
-        } else if (res && Array.isArray(res.items)) {
-          dataList = res.items;
-        }
-        setUserMcpList(dataList);
-      })
-      .catch((error) => {
-        console.error('Error fetching installed MCPs:', error);
-        setUserMcpList([]);
-      });
-  }, []);
+  const fetchInstalledMcps = useCallback(
+    (opts?: { force?: boolean }) => {
+      const u = email ?? null;
+      const snap = toolSelectCatalogSnapshot;
+      if (!opts?.force && snap && snap.email === u && snap.hasUserMcps) {
+        setUserMcpList(snap.userMcps);
+        return;
+      }
+
+      proxyFetchGet('/api/v1/mcp/users')
+        .then((res) => {
+          let dataList: any[] = [];
+          if (Array.isArray(res)) {
+            dataList = res;
+          } else if (res && Array.isArray(res.items)) {
+            dataList = res.items;
+          }
+          setUserMcpList(dataList);
+          const prev = toolSelectCatalogSnapshot;
+          const sameUser = prev?.email === u;
+          toolSelectCatalogSnapshot = {
+            email: u,
+            configInfo: sameUser ? (prev?.configInfo ?? null) : null,
+            userMcps: dataList,
+            hasUserMcps: true,
+          };
+        })
+        .catch((error) => {
+          console.error('Error fetching installed MCPs:', error);
+          setUserMcpList([]);
+        });
+    },
+    [email]
+  );
 
   // public save env/config logic
   const saveEnvAndConfig = async (
@@ -449,7 +500,7 @@ const ToolSelect = forwardRef<
             }
 
             // Refresh integrations to update install status
-            fetchIntegrationsData();
+            fetchIntegrationsData(undefined, { force: true });
 
             const selectedItem = {
               id: activeMcp.id,
@@ -518,7 +569,7 @@ const ToolSelect = forwardRef<
                       await proxyFetchPost('/api/v1/configs', configPayload);
                     }
 
-                    fetchIntegrationsData();
+                    fetchIntegrationsData(undefined, { force: true });
 
                     const selectedItem = {
                       id: activeMcp.id,
@@ -596,6 +647,7 @@ const ToolSelect = forwardRef<
       if (installedMcp) {
         addOption(installedMcp);
       }
+      void fetchInstalledMcps({ force: true });
     } catch (e) {
       console.error('Failed to install MCP:', e);
     }
@@ -609,7 +661,19 @@ const ToolSelect = forwardRef<
   const removeOption = useCallback(
     (item: McpItem) => {
       const currentSelected = initialSelectedTools || [];
-      const newSelected = currentSelected.filter((i) => i.id !== item.id);
+      const newSelected = currentSelected.filter((row) => {
+        const bothLocal =
+          row.isLocal === true &&
+          item.isLocal === true &&
+          row.key != null &&
+          item.key != null &&
+          String(row.key) !== '' &&
+          String(item.key) !== '';
+        if (bothLocal) {
+          return row.key !== item.key;
+        }
+        return row.id !== item.id;
+      });
       onSelectedToolsChange?.(newSelected);
     },
     [initialSelectedTools, onSelectedToolsChange]
@@ -773,24 +837,30 @@ const ToolSelect = forwardRef<
     const checked = !!(initialSelectedTools || []).find(
       (i) => i.id === item.id
     );
+    const label = String(item.mcp_name || item.mcp_key || '');
     return (
-      <div
+      <button
         key={item.id}
-        className="gap-2 rounded-lg bg-ds-bg-neutral-subtle-default py-2 px-3 last:mb-1 min-h-0 flex w-auto items-center"
+        type="button"
+        aria-pressed={checked}
+        aria-label={label}
+        onClick={() => handleToggleUserMcp(item, !checked)}
+        className={cn(
+          'gap-2 rounded-lg bg-ds-bg-neutral-subtle-default py-2 px-3 last:mb-1 min-h-0 min-w-0 flex w-full items-center text-left',
+          'cursor-pointer border-none shadow-none transition-colors',
+          'focus-visible:ring-ds-ring-brand-default-focus focus-visible:ring-offset-ds-bg-neutral-default-default focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none'
+        )}
       >
         <Checkbox
           checked={checked}
-          onCheckedChange={(c) => {
-            if (c === 'indeterminate') return;
-            handleToggleUserMcp(item, c === true);
-          }}
-          onClick={(e) => e.stopPropagation()}
-          aria-label={String(item.mcp_name || item.mcp_key || '')}
+          tabIndex={-1}
+          className="pointer-events-none"
+          aria-hidden
         />
         <span className="min-w-0 text-sm font-bold leading-5 text-ds-text-neutral-default-default sm:text-base line-clamp-2 flex-1 break-words">
           {capitalizeFirstLetter(item.mcp_name || '')}
         </span>
-      </div>
+      </button>
     );
   };
 
@@ -809,7 +879,7 @@ const ToolSelect = forwardRef<
         <div
           onMouseDown={() => inputRef.current?.focus()}
           className={cn(
-            'focus-within:ring-ds-border-brand-default-default/35 gap-1.5 rounded-lg border-ds-border-neutral-default-default bg-ds-bg-neutral-default-default min-w-0 px-2 py-1.5 flex max-h-[120px] min-h-[40px] w-full flex-wrap content-center items-center justify-start border border-solid focus-within:ring-2'
+            'focus-within:ring-ds-border-brand-default-default/35 gap-1.5 rounded-lg bg-ds-bg-neutral-default-default min-w-0 px-2 py-1.5 flex max-h-[120px] min-h-[40px] w-full flex-wrap content-center items-center justify-start focus-within:ring-2'
           )}
         >
           {renderSelectedItems()}
@@ -832,7 +902,7 @@ const ToolSelect = forwardRef<
           id="agent-tool-picker-panel"
           role="region"
           aria-label={t('workforce.agent-tool')}
-          className="min-w-0 rounded-lg border-ds-border-neutral-muted-default bg-ds-bg-neutral-default-default w-full overflow-hidden border border-solid"
+          className="min-w-0 rounded-lg bg-ds-bg-neutral-default-default border-ds-border-neutral-subtle-default w-full overflow-hidden border border-solid"
         >
           <div className="scrollbar-always-visible gap-1.5 px-2 py-2 min-h-0 flex h-[260px] flex-col overflow-x-hidden overflow-y-auto">
             {listHasItems ? (

--- a/src/components/AddWorker/ToolSelect.tsx
+++ b/src/components/AddWorker/ToolSelect.tsx
@@ -292,7 +292,9 @@ const ToolSelect = forwardRef<
     (keyword?: string, opts?: { force?: boolean }) => {
       const u = email ?? null;
       const snap = toolSelectCatalogSnapshot;
-      if (!opts?.force && snap && snap.email === u && snap.configInfo) {
+      const hydratedFromCache =
+        !opts?.force && snap && snap.email === u && snap.configInfo;
+      if (hydratedFromCache) {
         setIntegrations(
           buildIntegrationsFromConfigInfo(
             snap.configInfo,
@@ -301,7 +303,6 @@ const ToolSelect = forwardRef<
             addOption
           )
         );
-        return;
       }
 
       proxyFetchGet('/api/v1/config/info')
@@ -326,7 +327,7 @@ const ToolSelect = forwardRef<
         })
         .catch((error) => {
           console.error('Error fetching integrations:', error);
-          setIntegrations([]);
+          if (!hydratedFromCache) setIntegrations([]);
         });
     },
     [addOption, email, t]
@@ -336,9 +337,10 @@ const ToolSelect = forwardRef<
     (opts?: { force?: boolean }) => {
       const u = email ?? null;
       const snap = toolSelectCatalogSnapshot;
-      if (!opts?.force && snap && snap.email === u && snap.hasUserMcps) {
+      const hydratedFromCache =
+        !opts?.force && snap && snap.email === u && snap.hasUserMcps;
+      if (hydratedFromCache) {
         setUserMcpList(snap.userMcps);
-        return;
       }
 
       proxyFetchGet('/api/v1/mcp/users')
@@ -361,7 +363,7 @@ const ToolSelect = forwardRef<
         })
         .catch((error) => {
           console.error('Error fetching installed MCPs:', error);
-          setUserMcpList([]);
+          if (!hydratedFromCache) setUserMcpList([]);
         });
     },
     [email]

--- a/src/components/Dashboard/GroupedHistoryView/index.tsx
+++ b/src/components/Dashboard/GroupedHistoryView/index.tsx
@@ -126,33 +126,38 @@ export default function GroupedHistoryView({
     }
   }, [projects, email, triggerKey]);
 
-  const loadProjects = useCallback(async () => {
-    setLoading(true);
-    const u = email ?? null;
-    try {
-      const snapshotSetter: Dispatch<SetStateAction<ProjectGroupType[]>> = (
-        action
-      ) => {
-        setProjects((prev) => {
-          const next =
-            typeof action === 'function'
-              ? (action as (p: ProjectGroupType[]) => ProjectGroupType[])(prev)
-              : action;
-          groupedHistorySnapshot = {
-            email: u,
-            projects: next,
-            triggerKey,
-          };
-          return next;
-        });
-      };
-      await fetchGroupedHistoryTasks(snapshotSetter);
-    } catch (error) {
-      console.error('Failed to load grouped projects:', error);
-    } finally {
-      setLoading(false);
-    }
-  }, [email, triggerKey]);
+  const loadProjects = useCallback(
+    async (opts?: { silent?: boolean }) => {
+      if (!opts?.silent) setLoading(true);
+      const u = email ?? null;
+      try {
+        const snapshotSetter: Dispatch<SetStateAction<ProjectGroupType[]>> = (
+          action
+        ) => {
+          setProjects((prev) => {
+            const next =
+              typeof action === 'function'
+                ? (action as (p: ProjectGroupType[]) => ProjectGroupType[])(
+                    prev
+                  )
+                : action;
+            groupedHistorySnapshot = {
+              email: u,
+              projects: next,
+              triggerKey,
+            };
+            return next;
+          });
+        };
+        await fetchGroupedHistoryTasks(snapshotSetter);
+      } catch (error) {
+        console.error('Failed to load grouped projects:', error);
+      } finally {
+        if (!opts?.silent) setLoading(false);
+      }
+    },
+    [email, triggerKey]
+  );
 
   const onDelete = (historyId: string) => {
     try {
@@ -315,6 +320,7 @@ export default function GroupedHistoryView({
     if (snap && snap.email === u && snap.triggerKey === triggerKey) {
       setProjects(snap.projects);
       setLoading(false);
+      void loadProjects({ silent: true });
       return;
     }
     void loadProjects();

--- a/src/components/Dashboard/GroupedHistoryView/index.tsx
+++ b/src/components/Dashboard/GroupedHistoryView/index.tsx
@@ -17,7 +17,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Tag } from '@/components/ui/tag';
 import { useHost } from '@/host';
 import { fetchGroupedHistoryTasks } from '@/service/historyApi';
-import { getAuthStore } from '@/store/authStore';
+import { getAuthStore, useAuthStore } from '@/store/authStore';
 import { useGlobalStore } from '@/store/globalStore';
 import { useProjectStore } from '@/store/projectStore';
 import { ProjectGroup as ProjectGroupType } from '@/types/history';
@@ -30,9 +30,17 @@ import {
   ListChecks,
   Zap,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ProjectGroup from './ProjectGroup';
+
+/** Session cache so remounts (e.g. dialogs) show the project list immediately without refetching. */
+let groupedHistorySnapshot: {
+  email: string | null;
+  projects: ProjectGroupType[];
+  triggerKey: number | string;
+} | null = null;
 
 interface GroupedHistoryViewProps {
   /** When true, grid/list tabs are hidden (e.g. controlled from a parent sidebar). */
@@ -74,26 +82,77 @@ export default function GroupedHistoryView({
   onProjectDelete,
 }: GroupedHistoryViewProps) {
   const { t } = useTranslation();
+  const email = useAuthStore((s) => s.email);
   const host = useHost();
   const ipcRenderer = host?.ipcRenderer;
-  const [projects, setProjects] = useState<ProjectGroupType[]>([]);
-  const [loading, setLoading] = useState(true);
+  const triggerKey = refreshTrigger ?? '_default';
+
+  const [projects, setProjects] = useState<ProjectGroupType[]>(() => {
+    const snap = groupedHistorySnapshot;
+    if (
+      snap &&
+      snap.email === (email ?? null) &&
+      snap.triggerKey === triggerKey
+    ) {
+      return snap.projects;
+    }
+    return [];
+  });
+  const [loading, setLoading] = useState(() => {
+    const snap = groupedHistorySnapshot;
+    return !(
+      snap &&
+      snap.email === (email ?? null) &&
+      snap.triggerKey === triggerKey
+    );
+  });
   const { history_type, setHistoryType } = useGlobalStore();
   const projectStore = useProjectStore();
 
   // Default to list view if not set
   const viewType = history_type || 'list';
 
-  const loadProjects = async () => {
+  useEffect(() => {
+    const u = email ?? null;
+    if (
+      groupedHistorySnapshot &&
+      groupedHistorySnapshot.email === u &&
+      groupedHistorySnapshot.triggerKey === triggerKey
+    ) {
+      groupedHistorySnapshot = {
+        ...groupedHistorySnapshot,
+        projects,
+      };
+    }
+  }, [projects, email, triggerKey]);
+
+  const loadProjects = useCallback(async () => {
     setLoading(true);
+    const u = email ?? null;
     try {
-      await fetchGroupedHistoryTasks(setProjects);
+      const snapshotSetter: Dispatch<SetStateAction<ProjectGroupType[]>> = (
+        action
+      ) => {
+        setProjects((prev) => {
+          const next =
+            typeof action === 'function'
+              ? (action as (p: ProjectGroupType[]) => ProjectGroupType[])(prev)
+              : action;
+          groupedHistorySnapshot = {
+            email: u,
+            projects: next,
+            triggerKey,
+          };
+          return next;
+        });
+      };
+      await fetchGroupedHistoryTasks(snapshotSetter);
     } catch (error) {
       console.error('Failed to load grouped projects:', error);
     } finally {
       setLoading(false);
     }
-  };
+  }, [email, triggerKey]);
 
   const onDelete = (historyId: string) => {
     try {
@@ -251,8 +310,15 @@ export default function GroupedHistoryView({
   };
 
   useEffect(() => {
-    loadProjects();
-  }, [refreshTrigger]);
+    const u = email ?? null;
+    const snap = groupedHistorySnapshot;
+    if (snap && snap.email === u && snap.triggerKey === triggerKey) {
+      setProjects(snap.projects);
+      setLoading(false);
+      return;
+    }
+    void loadProjects();
+  }, [email, triggerKey, loadProjects]);
 
   // Filter projects based on search value
   const filteredProjects = projects.filter((project) => {
@@ -312,35 +378,35 @@ export default function GroupedHistoryView({
 
   // Skeleton component for list card loading state
   const ListCardSkeleton = () => (
-    <div className="overflow-hidden rounded-xl bg-ds-bg-neutral-default-default">
-      <div className="flex w-full items-center justify-between px-6 py-4">
+    <div className="rounded-xl bg-ds-bg-neutral-default-default overflow-hidden">
+      <div className="px-6 py-4 flex w-full items-center justify-between">
         {/* Start: Folder icon and project name skeleton */}
-        <div className="flex w-48 flex-shrink-0 items-center gap-3">
-          <div className="relative h-5 w-5 flex-shrink-0 overflow-hidden rounded bg-ds-bg-neutral-subtle-default">
-            <div className="absolute inset-0" style={shimmerStyle} />
+        <div className="w-48 gap-3 flex flex-shrink-0 items-center">
+          <div className="h-5 w-5 rounded bg-ds-bg-neutral-subtle-default relative flex-shrink-0 overflow-hidden">
+            <div className="inset-0 absolute" style={shimmerStyle} />
           </div>
-          <div className="relative h-5 w-32 overflow-hidden rounded bg-ds-bg-neutral-subtle-default">
-            <div className="absolute inset-0" style={shimmerStyle} />
+          <div className="h-5 w-32 rounded bg-ds-bg-neutral-subtle-default relative overflow-hidden">
+            <div className="inset-0 absolute" style={shimmerStyle} />
           </div>
         </div>
 
         {/* Middle: Tags skeleton */}
-        <div className="flex flex-1 items-center justify-end gap-4">
-          <div className="relative h-6 w-16 overflow-hidden rounded-full bg-ds-bg-neutral-subtle-default">
-            <div className="absolute inset-0" style={shimmerStyle} />
+        <div className="gap-4 flex flex-1 items-center justify-end">
+          <div className="h-6 w-16 bg-ds-bg-neutral-subtle-default relative overflow-hidden rounded-full">
+            <div className="inset-0 absolute" style={shimmerStyle} />
           </div>
-          <div className="relative h-6 w-12 overflow-hidden rounded-full bg-ds-bg-neutral-subtle-default">
-            <div className="absolute inset-0" style={shimmerStyle} />
+          <div className="h-6 w-12 bg-ds-bg-neutral-subtle-default relative overflow-hidden rounded-full">
+            <div className="inset-0 absolute" style={shimmerStyle} />
           </div>
-          <div className="relative h-6 w-12 overflow-hidden rounded-full bg-ds-bg-neutral-subtle-default">
-            <div className="absolute inset-0" style={shimmerStyle} />
+          <div className="h-6 w-12 bg-ds-bg-neutral-subtle-default relative overflow-hidden rounded-full">
+            <div className="inset-0 absolute" style={shimmerStyle} />
           </div>
         </div>
 
         {/* End: Menu skeleton */}
-        <div className="ml-4 flex min-w-32 items-center justify-end gap-2 pl-4">
-          <div className="relative h-8 w-8 overflow-hidden rounded-md bg-ds-bg-neutral-subtle-default">
-            <div className="absolute inset-0" style={shimmerStyle} />
+        <div className="ml-4 min-w-32 gap-2 pl-4 flex items-center justify-end">
+          <div className="h-8 w-8 rounded-md bg-ds-bg-neutral-subtle-default relative overflow-hidden">
+            <div className="inset-0 absolute" style={shimmerStyle} />
           </div>
         </div>
       </div>
@@ -349,7 +415,7 @@ export default function GroupedHistoryView({
 
   if (loading) {
     return (
-      <div className="flex w-full flex-col gap-4 pb-40">
+      <div className="gap-4 pb-40 flex w-full flex-col">
         {/* Keyframe animation for shimmer effect */}
         <style>
           {`
@@ -361,24 +427,24 @@ export default function GroupedHistoryView({
         </style>
 
         {/* Summary skeleton */}
-        <div className="flex items-center justify-between pb-4">
-          <div className="flex items-center gap-2">
-            <div className="relative h-7 w-28 overflow-hidden rounded-full bg-ds-bg-neutral-strong-default">
-              <div className="absolute inset-0" style={shimmerStyle} />
+        <div className="pb-4 flex items-center justify-between">
+          <div className="gap-2 flex items-center">
+            <div className="h-7 w-28 bg-ds-bg-neutral-strong-default relative overflow-hidden rounded-full">
+              <div className="inset-0 absolute" style={shimmerStyle} />
             </div>
-            <div className="relative h-7 w-32 overflow-hidden rounded-full bg-ds-bg-neutral-strong-default">
-              <div className="absolute inset-0" style={shimmerStyle} />
+            <div className="h-7 w-32 bg-ds-bg-neutral-strong-default relative overflow-hidden rounded-full">
+              <div className="inset-0 absolute" style={shimmerStyle} />
             </div>
           </div>
-          <div className="flex items-center gap-md">
-            <div className="relative h-9 w-40 overflow-hidden rounded-lg bg-ds-bg-neutral-strong-default">
-              <div className="absolute inset-0" style={shimmerStyle} />
+          <div className="gap-md flex items-center">
+            <div className="h-9 w-40 rounded-lg bg-ds-bg-neutral-strong-default relative overflow-hidden">
+              <div className="inset-0 absolute" style={shimmerStyle} />
             </div>
           </div>
         </div>
 
         {/* List skeleton cards */}
-        <div className="flex flex-col gap-3">
+        <div className="gap-3 flex flex-col">
           {[1, 2, 3, 4, 5].map((i) => (
             <ListCardSkeleton key={i} />
           ))}
@@ -389,7 +455,7 @@ export default function GroupedHistoryView({
 
   if (filteredProjects.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center p-8 text-center">
+      <div className="p-8 flex flex-col items-center justify-center text-center">
         <FolderOpen className="mb-4 h-12 w-12 text-ds-icon-neutral-muted-default" />
         <div className="text-sm text-ds-text-neutral-muted-default">
           {searchValue
@@ -406,12 +472,12 @@ export default function GroupedHistoryView({
   }
 
   return (
-    <div className="flex w-full flex-col gap-4 pb-40">
+    <div className="gap-4 pb-40 flex w-full flex-col">
       {/* Summary */}
       <div
-        className={`flex items-center pb-4 ${hideViewSwitcher ? 'justify-start' : 'justify-between'}`}
+        className={`pb-4 flex items-center ${hideViewSwitcher ? 'justify-start' : 'justify-between'}`}
       >
-        <div className="flex items-center gap-2">
+        <div className="gap-2 flex items-center">
           <Tag variant="primary" tone="neutral" size="sm" className="gap-2">
             <Folder />
             <span className="text-body-sm"> {t('layout.projects')}</span>
@@ -440,7 +506,7 @@ export default function GroupedHistoryView({
             )}
           </Tag>
         </div>
-        <div className="flex items-center gap-md">
+        <div className="gap-md flex items-center">
           {!hideViewSwitcher && (
             <Tabs
               value={viewType}
@@ -450,13 +516,13 @@ export default function GroupedHistoryView({
             >
               <TabsList>
                 <TabsTrigger value="grid">
-                  <div className="flex items-center gap-1 text-label-sm">
+                  <div className="gap-1 text-label-sm flex items-center">
                     <LayoutGrid size={16} />
                     <span>{t('dashboard.grid')}</span>
                   </div>
                 </TabsTrigger>
                 <TabsTrigger value="list">
-                  <div className="flex items-center gap-1 text-label-sm">
+                  <div className="gap-1 text-label-sm flex items-center">
                     <List size={16} />
                     <span>{t('dashboard.list')}</span>
                   </div>
@@ -478,7 +544,7 @@ export default function GroupedHistoryView({
           {viewType === 'grid' ? (
             // Grid layout for project cards
             <motion.div
-              className="grid auto-rows-fr grid-cols-1 gap-4 md:grid-cols-2"
+              className="gap-4 md:grid-cols-2 grid auto-rows-fr grid-cols-1"
               initial="hidden"
               animate="visible"
               variants={{
@@ -538,7 +604,7 @@ export default function GroupedHistoryView({
           ) : (
             // List layout for projects
             <motion.div
-              className="flex flex-col gap-3"
+              className="gap-3 flex flex-col"
               initial="hidden"
               animate="visible"
               variants={{

--- a/src/components/Dashboard/IntegrationList/index.tsx
+++ b/src/components/Dashboard/IntegrationList/index.tsx
@@ -100,7 +100,7 @@ export default function IntegrationList({
   const [activeMcp, setActiveMcp] = useState<any | null>(null);
   const isSelectMode = variant === 'select';
 
-  // Use shared hook for integration management
+  // Connection status uses `/api/v1/configs` via the hook; configs are session-cached so reopening this UI does not refetch on every mount.
   const {
     installed,
     fetchInstalled,
@@ -304,7 +304,7 @@ export default function IntegrationList({
     : 'flex flex-col w-full items-start justify-start gap-4';
 
   const itemClassName = isSelectMode
-    ? 'cursor-pointer gap-2 rounded-lg bg-ds-bg-neutral-subtle-default px-3 py-2 min-h-0 flex w-full items-center justify-between hover:bg-ds-bg-neutral-default-hover'
+    ? 'cursor-pointer gap-2 rounded-lg bg-ds-bg-neutral-subtle-default px-3 py-2 min-h-0 flex w-full items-center justify-between'
     : 'w-full px-6 py-4 bg-ds-bg-neutral-subtle-default rounded-2xl';
 
   const titleClassName = isSelectMode

--- a/src/hooks/useIntegrationManagement.ts
+++ b/src/hooks/useIntegrationManagement.ts
@@ -24,6 +24,12 @@ import { useHost } from '@/host';
 import { useAuthStore } from '@/store/authStore';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+/** Last fetched `/api/v1/configs` per session so connection status stays instant across remounts (e.g. opening another page and returning). */
+let integrationConfigsSnapshot: {
+  email: string | null;
+  configs: any[];
+} | null = null;
+
 export interface IntegrationItem {
   key: string;
   name: string;
@@ -60,21 +66,54 @@ export function useIntegrationManagement(items: IntegrationItem[]) {
     try {
       const configsRes = await proxyFetchGet('/api/v1/configs');
       if (!ignore) {
-        setConfigs(Array.isArray(configsRes) ? configsRes : []);
+        const list = Array.isArray(configsRes) ? configsRes : [];
+        setConfigs(list);
+        integrationConfigsSnapshot = {
+          email: useAuthStore.getState().email ?? null,
+          configs: list,
+        };
       }
     } catch (_e) {
-      if (!ignore) setConfigs([]);
+      if (!ignore) {
+        setConfigs([]);
+        integrationConfigsSnapshot = {
+          email: useAuthStore.getState().email ?? null,
+          configs: [],
+        };
+      }
     }
   }, []);
 
-  // Fetch configs when mounted
+  // Hydrate configs from cache or fetch once per user session when mounted
   useEffect(() => {
-    let ignore = false;
-    fetchInstalled(ignore);
+    const u = email ?? null;
+    const snap = integrationConfigsSnapshot;
+    if (snap && snap.email === u) {
+      setConfigs(snap.configs);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const configsRes = await proxyFetchGet('/api/v1/configs');
+        if (cancelled) return;
+        const list = Array.isArray(configsRes) ? configsRes : [];
+        setConfigs(list);
+        integrationConfigsSnapshot = {
+          email: u,
+          configs: list,
+        };
+      } catch {
+        if (!cancelled) {
+          setConfigs([]);
+          integrationConfigsSnapshot = { email: u, configs: [] };
+        }
+      }
+    })();
     return () => {
-      ignore = true;
+      cancelled = true;
     };
-  }, [fetchInstalled]);
+  }, [email]);
 
   // Recalculate installed status when items or configs change
   useEffect(() => {
@@ -349,9 +388,16 @@ export function useIntegrationManagement(items: IntegrationItem[]) {
       }
 
       // Update configs after deletion
-      setConfigs((prev) =>
-        prev.filter((c: any) => c.config_group?.toLowerCase() !== groupKey)
-      );
+      setConfigs((prev) => {
+        const next = prev.filter(
+          (c: any) => c.config_group?.toLowerCase() !== groupKey
+        );
+        integrationConfigsSnapshot = {
+          email: email ?? null,
+          configs: next,
+        };
+        return next;
+      });
     },
     [checkAgentTool, configs, electronAPI, email]
   );

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -23,7 +23,7 @@ import useChatStoreAdapter from '@/hooks/useChatStoreAdapter';
 import Project from '@/pages/Projects/Project';
 import Setting from '@/pages/Setting';
 import { useAuthStore } from '@/store/authStore';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import Agents from './Agents';
@@ -56,6 +56,17 @@ export default function Home() {
     }
     return 'projects' as HistoryTabId;
   }, [searchParams]);
+
+  /** Mount each tab once when first opened; keep mounted and hide inactive so lists do not refetch on every tab switch. */
+  const [visitedTabs, setVisitedTabs] = useState<HistoryTabId[]>(() => [
+    activeTab,
+  ]);
+
+  useEffect(() => {
+    setVisitedTabs((prev) =>
+      prev.includes(activeTab) ? prev : [...prev, activeTab]
+    );
+  }, [activeTab]);
 
   const handleTabChange = (value: string) => {
     if (value) {
@@ -138,12 +149,54 @@ export default function Home() {
         </div>
         <div className="m-auto flex h-auto w-full max-w-[1020px] flex-1 flex-col">
           <div className="px-6 flex h-auto min-h-[calc(100vh-80px)] w-full">
-            {activeTab === 'projects' && <Project />}
-            {activeTab === 'agents' && <Agents />}
-            {activeTab === 'channels' && <Channels />}
-            {activeTab === 'connectors' && <Connectors />}
-            {activeTab === 'browser' && <Browser />}
-            {activeTab === 'settings' && <Setting />}
+            {visitedTabs.includes('projects') && (
+              <div
+                className={activeTab === 'projects' ? 'contents' : 'hidden'}
+                aria-hidden={activeTab !== 'projects'}
+              >
+                <Project />
+              </div>
+            )}
+            {visitedTabs.includes('agents') && (
+              <div
+                className={activeTab === 'agents' ? 'contents' : 'hidden'}
+                aria-hidden={activeTab !== 'agents'}
+              >
+                <Agents />
+              </div>
+            )}
+            {visitedTabs.includes('channels') && (
+              <div
+                className={activeTab === 'channels' ? 'contents' : 'hidden'}
+                aria-hidden={activeTab !== 'channels'}
+              >
+                <Channels />
+              </div>
+            )}
+            {visitedTabs.includes('connectors') && (
+              <div
+                className={activeTab === 'connectors' ? 'contents' : 'hidden'}
+                aria-hidden={activeTab !== 'connectors'}
+              >
+                <Connectors />
+              </div>
+            )}
+            {visitedTabs.includes('browser') && (
+              <div
+                className={activeTab === 'browser' ? 'contents' : 'hidden'}
+                aria-hidden={activeTab !== 'browser'}
+              >
+                <Browser />
+              </div>
+            )}
+            {visitedTabs.includes('settings') && (
+              <div
+                className={activeTab === 'settings' ? 'contents' : 'hidden'}
+                aria-hidden={activeTab !== 'settings'}
+              >
+                <Setting />
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

What this branch adds on top of its base (latest commit)
Commit: 048e9608 — add auto preload for project and mcp list

The goal is to make project lists, MCP/integration config, and Add Worker tool lists feel instant when you reopen UI, remount after dialogs, or switch tabs, by avoiding unnecessary refetches and keeping state alive where it helps.

GroupedHistoryView (src/components/Dashboard/GroupedHistoryView/index.tsx)

Adds a session-level snapshot (groupedHistorySnapshot) keyed by signed-in email and refreshTrigger.
Seeds projects and skips the loading skeleton when the snapshot matches, so grouped projects can render immediately after remount.
Refreshes the snapshot whenever the project list updates after a fetch.
useIntegrationManagement (src/hooks/useIntegrationManagement.ts)

Caches /api/v1/configs in integrationConfigsSnapshot (again per email).
On mount, reuses cached configs instead of hitting the API every time.
Keeps the snapshot in sync after successful fetch, errors (empty list), and deletes.
ToolSelect (src/components/AddWorker/ToolSelect.tsx)

Adds toolSelectCatalogSnapshot so the market catalog + user MCP list can rehydrate when the Add Worker tool picker is opened again in the same session.
Includes a sizeable refactor (e.g. buildIntegrationsFromConfigInfo extracted).
Small UX/a11y tweaks: user MCP row as a button with checkbox as non-interactive visual, minor border styling.
History page tabs (src/pages/History.tsx)

Tracks visitedTabs so each tab’s content is mounted once and then only hidden when inactive (contents / hidden, aria-hidden).
Reduces remount-driven refetches when jumping between Projects, Agents, Connectors, etc.
IntegrationList

Comment updated to describe session caching; select-mode row styling slightly adjusted (e.g. hover class).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [ ] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
