### PR TITLE
fix: work-log timeline, execution context, and task box focus

### DIFF
--- a/src/components/ChatBox/MessageItem/TaskWorkLogAccordion.tsx
+++ b/src/components/ChatBox/MessageItem/TaskWorkLogAccordion.tsx
@@ -43,6 +43,7 @@ const HEIGHT_MOTION = {
 } as const;
 const MARKDOWN_DEFER_THRESHOLD = 1200;
 const MARKDOWN_DEFER_MS = 180;
+const TOOL_INLINE_PREVIEW_MAX = 200;
 
 function normalizeToolkitMessage(value: unknown): string {
   if (typeof value === 'string') return value;
@@ -96,111 +97,148 @@ function truncateText(text: string, max: number): string {
   return `${t.slice(0, max - 1)}…`;
 }
 
-function formatToolSummary(
-  toolkitName: string,
-  method: string,
-  preview: string
-): string {
-  const p = preview.trim();
-  const head = `${toolkitName} · ${titleCaseMethod(method)}`;
-  return p ? `${head} — ${truncateText(p, 100)}` : head;
-}
-
 function toolRowTitle(toolkitName: string, method: string): string {
   return `${toolkitName} · ${titleCaseMethod(method)}`;
 }
 
-type ToolSegment = {
+/**
+ * Heuristic: does this toolkit message read as agent narration ("Cloning
+ * session …", "Found 12 results.") rather than a kwargs-style payload
+ * (`url='https://x'`, `{"q": "…"}`) we'd only want hidden inside the fold?
+ *
+ * Narration is shown inline above the tool row so the user always sees what
+ * the agent is doing, even with the tool fold collapsed. Payloads stay folded.
+ */
+function looksLikeNarration(raw: string): boolean {
+  const s = raw.trim();
+  if (!s) return false;
+  if (s.length < 12) return false;
+  const head = s.slice(0, 1);
+  if (head === '{' || head === '[' || head === '<') return false;
+  if (/^https?:\/\//i.test(s)) return false;
+  // kwargs-ish: leading `key=` or `key='`
+  if (/^[a-z_][\w]*\s*=/i.test(s)) return false;
+  // Multi-word, alpha-leading, ends in punctuation or is a long sentence.
+  if (!/[a-zA-Z]/.test(s)) return false;
+  const wordCount = s.split(/\s+/).length;
+  if (wordCount < 3) return false;
+  return true;
+}
+
+type ToolItem = {
+  kind: 'tool';
   id: string;
   rowTitle: string;
   toolkitName: string;
   method: string;
-  summary: string;
+  /** Concatenated input + output (markdown-rendered when expanded). */
   detail: string;
   status: 'running' | 'done';
 };
 
+type MessageItem = {
+  kind: 'message';
+  id: string;
+  text: string;
+  source: 'reasoning' | 'notice' | 'toolkit_message';
+  /**
+   * `running` is true while the agent action that emitted this narration is
+   * still in flight (e.g. the matching tool hasn't deactivated yet). Used to
+   * shimmer the inline text and to drive the live status row.
+   */
+  running: boolean;
+  /** Stable handle so DEACTIVATE_TOOLKIT can flip the sibling narration off. */
+  pairKey: string | null;
+};
+
+export type TimelineItem = ToolItem | MessageItem;
+
 /**
- * One "action" — a bounded unit of agent work delimited by either an
- * `ACTIVATE_AGENT` message (reasoning for the next tool burst) or an
- * agent-id change in the chronological log.
+ * One agent's slice of work — a chronological list of inline messages
+ * (reasoning, notices, toolkit narration) and tool rows. Renders flat: the
+ * only foldable element inside is each tool's input/output detail.
  */
-export type ActionGroup = {
+export type AgentBlock = {
   id: string;
   agentId: string;
   agentType: string;
   agentName: string;
-  /** The reasoning text from ACTIVATE_AGENT, if one bounded this group. */
-  reasoning: string | null;
-  /** `NOTICE` messages collected while this group was active. */
-  notices: string[];
-  /** Tool invocations that fired while this group was active. */
-  tools: ToolSegment[];
-  /**
-   * `running` until either a newer group starts, the agent emits
-   * `DEACTIVATE_AGENT`, or the overall task leaves RUNNING. The component
-   * re-derives final status with the task-level context.
-   */
+  items: TimelineItem[];
   status: 'running' | 'done';
   /**
-   * `preparation` is the synthetic group that collapses the workforce's
-   * leading `register agent` toolkit calls into one "Preparing agents" row.
-   * Everything else is `action`.
+   * `preparation` is the synthetic block that collapses the workforce's
+   * leading/lazy `register agent` toolkit calls into one "Preparing agents"
+   * row. Everything else is `action`.
    */
   kind: 'preparation' | 'action';
 };
 
-const PREPARATION_GROUP_ID = 'g-prep';
-const PREPARATION_GROUP_LABEL = 'Preparing agents';
+const PREPARATION_BLOCK_ID = 'b-prep';
+const PREPARATION_BLOCK_LABEL = 'Preparing agents';
 
-function isRegisterAgentEvent(entry: AgentMessage): boolean {
+function pairKey(toolkit: string, method: string): string {
+  return `${toolkit}::${method}`;
+}
+
+/**
+ * Toolkit calls that should always land in the synthetic "Preparing agents"
+ * block at the top — agent registration and per-agent browser session
+ * cloning, both of which are workforce setup, not part of the agent's own
+ * action timeline.
+ *
+ * `clone for new session` is `HybridBrowserToolkit.clone_for_new_session`
+ * (the listener replaces underscores with spaces, see
+ * `app/utils/listen/toolkit_listen.py`).
+ */
+const PREPARATION_METHODS: ReadonlySet<string> = new Set([
+  'register agent',
+  'clone for new session',
+]);
+
+function isPreparationEvent(entry: AgentMessage): boolean {
   if (
     entry.step !== AgentStep.ACTIVATE_TOOLKIT &&
     entry.step !== AgentStep.DEACTIVATE_TOOLKIT
   ) {
     return false;
   }
-  return (
-    (entry.data?.method_name ?? '').trim().toLowerCase() === 'register agent'
-  );
+  const method = (entry.data?.method_name ?? '').trim().toLowerCase();
+  return PREPARATION_METHODS.has(method);
 }
 
 /**
  * Exported for unit tests. Folds a tagged, chronological log into
- * `ActionGroup[]`, pairing DEACTIVATE_TOOLKIT with the most recent matching
- * running tool inside the active group.
+ * `AgentBlock[]`, preserving the wall-clock order of messages and tools
+ * inside each block.
  */
-export function buildActionGroups(tagged: TaggedLog[]): ActionGroup[] {
-  const groups: ActionGroup[] = [];
-  const cursor: { current: ActionGroup | null } = { current: null };
-  let prep: ActionGroup | null = null;
+export function buildAgentBlocks(tagged: TaggedLog[]): AgentBlock[] {
+  const blocks: AgentBlock[] = [];
+  const cursor: { current: AgentBlock | null } = { current: null };
+  let prep: AgentBlock | null = null;
 
   // The workforce factory wires up agents via `register agent` toolkit calls.
   // Those calls can appear as a leading burst *and* sprinkled in mid-run
-  // whenever a new specialist (e.g. a multi-modal agent) is lazily registered
-  // after another agent has already started acting. We always route them to
-  // a single synthetic "Preparing agents" group pinned at the top so the
-  // currently-active agent's action group is not interrupted by registration
-  // noise.
-  const ensurePrep = (): ActionGroup => {
+  // whenever a new specialist is lazily registered after another agent has
+  // already started acting. We always route them to a single synthetic
+  // "Preparing agents" block pinned at the top so the currently-active
+  // agent's timeline is not interrupted by registration noise.
+  const ensurePrep = (): AgentBlock => {
     if (!prep) {
       prep = {
-        id: PREPARATION_GROUP_ID,
+        id: PREPARATION_BLOCK_ID,
         agentId: '__prep__',
         agentType: '__prep__',
-        agentName: PREPARATION_GROUP_LABEL,
-        reasoning: null,
-        notices: [],
-        tools: [],
+        agentName: PREPARATION_BLOCK_LABEL,
+        items: [],
         status: 'running',
         kind: 'preparation',
       };
-      groups.unshift(prep);
+      blocks.unshift(prep);
     }
     return prep;
   };
 
-  const appendRegisterEvent = (tag: TaggedLog, idx: number) => {
+  const appendPreparationEvent = (tag: TaggedLog, idx: number) => {
     const p = ensurePrep();
     const entry = tag.entry;
     const name = (entry.data?.toolkit_name ?? '').trim() || 'Tool';
@@ -208,50 +246,48 @@ export function buildActionGroups(tagged: TaggedLog[]): ActionGroup[] {
     const rawMsg = normalizeToolkitMessage(entry.data?.message).trim();
 
     if (entry.step === AgentStep.ACTIVATE_TOOLKIT) {
-      p.tools.push({
+      p.items.push({
+        kind: 'tool',
         id: `t-prep-${idx}`,
         rowTitle: `${tag.agentName} · ${name}`,
         toolkitName: name,
         method,
-        summary: formatToolSummary(name, method, rawMsg),
         detail: rawMsg,
         status: 'running',
       });
       return;
     }
 
-    for (let j = p.tools.length - 1; j >= 0; j--) {
-      const s = p.tools[j]!;
-      if (s.status !== 'running') continue;
-      if (s.toolkitName !== name || s.method !== method) continue;
-      s.status = 'done';
-      s.detail = [s.detail, rawMsg].filter(Boolean).join('\n\n').trim();
-      s.summary = formatToolSummary(name, method, s.detail);
+    for (let j = p.items.length - 1; j >= 0; j--) {
+      const it = p.items[j]!;
+      if (it.kind !== 'tool') continue;
+      if (it.status !== 'running') continue;
+      if (it.toolkitName !== name || it.method !== method) continue;
+      it.status = 'done';
+      it.detail = [it.detail, rawMsg].filter(Boolean).join('\n\n').trim();
       break;
     }
   };
 
-  const startNew = (tag: TaggedLog, reasoning: string | null): ActionGroup => {
-    const g: ActionGroup = {
-      id: `g-${groups.length}-${tag.agentId}`,
+  const startNew = (tag: TaggedLog): AgentBlock => {
+    const b: AgentBlock = {
+      id: `b-${blocks.length}-${tag.agentId}`,
       agentId: tag.agentId,
       agentType: tag.agentType,
       agentName: tag.agentName,
-      reasoning,
-      notices: [],
-      tools: [],
+      items: [],
       status: 'running',
       kind: 'action',
     };
-    groups.push(g);
-    cursor.current = g;
-    return g;
+    blocks.push(b);
+    cursor.current = b;
+    return b;
   };
 
-  const ensureGroupForAgent = (tag: TaggedLog): ActionGroup => {
+  const ensureBlockForAgent = (tag: TaggedLog): AgentBlock => {
     const c = cursor.current;
     if (!c || c.kind === 'preparation' || c.agentId !== tag.agentId) {
-      return startNew(tag, null);
+      return startNew(tag);
     }
     return c;
   };
@@ -260,14 +296,24 @@ export function buildActionGroups(tagged: TaggedLog[]): ActionGroup[] {
     const tag = tagged[i]!;
     const { entry } = tag;
 
-    if (isRegisterAgentEvent(entry)) {
-      appendRegisterEvent(tag, i);
+    if (isPreparationEvent(entry)) {
+      appendPreparationEvent(tag, i);
       continue;
     }
 
     if (entry.step === AgentStep.ACTIVATE_AGENT) {
       const text = normalizeToolkitMessage(entry.data?.message).trim();
-      startNew(tag, text || null);
+      const b = startNew(tag);
+      if (text) {
+        b.items.push({
+          kind: 'message',
+          id: `m-${i}`,
+          text,
+          source: 'reasoning',
+          running: false,
+          pairKey: null,
+        });
+      }
       continue;
     }
 
@@ -277,25 +323,67 @@ export function buildActionGroups(tagged: TaggedLog[]): ActionGroup[] {
       continue;
     }
 
+    if (entry.step === AgentStep.NOTICE) {
+      const text = normalizeToolkitMessage(
+        entry.data?.notice ?? entry.data?.message
+      ).trim();
+      if (!text) continue;
+      ensureBlockForAgent(tag).items.push({
+        kind: 'message',
+        id: `m-${i}`,
+        text,
+        source: 'notice',
+        running: false,
+        pairKey: null,
+      });
+      continue;
+    }
+
     if (entry.step === AgentStep.ACTIVATE_TOOLKIT) {
       const name = (entry.data?.toolkit_name ?? '').trim() || 'Tool';
       const method = (entry.data?.method_name ?? '').trim();
       const rawMsg = normalizeToolkitMessage(entry.data?.message).trim();
 
+      // Backend sometimes emits "notice" through the toolkit channel.
       if (name.toLowerCase() === 'notice') {
-        if (rawMsg) ensureGroupForAgent(tag).notices.push(rawMsg);
+        if (rawMsg) {
+          ensureBlockForAgent(tag).items.push({
+            kind: 'message',
+            id: `m-${i}`,
+            text: rawMsg,
+            source: 'notice',
+            running: false,
+            pairKey: null,
+          });
+        }
         continue;
       }
 
       if (!method && !rawMsg) continue;
 
-      const g = ensureGroupForAgent(tag);
-      g.tools.push({
+      const b = ensureBlockForAgent(tag);
+      const pk = pairKey(name, method);
+
+      // Show narration above the tool row so the user always sees what the
+      // agent is doing, even with the fold closed. Payload-shaped messages
+      // stay inside the fold to avoid clutter.
+      if (looksLikeNarration(rawMsg)) {
+        b.items.push({
+          kind: 'message',
+          id: `m-${i}-narr`,
+          text: rawMsg,
+          source: 'toolkit_message',
+          running: true,
+          pairKey: pk,
+        });
+      }
+
+      b.items.push({
+        kind: 'tool',
         id: `t-${i}`,
         rowTitle: toolRowTitle(name, method),
         toolkitName: name,
         method,
-        summary: formatToolSummary(name, method, rawMsg),
         detail: rawMsg,
         status: 'running',
       });
@@ -308,50 +396,97 @@ export function buildActionGroups(tagged: TaggedLog[]): ActionGroup[] {
       const name = (entry.data?.toolkit_name ?? '').trim();
       const method = (entry.data?.method_name ?? '').trim();
       const msg = normalizeToolkitMessage(entry.data?.message).trim();
+      const pk = pairKey(name, method);
 
-      for (let j = cur.tools.length - 1; j >= 0; j--) {
-        const s = cur.tools[j]!;
-        if (s.status !== 'running') continue;
-        if (s.toolkitName !== name || s.method !== method) continue;
-        s.status = 'done';
-        s.detail = [s.detail, msg].filter(Boolean).join('\n\n').trim();
-        s.summary = formatToolSummary(name, method, s.detail);
+      // Match the most recent running tool of the same toolkit/method.
+      for (let j = cur.items.length - 1; j >= 0; j--) {
+        const it = cur.items[j]!;
+        if (it.kind !== 'tool') continue;
+        if (it.status !== 'running') continue;
+        if (it.toolkitName !== name || it.method !== method) continue;
+        it.status = 'done';
+        it.detail = [it.detail, msg].filter(Boolean).join('\n\n').trim();
+        break;
+      }
+
+      // Settle the sibling narration message (if any) that paired with this
+      // tool — turns off the shimmer once the tool is done.
+      for (let j = cur.items.length - 1; j >= 0; j--) {
+        const it = cur.items[j]!;
+        if (it.kind !== 'message') continue;
+        if (it.pairKey !== pk) continue;
+        if (!it.running) continue;
+        it.running = false;
         break;
       }
     }
   }
 
-  // A non-last group is always done (a newer group started). The last group
+  // A non-last block is always done (a newer block started). The last block
   // inherits the most recent explicit transition; component-level logic may
-  // still force all groups to 'done' when the task leaves RUNNING.
-  for (let i = 0; i < groups.length - 1; i++) {
-    groups[i]!.status = 'done';
+  // still force all blocks to 'done' when the task leaves RUNNING.
+  for (let i = 0; i < blocks.length - 1; i++) {
+    blocks[i]!.status = 'done';
   }
 
-  return groups;
+  return blocks;
 }
 
-/** Title shown on a group header. Prefers reasoning; falls back to the latest tool. */
-export function getGroupTitle(group: ActionGroup): string {
-  if (group.reasoning) return group.reasoning;
-  const last = group.tools[group.tools.length - 1];
-  if (last) return last.rowTitle;
-  return 'Thinking…';
-}
+type BlockHeaderParts = {
+  /** Static agent label, e.g. "Browser Agent" or "Preparing agents". */
+  agentLabel: string;
+  /**
+   * The right-hand subtitle that tracks the latest tool/state for this
+   * block. `null` when there's nothing to show (e.g. an empty action block
+   * that already finished, or a preparation block with no register events
+   * yet).
+   */
+  detail: string | null;
+  /** Whether `detail` should render with the running shimmer. */
+  detailRunning: boolean;
+};
 
-function getGroupHeaderTitle(group: ActionGroup): string {
-  if (group.kind === 'preparation') {
-    return group.tools.length > 0
-      ? `${group.agentName} · ${group.tools.length} Registered`
-      : group.agentName;
+/**
+ * Splits a block's collapsed-header into agent label + dynamically-tracking
+ * detail. The detail is the latest tool's `Toolkit · Method` for action
+ * blocks, "Thinking…" while a running block has no tool yet, or
+ * "N Registered" for the preparation block.
+ *
+ * Exported for testing — callers should not assume the precise wording.
+ */
+export function getBlockHeaderParts(block: AgentBlock): BlockHeaderParts {
+  if (block.kind === 'preparation') {
+    const toolCount = block.items.filter((i) => i.kind === 'tool').length;
+    return {
+      agentLabel: block.agentName,
+      detail: toolCount > 0 ? `${toolCount} Registered` : null,
+      detailRunning: false,
+    };
   }
 
-  const lastTool = group.tools[group.tools.length - 1];
-  if (!lastTool) return `${group.agentName} · Thinking…`;
+  let latestTool: ToolItem | null = null;
+  for (let i = block.items.length - 1; i >= 0; i--) {
+    const item = block.items[i]!;
+    if (item.kind === 'tool') {
+      latestTool = item;
+      break;
+    }
+  }
 
-  const parts = [group.agentName, lastTool.toolkitName];
-  if (lastTool.method) parts.push(titleCaseMethod(lastTool.method));
-  return parts.join(' · ');
+  if (!latestTool) {
+    return {
+      agentLabel: block.agentName,
+      detail: block.status === 'running' ? 'Thinking…' : null,
+      detailRunning: block.status === 'running',
+    };
+  }
+
+  return {
+    agentLabel: block.agentName,
+    detail: toolRowTitle(latestTool.toolkitName, latestTool.method),
+    detailRunning:
+      latestTool.status === 'running' && block.status === 'running',
+  };
 }
 
 /**
@@ -395,12 +530,12 @@ function useTaskWorkLogData(
 ) {
   void _snapshot;
   if (!taskId) {
-    return { task: undefined, groups: [] as ActionGroup[] };
+    return { task: undefined, blocks: [] as AgentBlock[] };
   }
   const t = chatStore.getState().tasks[taskId];
   const tagged = mergeTaggedAgentLogs(t?.taskAssigning);
-  const groups = buildActionGroups(tagged);
-  return { task: t, groups };
+  const blocks = buildAgentBlocks(tagged);
+  return { task: t, blocks };
 }
 
 function useWorkLogElapsedMs(
@@ -460,16 +595,16 @@ const ToolDetailRow = memo(function ToolDetailRow({
         type="button"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
-        className="group min-w-0 gap-1 py-0.5 inline-flex max-w-full items-center self-start text-left transition-opacity hover:opacity-80"
+        className="group min-w-0 gap-1 px-0 py-0.5 inline-flex max-w-full items-center self-start text-left transition-opacity hover:opacity-80"
       >
         {status === 'running' ? (
           <ShinyText
             text={rowTitle}
             speed={2.5}
-            className="!text-label-xs font-medium min-w-0 text-ds-text-neutral-subtle-default shrink overflow-hidden text-ellipsis whitespace-nowrap"
+            className="!text-label-sm font-normal min-w-0 text-ds-text-neutral-subtle-default shrink overflow-hidden text-ellipsis whitespace-nowrap"
           />
         ) : (
-          <span className="!text-label-xs font-medium min-w-0 text-ds-text-neutral-subtle-default shrink overflow-hidden text-ellipsis whitespace-nowrap">
+          <span className="!text-label-sm font-normal min-w-0 text-ds-text-neutral-subtle-default shrink overflow-hidden text-ellipsis whitespace-nowrap">
             {rowTitle}
           </span>
         )}
@@ -517,42 +652,98 @@ const ToolDetailRow = memo(function ToolDetailRow({
 });
 ToolDetailRow.displayName = 'ToolDetailRow';
 
-const ActionGroupRow = memo(function ActionGroupRow({
-  group,
-  isLastRunning,
+const InlineMessageRow = memo(function InlineMessageRow({
+  text,
+  source,
+  running,
+}: {
+  text: string;
+  source: MessageItem['source'];
+  running: boolean;
+}) {
+  const display =
+    source === 'toolkit_message'
+      ? truncateText(text, TOOL_INLINE_PREVIEW_MAX)
+      : text;
+  // Reasoning is the agent's primary narration ("open DuckDuckGo to search
+  // for…"); render at default text intensity. Notices and toolkit-message
+  // narration stay subtle so the eye stays on tool titles + reasoning.
+  const colorClass =
+    source === 'reasoning'
+      ? 'text-ds-text-neutral-subtle-default'
+      : 'text-ds-text-neutral-default-default';
+  return (
+    <div className="min-w-0 w-full">
+      {running ? (
+        <ShinyText
+          text={display}
+          speed={2.5}
+          className={cn(
+            '!text-label-sm font-normal break-words whitespace-pre-wrap',
+            colorClass
+          )}
+        />
+      ) : (
+        <span
+          className={cn(
+            '!text-label-sm m-0 font-medium break-words whitespace-pre-wrap',
+            colorClass
+          )}
+        >
+          {display}
+        </span>
+      )}
+    </div>
+  );
+});
+InlineMessageRow.displayName = 'InlineMessageRow';
+
+const AgentBlockRow = memo(function AgentBlockRow({
+  block,
   taskRunning,
   open,
   onToggle,
 }: {
-  group: ActionGroup;
-  isLastRunning: boolean;
+  block: AgentBlock;
   taskRunning: boolean;
   open: boolean;
   onToggle: () => void;
 }) {
-  const running = group.status === 'running' || isLastRunning;
-  const headerTitle = getGroupHeaderTitle(group);
+  const { agentLabel, detail, detailRunning } = getBlockHeaderParts(block);
 
+  // Agent label is static. The detail tracks the latest toolkit/method for
+  // this agent and shimmers while that tool is still running — that's the
+  // user's "live" cue, in the row that owns the work.
   return (
     <div className="min-w-0 flex w-full flex-col">
       <button
         type="button"
         aria-expanded={open}
         onClick={onToggle}
-        className="min-w-0 gap-2 py-1 my-1 flex w-fit max-w-full items-center text-left transition-opacity hover:opacity-80"
+        className="min-w-0 gap-2 py-1 px-0 my-1 flex w-fit max-w-full items-center text-left transition-opacity hover:opacity-80"
       >
-        <span className="text-label-sm font-normal min-w-0 max-w-full truncate">
-          {running ? (
-            <ShinyText
-              text={headerTitle}
-              speed={2.5}
-              className="text-label-sm font-normal text-ds-text-neutral-muted-default truncate"
-            />
-          ) : (
-            <span className="text-ds-text-neutral-muted-default">
-              {headerTitle}
-            </span>
-          )}
+        <span className="min-w-0 gap-1.5 inline-flex max-w-full items-baseline truncate">
+          <span className="text-label-sm font-normal text-ds-text-neutral-muted-default">
+            {agentLabel}
+          </span>
+          {detail ? (
+            <>
+              <span className="text-label-sm text-ds-text-neutral-subtle-default">
+                ·
+              </span>
+              {detailRunning ? (
+                <ShinyText
+                  text={detail}
+                  speed={2.5}
+                  className="text-label-sm font-normal text-ds-text-neutral-subtle-default truncate"
+                />
+              ) : (
+                <span className="text-label-sm font-normal text-ds-text-neutral-subtle-default truncate">
+                  {detail}
+                </span>
+              )}
+            </>
+          ) : null}
         </span>
         {open ? (
           <ChevronDown
@@ -572,7 +763,7 @@ const ActionGroupRow = memo(function ActionGroupRow({
       <AnimatePresence initial={false}>
         {open ? (
           <motion.div
-            key="group-body"
+            key="block-body"
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
@@ -580,38 +771,36 @@ const ActionGroupRow = memo(function ActionGroupRow({
             className="min-w-0 overflow-hidden"
           >
             <div className="py-1 gap-2 flex flex-col">
-              {group.reasoning ? (
-                <p className="text-label-sm text-ds-text-neutral-subtle-default break-words whitespace-pre-wrap">
-                  {group.reasoning}
-                </p>
-              ) : null}
-              {group.notices.map((notice, i) => (
-                <p
-                  key={`n-${i}`}
-                  className="text-label-sm text-ds-text-neutral-subtle-default break-words whitespace-pre-wrap"
-                >
-                  {notice}
-                </p>
-              ))}
-              {group.tools.map((tool) => (
-                <ToolDetailRow
-                  key={tool.id}
-                  rowTitle={tool.rowTitle}
-                  detail={tool.detail}
-                  status={
-                    taskRunning &&
-                    group.status === 'running' &&
-                    tool.status === 'running'
-                      ? 'running'
-                      : 'done'
-                  }
-                />
-              ))}
-              {group.tools.length === 0 && running && !group.reasoning && (
-                <p className="text-label-sm text-ds-text-neutral-subtle-default italic">
-                  Waiting for tool calls…
-                </p>
+              {block.items.map((item) =>
+                item.kind === 'message' ? (
+                  <InlineMessageRow
+                    key={item.id}
+                    text={item.text}
+                    source={item.source}
+                    running={item.running && taskRunning}
+                  />
+                ) : (
+                  <ToolDetailRow
+                    key={item.id}
+                    rowTitle={item.rowTitle}
+                    detail={item.detail}
+                    status={
+                      taskRunning &&
+                      block.status === 'running' &&
+                      item.status === 'running'
+                        ? 'running'
+                        : 'done'
+                    }
+                  />
+                )
               )}
+              {block.items.length === 0 &&
+                taskRunning &&
+                block.status === 'running' && (
+                  <p className="!text-label-sm text-ds-text-neutral-subtle-default m-0 italic">
+                    Waiting for tool calls…
+                  </p>
+                )}
             </div>
           </motion.div>
         ) : null}
@@ -619,17 +808,18 @@ const ActionGroupRow = memo(function ActionGroupRow({
     </div>
   );
 });
-ActionGroupRow.displayName = 'ActionGroupRow';
+AgentBlockRow.displayName = 'AgentBlockRow';
 
 /**
- * Per-group open state with user override.
- * - Default: every group is folded.
- * - User clicks set an override for the current phase only. When a group
- *   transitions running → done, its override is cleared so auto-fold wins
- *   unless the user toggles again after the transition.
+ * Per-block open state with user override.
+ * - Default: running blocks are open (so the live timeline is visible),
+ *   finished blocks are closed.
+ * - User clicks set an override for the current phase only. When a block
+ *   transitions running → done, its override is cleared so the auto-default
+ *   wins again unless the user toggles after the transition.
  */
-function useGroupOpenState(groups: ActionGroup[]): {
-  isOpen: (group: ActionGroup) => boolean;
+function useBlockOpenState(blocks: AgentBlock[]): {
+  isOpen: (block: AgentBlock) => boolean;
   toggle: (id: string) => void;
 } {
   // key → open flag. Key is `${id}:${phase}` so each phase owns its override.
@@ -639,14 +829,12 @@ function useGroupOpenState(groups: ActionGroup[]): {
   useEffect(() => {
     const prev = prevStatusRef.current;
     const next = new Map<string, 'running' | 'done'>();
-    for (const g of groups) next.set(g.id, g.status);
+    for (const b of blocks) next.set(b.id, b.status);
     prevStatusRef.current = next;
 
-    // Drop overrides whose group disappeared, plus running-phase overrides
-    // for any group that just flipped to done.
     setOverrides((current) => {
       if (current.size === 0) return current;
-      const live = new Set(groups.map((g) => g.id));
+      const live = new Set(blocks.map((b) => b.id));
       let changed = false;
       const updated = new Map(current);
       for (const key of current.keys()) {
@@ -661,19 +849,19 @@ function useGroupOpenState(groups: ActionGroup[]): {
           changed = true;
         }
       }
-      // No-op branch: also track that prev tracked running transitioning away.
       void prev;
       return changed ? updated : current;
     });
-  }, [groups]);
+  }, [blocks]);
 
-  const phaseKey = (group: ActionGroup) => `${group.id}:${group.status}`;
+  const phaseKey = (block: AgentBlock) => `${block.id}:${block.status}`;
 
   const isOpen = useCallback(
-    (group: ActionGroup) => {
-      const override = overrides.get(phaseKey(group));
+    (block: AgentBlock) => {
+      const override = overrides.get(phaseKey(block));
       if (override !== undefined) return override;
-      return false;
+      // Auto: open the running action block; closed for everything else.
+      return block.kind === 'action' && block.status === 'running';
     },
     [overrides]
   );
@@ -681,18 +869,17 @@ function useGroupOpenState(groups: ActionGroup[]): {
   const toggle = useCallback(
     (id: string) => {
       setOverrides((prev) => {
-        const group = groups.find((g) => g.id === id);
-        if (!group) return prev;
-        const key = `${group.id}:${group.status}`;
-        const currentlyOpen = prev.has(key)
-          ? (prev.get(key) as boolean)
-          : false;
+        const block = blocks.find((b) => b.id === id);
+        if (!block) return prev;
+        const key = `${block.id}:${block.status}`;
+        const auto = block.kind === 'action' && block.status === 'running';
+        const currentlyOpen = prev.has(key) ? (prev.get(key) as boolean) : auto;
         const next = new Map(prev);
         next.set(key, !currentlyOpen);
         return next;
       });
     },
-    [groups]
+    [blocks]
   );
 
   return { isOpen, toggle };
@@ -711,21 +898,28 @@ export function TaskWorkLogAccordion({
 }: TaskWorkLogAccordionProps) {
   const { t: _t } = useTranslation();
   const snapshot = useTaskWorkStoreSnapshot(chatStore, taskId);
-  const { task, groups } = useTaskWorkLogData(chatStore, taskId, snapshot);
+  const { task, blocks } = useTaskWorkLogData(chatStore, taskId, snapshot);
   const status = task?.status;
   const elapsedMs = useWorkLogElapsedMs(chatStore, taskId, snapshot);
   const taskRunning = status === ChatTaskStatus.RUNNING;
 
-  // Normalize group status with task-level context — once the task stops,
-  // every group is done regardless of whether DEACTIVATE_AGENT arrived.
-  const effectiveGroups = useMemo(() => {
-    if (taskRunning) return groups;
-    return groups.map((g) =>
-      g.status === 'done' ? g : { ...g, status: 'done' as const }
-    );
-  }, [groups, taskRunning]);
+  // Normalize block status with task-level context — once the task stops,
+  // every block (and any running message/tool) is done regardless of whether
+  // DEACTIVATE_AGENT / DEACTIVATE_TOOLKIT actually arrived.
+  const effectiveBlocks = useMemo(() => {
+    if (taskRunning) return blocks;
+    return blocks.map((b) => ({
+      ...b,
+      status: 'done' as const,
+      items: b.items.map((it) =>
+        it.kind === 'tool'
+          ? { ...it, status: 'done' as const }
+          : { ...it, running: false }
+      ),
+    }));
+  }, [blocks, taskRunning]);
 
-  const { isOpen, toggle } = useGroupOpenState(effectiveGroups);
+  const { isOpen, toggle } = useBlockOpenState(effectiveBlocks);
 
   const [outerOpen, setOuterOpen] = useState(() => taskRunning);
 
@@ -745,7 +939,7 @@ export function TaskWorkLogAccordion({
     status === ChatTaskStatus.PAUSE;
 
   if (!allowed) return null;
-  if (!taskRunning && effectiveGroups.length === 0) return null;
+  if (!taskRunning && effectiveBlocks.length === 0) return null;
 
   const timeLabel = formatSplittingElapsed(elapsedMs);
 
@@ -755,7 +949,7 @@ export function TaskWorkLogAccordion({
         type="button"
         aria-expanded={outerOpen}
         onClick={() => setOuterOpen((v) => !v)}
-        className="gap-1 py-2 min-w-0 flex w-full items-center justify-start text-left"
+        className="gap-1 py-2 px-0 min-w-0 flex w-full items-center justify-start text-left"
       >
         <span className="text-body-sm font-medium text-ds-text-neutral-muted-default">
           {status === ChatTaskStatus.RUNNING ||
@@ -809,22 +1003,15 @@ export function TaskWorkLogAccordion({
             className="overflow-hidden"
           >
             <div className="gap-1 pb-1 min-w-0 flex flex-col">
-              {effectiveGroups.map((group, i) => {
-                const isLastRunning =
-                  taskRunning &&
-                  i === effectiveGroups.length - 1 &&
-                  group.status === 'running';
-                return (
-                  <ActionGroupRow
-                    key={group.id}
-                    group={group}
-                    isLastRunning={isLastRunning}
-                    taskRunning={taskRunning}
-                    open={isOpen(group)}
-                    onToggle={() => toggle(group.id)}
-                  />
-                );
-              })}
+              {effectiveBlocks.map((block) => (
+                <AgentBlockRow
+                  key={block.id}
+                  block={block}
+                  taskRunning={taskRunning}
+                  open={isOpen(block)}
+                  onToggle={() => toggle(block.id)}
+                />
+              ))}
             </div>
           </motion.div>
         ) : null}

--- a/src/components/ChatBox/MessageItem/UserMessageCard.tsx
+++ b/src/components/ChatBox/MessageItem/UserMessageCard.tsx
@@ -131,7 +131,7 @@ export function UserMessageCard({
 
   return (
     <div key={id} className={cn('group/msg relative w-full', className)}>
-      <div className="rounded-xl py-2 px-4 bg-ds-bg-neutral-default-default w-full overflow-visible">
+      <div className="rounded-xl py-2 px-4 bg-ds-bg-neutral-subtle-default border-ds-border-neutral-muted-default w-full overflow-visible border border-solid">
         {attaches && attaches.length > 0 && (
           <div className="mb-2 gap-1 relative box-border flex w-full flex-wrap items-start">
             {(() => {
@@ -174,7 +174,7 @@ export function UserMessageCard({
                         {/* File Name */}
                         <p
                           className={cn(
-                            "my-0 text-xs font-bold leading-tight relative min-h-px min-w-px flex-1 overflow-hidden font-['Inter'] overflow-ellipsis whitespace-nowrap text-ds-text-neutral-default-default"
+                            "my-0 text-xs font-bold leading-tight text-ds-text-neutral-default-default relative min-h-px min-w-px flex-1 overflow-hidden font-['Inter'] overflow-ellipsis whitespace-nowrap"
                           )}
                           title={file.fileName}
                         >
@@ -195,14 +195,14 @@ export function UserMessageCard({
                           size="xs"
                           buttonContent="text"
                           variant="ghost"
-                          className="rounded-lg relative flex items-center bg-ds-bg-neutral-strong-default"
+                          className="rounded-lg bg-ds-bg-neutral-strong-default relative flex items-center"
                           onMouseEnter={openRemainingPopover}
                           onMouseLeave={scheduleCloseRemainingPopover}
                           onClick={(e) => {
                             e.stopPropagation();
                           }}
                         >
-                          <span className="text-label-xs font-bold leading-tight font-['Inter'] whitespace-nowrap text-ds-text-neutral-default-default">
+                          <span className="text-label-xs font-bold leading-tight text-ds-text-neutral-default-default font-['Inter'] whitespace-nowrap">
                             {remainingCount}+
                           </span>
                         </Button>
@@ -210,7 +210,7 @@ export function UserMessageCard({
                       <PopoverContent
                         align="end"
                         sideOffset={4}
-                        className="max-w-40 rounded-md p-1 shadow-perfect !w-auto border border-ds-border-neutral-subtle-default bg-ds-bg-neutral-default-default"
+                        className="max-w-40 rounded-md p-1 shadow-perfect border-ds-border-neutral-subtle-default bg-ds-bg-neutral-default-default !w-auto border"
                         onMouseEnter={openRemainingPopover}
                         onMouseLeave={scheduleCloseRemainingPopover}
                       >
@@ -219,7 +219,7 @@ export function UserMessageCard({
                             return (
                               <div
                                 key={file.filePath}
-                                className="gap-1 rounded-lg py-0.5 flex cursor-pointer items-center bg-ds-bg-neutral-strong-default transition-colors duration-300 hover:bg-ds-bg-neutral-default-hover"
+                                className="gap-1 rounded-lg py-0.5 bg-ds-bg-neutral-strong-default hover:bg-ds-bg-neutral-default-hover flex cursor-pointer items-center transition-colors duration-300"
                                 onMouseLeave={() =>
                                   setHoveredFilePath((prev) =>
                                     prev === file.filePath ? null : prev
@@ -237,7 +237,7 @@ export function UserMessageCard({
                                 <div className="h-6 w-6 rounded-md flex items-center justify-center">
                                   {getFileIcon(file.fileName)}
                                 </div>
-                                <p className="my-0 text-xs font-bold leading-tight flex-1 overflow-hidden font-['Inter'] text-ellipsis whitespace-nowrap text-ds-text-neutral-default-default">
+                                <p className="my-0 text-xs font-bold leading-tight text-ds-text-neutral-default-default flex-1 overflow-hidden font-['Inter'] text-ellipsis whitespace-nowrap">
                                   {file.fileName}
                                 </p>
                               </div>

--- a/src/components/ChatBox/ProjectChatContainer.tsx
+++ b/src/components/ChatBox/ProjectChatContainer.tsx
@@ -161,6 +161,29 @@ export const ProjectChatContainer: React.FC<ProjectChatContainerProps> = ({
     setScrollToQueryId(null);
   }, [scrollToQueryId, setScrollToQueryId]);
 
+  // Surface the task box when the side-panel Progress section asks for it.
+  // TaskCard listens to the same counter to expand itself; we own the
+  // scroll. The `data-task-card="true"` attribute is set on a query
+  // group's outer wrapper only when its TaskCard is currently visible.
+  const taskBoxFocusRequestId = usePageTabStore((s) => s.taskBoxFocusRequestId);
+  useEffect(() => {
+    if (!taskBoxFocusRequestId) return;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const matches = container.querySelectorAll<HTMLElement>(
+      '[data-task-card="true"]'
+    );
+    const target = matches[matches.length - 1];
+    if (!target) return;
+    // TaskCard's expand transition is ~300ms; do the scroll after a tick
+    // so the card has started animating, but anchor on its top edge so
+    // the final position is stable regardless of how tall it grows.
+    const containerRect = container.getBoundingClientRect();
+    const elRect = target.getBoundingClientRect();
+    const scrollOffset = elRect.top - containerRect.top + container.scrollTop;
+    container.scrollTo({ top: scrollOffset, behavior: 'smooth' });
+  }, [taskBoxFocusRequestId, scrollContainerRef]);
+
   return (
     <div className={`relative z-10 w-full ${className}`}>
       <div

--- a/src/components/ChatBox/TaskBox/TaskCard.tsx
+++ b/src/components/ChatBox/TaskBox/TaskCard.tsx
@@ -19,6 +19,7 @@ import { TaskItem } from './TaskItem';
 
 import { TaskState, TaskStateType } from '@/components/TaskState';
 import useChatStoreAdapter from '@/hooks/useChatStoreAdapter';
+import { usePageTabStore } from '@/store/pageTabStore';
 import { ChatTaskStatus, TaskStatus } from '@/types/constants';
 import {
   ChevronDown,
@@ -118,6 +119,18 @@ export function TaskCard({
   useEffect(() => {
     writeStoredTaskCardExpanded(expandStorageKey, isExpanded);
   }, [expandStorageKey, isExpanded]);
+
+  // Side-panel Progress section can ask the chat to surface this card. Each
+  // bump of the counter forces the card open; ProjectChatContainer handles
+  // the scroll. Skip the initial value so we don't pop on mount.
+  const taskBoxFocusRequestId = usePageTabStore((s) => s.taskBoxFocusRequestId);
+  const lastSeenFocusRef = useRef(taskBoxFocusRequestId);
+  useEffect(() => {
+    if (taskBoxFocusRequestId !== lastSeenFocusRef.current) {
+      lastSeenFocusRef.current = taskBoxFocusRequestId;
+      setIsExpanded(true);
+    }
+  }, [taskBoxFocusRequestId]);
 
   useEffect(() => {
     const tasks = taskRunning || [];

--- a/src/components/ChatBox/UserQueryGroup.tsx
+++ b/src/components/ChatBox/UserQueryGroup.tsx
@@ -47,26 +47,26 @@ const AgentResultCard: React.FC<{
   const label = agentName || 'Agent';
 
   return (
-    <div className="overflow-hidden px-2">
+    <div className="px-2 overflow-hidden">
       {/* Header (always visible) */}
       <button
         type="button"
-        className="focus-visible:ring-ds-border-brand-default-focus/40 flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-semibold text-ds-text-neutral-default-default transition-colors hover:bg-ds-bg-neutral-default-hover focus-visible:outline-none focus-visible:ring-2 active:bg-ds-bg-neutral-default-active"
+        className="focus-visible:ring-ds-border-brand-default-focus/40 gap-2 rounded-xl px-3 py-2 text-sm font-semibold text-ds-text-neutral-default-default hover:bg-ds-bg-neutral-default-hover active:bg-ds-bg-neutral-default-active flex w-full items-center text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
         onClick={() => setIsOpen((v) => !v)}
       >
         <span className="min-w-0 flex-1 truncate">{label}</span>
         <ChevronDown
           size={14}
           aria-hidden
-          className={`shrink-0 text-ds-icon-neutral-default-default transition-transform duration-200 ${isOpen ? 'rotate-180' : 'rotate-0'}`}
+          className={`text-ds-icon-neutral-default-default shrink-0 transition-transform duration-200 ${isOpen ? 'rotate-180' : 'rotate-0'}`}
         />
       </button>
 
       {/* Collapsible body */}
       <div
-        className={`overflow-hidden transition-all duration-200 ease-in-out ${isOpen ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}`}
+        className={`ease-in-out overflow-hidden transition-all duration-200 ${isOpen ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}`}
       >
-        <div className="border-t border-ds-border-neutral-default-default px-1 py-1">
+        <div className="border-ds-border-neutral-default-default px-1 py-1 border-t">
           <AgentMessageCard
             id={id}
             content={content}
@@ -324,6 +324,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
     <motion.div
       ref={groupRef}
       data-query-id={queryGroup.queryId}
+      data-task-card={taskCardVisible ? 'true' : undefined}
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{
@@ -352,7 +353,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
       {taskCardVisible && queryGroup.userMessage && (
         <motion.div
           ref={taskBoxRef}
-          className="sticky top-0 z-20"
+          className="top-0 sticky z-20"
           style={{
             position: 'sticky',
             top: 0,
@@ -444,7 +445,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
-                className="flex flex-col gap-4"
+                className="gap-4 flex flex-col"
               >
                 <AgentMessageCard
                   typewriter={shouldUseLiveAgentTypewriter(task, message.id)}
@@ -454,7 +455,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                   onMarkdownRenderComplete={onTaskCompletionMarkdownReady}
                   deferredFooter={
                     message.fileList?.length ? (
-                      <div className="my-2 flex flex-wrap gap-2">
+                      <div className="my-2 gap-2 flex flex-wrap">
                         {message.fileList.map(
                           (file: any, fileIndex: number) => (
                             <motion.div
@@ -465,14 +466,14 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                               onClick={() => {
                                 openFilePreview(file);
                               }}
-                              className="flex w-[140px] cursor-pointer items-center gap-2 rounded-lg bg-ds-bg-neutral-default-default px-3 py-2 transition-colors hover:bg-ds-bg-neutral-default-hover"
+                              className="gap-2 rounded-lg bg-ds-bg-neutral-default-default px-3 py-2 hover:bg-ds-bg-neutral-default-hover flex w-[140px] cursor-pointer items-center transition-colors"
                             >
                               <FileText
                                 size={16}
-                                className="flex-shrink-0 text-ds-icon-neutral-default-default"
+                                className="text-ds-icon-neutral-default-default flex-shrink-0"
                               />
                               <div className="flex flex-col">
-                                <div className="max-w-[100px] overflow-hidden text-ellipsis whitespace-nowrap text-body-sm font-bold text-ds-text-neutral-default-default">
+                                <div className="text-body-sm font-bold text-ds-text-neutral-default-default max-w-[100px] overflow-hidden text-ellipsis whitespace-nowrap">
                                   {file.name.split('.')[0]}
                                 </div>
                                 <div className="text-label-xs font-medium text-ds-text-neutral-muted-default">
@@ -495,7 +496,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
-                className="flex flex-col gap-4"
+                className="gap-4 flex flex-col"
               >
                 <AgentMessageCard
                   key={message.id}
@@ -530,7 +531,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
-                className="flex flex-col gap-4"
+                className="gap-4 flex flex-col"
               >
                 <AgentMessageCard
                   key={message.id}
@@ -550,10 +551,10 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ delay: 0.2 }}
-              className="flex flex-col gap-4"
+              className="gap-4 flex flex-col"
             >
               {message.fileList && (
-                <div className="flex flex-wrap gap-2">
+                <div className="gap-2 flex flex-wrap">
                   {message.fileList.map((file: any, fileIndex: number) => (
                     <motion.div
                       key={`file-${message.id}-${file.name}-${fileIndex}`}
@@ -563,14 +564,14 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                       onClick={() => {
                         openFilePreview(file);
                       }}
-                      className="flex w-[120px] cursor-pointer items-center gap-2 rounded-2xl bg-ds-bg-neutral-default-default px-2 py-1 transition-colors hover:bg-ds-bg-neutral-default-hover"
+                      className="gap-2 rounded-2xl bg-ds-bg-neutral-default-default px-2 py-1 hover:bg-ds-bg-neutral-default-hover flex w-[120px] cursor-pointer items-center transition-colors"
                     >
                       <FileText
                         size={16}
-                        className="flex-shrink-0 text-ds-icon-neutral-default-default"
+                        className="text-ds-icon-neutral-default-default flex-shrink-0"
                       />
                       <div className="flex flex-col">
-                        <div className="text-body max-w-48 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-bold text-ds-text-neutral-default-default">
+                        <div className="text-body max-w-48 text-sm font-bold text-ds-text-neutral-default-default overflow-hidden text-ellipsis whitespace-nowrap">
                           {file.name.split('.')[0]}
                         </div>
                         <div className="text-xs font-medium leading-29 text-ds-text-neutral-default-default">
@@ -606,7 +607,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.25 }}
-            className="mb-md flex flex-col gap-4 px-sm"
+            className="mb-md gap-4 px-sm flex flex-col"
           >
             <TaskCompletionCard
               taskPrompt={queryGroup.userMessage?.content}

--- a/src/components/Session/SidePanelSections/ExecutionContextSection.tsx
+++ b/src/components/Session/SidePanelSections/ExecutionContextSection.tsx
@@ -66,7 +66,7 @@ export function ExecutionContextSection({
           Track skills, MCPs and referenced files used in this task.
         </div>
       ) : (
-        <div className="flex flex-col">
+        <div className="gap-2 flex flex-col">
           {grouped.map(({ category, items: groupItems }) => (
             <div key={category} className="flex flex-col">
               <CategoryLabel>{CATEGORY_LABEL[category]}</CategoryLabel>

--- a/src/components/Session/SidePanelSections/ProgressSection.tsx
+++ b/src/components/Session/SidePanelSections/ProgressSection.tsx
@@ -19,6 +19,8 @@ import {
   ProgressConnector,
   SidePanelListRow,
 } from '@/components/Session/SidePanelSections/primitives';
+import { cn } from '@/lib/utils';
+import { usePageTabStore } from '@/store/pageTabStore';
 import { TaskStatus } from '@/types/constants';
 import { AnimatePresence, motion } from 'framer-motion';
 
@@ -33,6 +35,7 @@ interface ProgressSectionProps {
 
 export function ProgressSection({ title, subtasks }: ProgressSectionProps) {
   const count = subtasks.length;
+  const requestTaskBoxFocus = usePageTabStore((s) => s.requestTaskBoxFocus);
 
   const collapsedStrip =
     count > 0 ? (
@@ -85,10 +88,13 @@ export function ProgressSection({ title, subtasks }: ProgressSectionProps) {
                   transition={{ duration: 0.2, ease: 'easeOut' }}
                 >
                   <SidePanelListRow
-                    className="hover:bg-ds-bg-neutral-subtle-default cursor-pointer"
+                    className="hover:bg-ds-bg-neutral-subtle-default"
                     leading={<ProgressCircle done={isDone(task)} />}
+                    onClick={requestTaskBoxFocus}
                   >
-                    {task.content}
+                    <span className={cn(isDone(task) && 'line-through')}>
+                      {task.content}
+                    </span>
                   </SidePanelListRow>
                 </motion.li>
               ))}

--- a/src/components/Session/SidePanelSections/buildContextItems.ts
+++ b/src/components/Session/SidePanelSections/buildContextItems.ts
@@ -12,22 +12,192 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-import { getToolkitIcon } from '@/lib/toolkitIcons';
-import { FileText } from 'lucide-react';
+import { FileText, Hammer, WandSparkles } from 'lucide-react';
 import { createElement } from 'react';
 import type { ContextItem } from './ExecutionContextSection';
 
-function addHint(set: Set<string>, raw: string) {
-  const t = raw.trim().toLowerCase();
-  if (!t) return;
-  set.add(t);
-  const noToolkit = t.replace(/\s+toolkit\s*$/i, '').trim();
-  if (noToolkit && noToolkit !== t) set.add(noToolkit);
+/**
+ * Minimal shape this builder needs from a skill record. Mirrors the
+ * skillsStore's `Skill` interface but kept local so this module doesn't
+ * depend on the Zustand store.
+ */
+export interface ContextSkill {
+  name: string;
+  enabled: boolean;
+  scope?: { isGlobal?: boolean; selectedAgents?: string[] };
 }
 
-function collectWorkerHintSets(agents: Agent[]) {
+/**
+ * Normalize a toolkit/server/skill name for dedup and hint-matching.
+ * Lowercases, strips whitespace/underscores/hyphens, and drops a trailing
+ * "toolkit" so e.g. "Google Calendar Toolkit", "google_calendar", and
+ * "google-calendar" all collapse to the same key.
+ */
+function normalizeKey(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/\s+toolkit\s*$/i, '')
+    .replace(/[\s_-]+/g, '');
+}
+
+function categoryFromCategoryName(
+  categoryName: string | undefined
+): 'skill' | 'connector' {
+  return (categoryName ?? '').toLowerCase() === 'skill' ? 'skill' : 'connector';
+}
+
+const SKILL_TOOLKIT_NAME = 'SkillToolkit';
+/**
+ * Method names show up in two flavors depending on which path emitted the
+ * event: `@listen_toolkit` rewrites `_` → ` ` ("load skill"), while the
+ * agent's untracked-tool path passes the raw Python identifier
+ * ("load_skill"). We normalize before comparing so both flavors match.
+ */
+const SKILL_LOAD_METHOD = 'load skill';
+const SKILL_LIST_METHOD = 'list skills';
+
+function normalizeMethodName(method: string): string {
+  return method.trim().toLowerCase().replace(/_/g, ' ');
+}
+
+/**
+ * Substring (not word-boundary) checks: backend toolkit class names like
+ * `SkillToolkit` and `XxxMCPToolkit` don't have a word boundary after
+ * "skill"/"mcp", so a `\bskill\b` / `\bmcp\b` regex would silently miss them.
+ */
+function isSkillToolkitName(name: string): boolean {
+  return /skill/i.test(name);
+}
+
+function isMcpToolkitName(name: string): boolean {
+  return /mcp/i.test(name);
+}
+
+/**
+ * Pull skill name(s) out of a `SkillToolkit.load_skill(...)` args string.
+ *
+ * Two emission paths produce two formats:
+ *   1. **Agent path** (`listen_chat_agent._aexecute_tool` /
+ *      `_execute_tool`) emits `message = json.dumps(args)`, e.g.
+ *      `{"name":"pdf"}` or `{"name":["pdf","foo"]}`. This is what
+ *      SkillToolkit currently goes through because its `load_skill` /
+ *      `list_skills` methods aren't `@listen_toolkit`-decorated.
+ *   2. **`@listen_toolkit` path** (other toolkits) emits Python `repr`
+ *      formatted args, e.g. `'pdf'` or `name='pdf'` or `['pdf','foo']`.
+ *      Kept as a fallback in case SkillToolkit ever gets decorated.
+ *
+ * Once the tool deactivates, chatStore concatenates the activate args and
+ * the deactivate result with a `\n`, so the args are on the first line and
+ * the rest of `message` is the skill body. Backend may also append a
+ * "(truncated, …)" tail at 500 chars — we strip it.
+ */
+function extractLoadedSkillNames(message: string): string[] {
+  if (!message) return [];
+
+  // Args (if present) sit on the first line — the deactivate result is
+  // appended after a newline. Try the head first, then fall back to the
+  // whole string if the head doesn't yield anything.
+  const head = message.split(/\r?\n/)[0] ?? '';
+  const candidates =
+    head.trim() && head.trim() !== message.trim() ? [head, message] : [message];
+
+  for (const candidate of candidates) {
+    const cleaned = candidate
+      .replace(/\.\.\.\s*\(truncated[^)]*\)\s*$/i, '')
+      .trim();
+    if (!cleaned) continue;
+
+    // 1. JSON args from the agent path.
+    try {
+      const parsed = JSON.parse(cleaned);
+      if (parsed && typeof parsed === 'object' && 'name' in parsed) {
+        const name = (parsed as { name: unknown }).name;
+        if (Array.isArray(name)) {
+          const items = name
+            .filter((n): n is string => typeof n === 'string')
+            .map((n) => n.trim())
+            .filter(Boolean);
+          if (items.length) return items;
+        } else if (typeof name === 'string' && name.trim()) {
+          return [name.trim()];
+        }
+      }
+    } catch {
+      // Not JSON — fall through to repr parsing.
+    }
+
+    // 2. Python-repr fallback (`@listen_toolkit` formatting).
+    const noKw = cleaned.replace(/^\s*name\s*=\s*/i, '').trim();
+    if (noKw.startsWith('[')) {
+      const items: string[] = [];
+      const re = /['"]([^'"]+?)['"]/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(noKw)) !== null) {
+        const v = m[1].trim();
+        if (v) items.push(v);
+      }
+      if (items.length) return items;
+    }
+    const quoted = noKw.match(/^['"]([^'"]+?)['"]/);
+    if (quoted) return [quoted[1].trim()];
+  }
+
+  return [];
+}
+
+type RuntimeToolkit = {
+  toolkitName: string;
+  method: string;
+  message: string;
+};
+
+function forEachRuntimeToolkit(
+  agents: Agent[],
+  taskRunning: TaskInfo[] | undefined,
+  fn: (tk: RuntimeToolkit) => void
+) {
+  for (const agent of agents) {
+    for (const task of agent.tasks ?? []) {
+      for (const tk of task.toolkits ?? []) {
+        const name = tk.toolkitName;
+        if (!name || name === 'notice') continue;
+        fn({
+          toolkitName: name,
+          method: tk.toolkitMethods ?? '',
+          message: tk.message ?? '',
+        });
+      }
+    }
+  }
+  for (const task of taskRunning ?? []) {
+    for (const tk of task.toolkits ?? []) {
+      const name = tk.toolkitName;
+      if (!name || name === 'notice') continue;
+      fn({
+        toolkitName: name,
+        method: tk.toolkitMethods ?? '',
+        message: tk.message ?? '',
+      });
+    }
+  }
+}
+
+/**
+ * Collect classification hints from per-agent `workerInfo` and the skills
+ * store. These are used **only** to bucket runtime toolkit names into
+ * skill vs connector — configured items are not surfaced until they
+ * actually fire at runtime, so the panel stays scoped to "what was used in
+ * this task".
+ */
+function collectHints(agents: Agent[], skills: ContextSkill[]) {
   const skillHints = new Set<string>();
   const connectorHints = new Set<string>();
+
+  const add = (set: Set<string>, raw: string) => {
+    const k = normalizeKey(raw);
+    if (k) set.add(k);
+  };
 
   for (const agent of agents) {
     const info = agent.workerInfo;
@@ -38,113 +208,126 @@ function collectWorkerHintSets(agents: Agent[]) {
       const servers = (mcp as { mcpServers?: Record<string, unknown> })
         .mcpServers;
       if (servers && typeof servers === 'object') {
-        for (const name of Object.keys(servers)) {
-          addHint(connectorHints, name);
-        }
+        for (const name of Object.keys(servers)) add(connectorHints, name);
       }
     }
 
     const selected: unknown = info.selectedTools;
-    if (!Array.isArray(selected)) continue;
-    for (const raw of selected) {
-      if (!raw || typeof raw !== 'object') continue;
-      const item = raw as {
-        name?: string;
-        key?: string;
-        toolkit?: string;
-        category?: { name?: string };
-      };
-      const label = item.name ?? item.key ?? item.toolkit;
-      if (!label) continue;
-      const categoryName = item.category?.name?.toLowerCase() ?? '';
-      const hints = categoryName === 'skill' ? skillHints : connectorHints;
-      addHint(hints, label);
-      if (item.toolkit) addHint(hints, item.toolkit);
+    if (Array.isArray(selected)) {
+      for (const raw of selected) {
+        if (!raw || typeof raw !== 'object') continue;
+        const item = raw as {
+          name?: string;
+          key?: string;
+          toolkit?: string;
+          category?: { name?: string };
+        };
+        const label = item.name ?? item.key ?? item.toolkit;
+        if (!label) continue;
+        const cat = categoryFromCategoryName(item.category?.name);
+        const set = cat === 'skill' ? skillHints : connectorHints;
+        add(set, label);
+        if (item.toolkit) add(set, item.toolkit);
+      }
     }
+  }
+
+  for (const skill of skills) {
+    if (!skill.enabled) continue;
+    add(skillHints, skill.name);
   }
 
   return { skillHints, connectorHints };
 }
 
-function runtimeCategoryForToolkit(
-  toolkitName: string,
-  skillHints: Set<string>,
-  connectorHints: Set<string>
-): ContextItem['category'] | null {
-  const tn = toolkitName.trim().toLowerCase();
-  if (/\bskill\b/i.test(tn)) return 'skill';
-  if (/\bmcp\b/i.test(tn)) return 'connector';
-  if (skillHints.has(tn)) return 'skill';
-  const noTk = tn.replace(/\s+toolkit\s*$/i, '').trim();
-  if (skillHints.has(noTk)) return 'skill';
-  if (connectorHints.has(tn)) return 'connector';
-  if (connectorHints.has(noTk)) return 'connector';
-  return null;
-}
-
-function forEachRuntimeToolkit(
-  agents: Agent[],
-  taskRunning: TaskInfo[] | undefined,
-  fn: (toolkitName: string) => void
-) {
-  for (const agent of agents) {
-    for (const task of agent.tasks ?? []) {
-      for (const tk of task.toolkits ?? []) {
-        const name = tk.toolkitName;
-        if (!name || name === 'notice') continue;
-        fn(name);
-      }
-    }
-  }
-  for (const task of taskRunning ?? []) {
-    for (const tk of task.toolkits ?? []) {
-      const name = tk.toolkitName;
-      if (!name || name === 'notice') continue;
-      fn(name);
-    }
-  }
-}
-
 /**
- * Derive a flat, deduplicated list of context items (skills / MCP tools)
- * from runtime toolkit usage on subtasks of the active task.
+ * Derive a flat, deduplicated list of context items (skills / MCP tools /
+ * referenced files) for the **active task**. Only items the task has
+ * actually used at runtime appear here — configured-but-unused skills and
+ * MCP servers are intentionally hidden so the panel reflects work in
+ * flight, not the user's library.
  *
- * - `task.toolkits` / `taskRunning[].toolkits` from ACTIVATE_TOOLKIT are
- *   treated as the source of truth for "currently used" context.
- * - `workerInfo` is used only as a hint to classify runtime toolkit names as
- *   skill vs connector.
+ * Sources:
+ *   1. Runtime toolkit usage from `task.toolkits` /
+ *      `taskRunning[].toolkits` (ACTIVATE_TOOLKIT). For `SkillToolkit` the
+ *      *method* is the skill name and is surfaced one row per skill;
+ *      everything else surfaces by toolkit name. Classification falls
+ *      back to substring tests against the toolkit name itself, so
+ *      `SkillToolkit` / `XxxMCPToolkit` always classify even with no
+ *      hints.
+ *   2. Uploaded files referenced on user messages.
+ *
+ * The `skills` and `workerInfo` data are read **only** to seed
+ * classification hints for ambiguous toolkit names — they never produce
+ * standalone rows.
  */
 export function buildContextItems(
   agents: Agent[],
   taskRunning?: TaskInfo[],
-  uploadedFiles: File[] = []
+  uploadedFiles: File[] = [],
+  skills: ContextSkill[] = []
 ): ContextItem[] {
   const seen = new Set<string>();
   const out: ContextItem[] = [];
 
   const push = (item: ContextItem) => {
-    const key = `${item.category}:${item.id}`;
+    const key = `${item.category}:${normalizeKey(item.id)}`;
     if (seen.has(key)) return;
     seen.add(key);
     out.push(item);
   };
 
-  const { skillHints, connectorHints } = collectWorkerHintSets(agents);
+  const { skillHints, connectorHints } = collectHints(agents, skills);
 
-  forEachRuntimeToolkit(agents, taskRunning, (toolkitName) => {
-    const category = runtimeCategoryForToolkit(
-      toolkitName,
-      skillHints,
-      connectorHints
-    );
-    if (!category) return;
-    push({
-      id: toolkitName,
-      label: toolkitName,
-      category,
-      icon: getToolkitIcon(toolkitName, 16),
-    });
-  });
+  forEachRuntimeToolkit(
+    agents,
+    taskRunning,
+    ({ toolkitName, method, message }) => {
+      // SkillToolkit only exposes two methods to the agent: `list_skills`
+      // and `load_skill(name)`. The skill the user actually invoked is the
+      // *argument* to `load_skill`, never the method name. So we ignore
+      // `list skills` (it's just enumeration) and parse the args of
+      // `load skill` to surface one row per loaded skill.
+      if (toolkitName === SKILL_TOOLKIT_NAME) {
+        const m = normalizeMethodName(method);
+        if (m === SKILL_LIST_METHOD) return;
+        if (m === SKILL_LOAD_METHOD) {
+          for (const skillName of extractLoadedSkillNames(message)) {
+            push({
+              id: `skill:${skillName}`,
+              label: skillName,
+              category: 'skill',
+              icon: createElement(WandSparkles, { size: 16 }),
+            });
+          }
+          return;
+        }
+        // Unknown method on SkillToolkit — never surface the umbrella row.
+        // If a real skill was invoked we'd have hit the `load_skill` branch
+        // above; falling through here would just re-display "SkillToolkit".
+        return;
+      }
+
+      const norm = normalizeKey(toolkitName);
+      let category: ContextItem['category'] | null = null;
+      if (skillHints.has(norm) || isSkillToolkitName(toolkitName)) {
+        category = 'skill';
+      } else if (connectorHints.has(norm) || isMcpToolkitName(toolkitName)) {
+        category = 'connector';
+      }
+      if (!category) return;
+
+      push({
+        id: toolkitName,
+        label: toolkitName,
+        category,
+        icon:
+          category === 'skill'
+            ? createElement(WandSparkles, { size: 16 })
+            : createElement(Hammer, { size: 16 }),
+      });
+    }
+  );
 
   for (const file of uploadedFiles) {
     const filePath = file.filePath?.trim();

--- a/src/components/Session/SidePanelSections/primitives.tsx
+++ b/src/components/Session/SidePanelSections/primitives.tsx
@@ -40,7 +40,7 @@ export function CategoryLabel({
   return (
     <div
       className={cn(
-        'text-ds-text-neutral-muted-default text-body-sm px-1 pb-1 pt-2 first:pt-0',
+        'text-ds-text-neutral-muted-default text-body-xs px-1 pb-1 pt-2 first:pt-0',
         className
       )}
     >
@@ -134,7 +134,8 @@ SidePanelListRow.displayName = 'SidePanelListRow';
 
 /**
  * Progress circle. Incomplete: neutral subtle fill so the ring reads on any
- * panel background. Complete: success subtle fill, strong border and check.
+ * panel background. Complete: filled success (matches primary success button)
+ * with inverse check mark.
  */
 export function ProgressCircle({
   done,
@@ -148,13 +149,19 @@ export function ProgressCircle({
       className={cn(
         'inline-flex shrink-0 items-center justify-center rounded-full border-[0.5px] border-solid',
         done
-          ? 'bg-ds-bg-success-subtle-default border-ds-border-success-strong-default text-ds-text-success-strong-default'
+          ? 'border-ds-bg-success-default-default bg-ds-bg-success-default-default text-ds-text-success-inverse-default'
           : 'border-ds-border-neutral-default-default bg-ds-bg-neutral-subtle-default'
       )}
       style={{ width: size, height: size }}
       aria-hidden
     >
-      {done ? <Check size={Math.max(8, size - 6)} strokeWidth={4} /> : null}
+      {done ? (
+        <Check
+          className="!text-ds-text-success-inverse-default"
+          size={Math.max(8, size - 6)}
+          strokeWidth={4}
+        />
+      ) : null}
     </span>
   );
 }

--- a/src/components/Session/SingleAgent/SingleAgentSidePanel.tsx
+++ b/src/components/Session/SingleAgent/SingleAgentSidePanel.tsx
@@ -20,6 +20,7 @@ import { collectSidePanelOutputFiles } from '@/components/Session/SidePanelSecti
 import useChatStoreAdapter from '@/hooks/useChatStoreAdapter';
 import { cn } from '@/lib/utils';
 import { usePageTabStore } from '@/store/pageTabStore';
+import { useSkillsStore } from '@/store/skillsStore';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -64,9 +65,11 @@ export function SingleAgentSidePanel() {
       return true;
     });
   }, [activeTask]);
+  const skills = useSkillsStore((s) => s.skills);
   const contextItems = useMemo(
-    () => buildContextItems(agents, activeTask?.taskRunning, uploadedFiles),
-    [agents, activeTask?.taskRunning, uploadedFiles]
+    () =>
+      buildContextItems(agents, activeTask?.taskRunning, uploadedFiles, skills),
+    [agents, activeTask?.taskRunning, uploadedFiles, skills]
   );
 
   const handleOpenAgentFile = useCallback(

--- a/src/components/Session/Workforce/WorkforceSidePanel.tsx
+++ b/src/components/Session/Workforce/WorkforceSidePanel.tsx
@@ -22,6 +22,7 @@ import ExpandedOverlay from '@/components/Session/Workforce/ExpandedOverlay';
 import useChatStoreAdapter from '@/hooks/useChatStoreAdapter';
 import { cn } from '@/lib/utils';
 import { usePageTabStore } from '@/store/pageTabStore';
+import { useSkillsStore } from '@/store/skillsStore';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -91,9 +92,11 @@ export function WorkforceSidePanel({
       return true;
     });
   }, [activeTask]);
+  const skills = useSkillsStore((s) => s.skills);
   const contextItems = useMemo(
-    () => buildContextItems(agents, activeTask?.taskRunning, uploadedFiles),
-    [agents, activeTask?.taskRunning, uploadedFiles]
+    () =>
+      buildContextItems(agents, activeTask?.taskRunning, uploadedFiles, skills),
+    [agents, activeTask?.taskRunning, uploadedFiles, skills]
   );
 
   const handleOpenAgentFile = useCallback(

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -2993,6 +2993,9 @@ const chatStore = (initial?: Partial<ChatStore>) =>
               if (assigneeAgentIndex !== -1 && task) {
                 task.toolkits ??= [];
                 task.toolkits.push({ ...toolkit });
+                // Mirror the notice onto the agent log so the work-log
+                // timeline can render it inline alongside tool calls.
+                taskAssigning[assigneeAgentIndex].log.push(agentMessages);
               }
               setTaskAssigning(currentTaskId, [...taskAssigning]);
             } else {

--- a/src/store/pageTabStore.ts
+++ b/src/store/pageTabStore.ts
@@ -63,6 +63,13 @@ interface PageTabState {
   scrollToQueryId: string | null;
   setScrollToQueryId: (queryId: string | null) => void;
   /**
+   * Bumped when the side-panel Progress section asks the chat to surface
+   * the task box: TaskCard expands itself, ProjectChatContainer scrolls
+   * the active query group so the task box sits at the top.
+   */
+  taskBoxFocusRequestId: number;
+  requestTaskBoxFocus: () => void;
+  /**
    * Optional absolute path override for the agent folder (per project).
    * When unset for a project, the default Eigent project folder is used.
    */
@@ -169,6 +176,11 @@ export const usePageTabStore = create<PageTabState>()(
         }),
       scrollToQueryId: null,
       setScrollToQueryId: (queryId) => set({ scrollToQueryId: queryId }),
+      taskBoxFocusRequestId: 0,
+      requestTaskBoxFocus: () =>
+        set((state) => ({
+          taskBoxFocusRequestId: state.taskBoxFocusRequestId + 1,
+        })),
       customAgentFolderPathByProjectId: {},
       setProjectCustomAgentFolderPath: (projectId, path) =>
         set((state) => {

--- a/test/unit/components/TaskWorkLogAccordion.test.tsx
+++ b/test/unit/components/TaskWorkLogAccordion.test.tsx
@@ -13,13 +13,15 @@
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
 import {
-  buildActionGroups,
-  getGroupTitle,
+  buildAgentBlocks,
+  getBlockHeaderParts,
+  type AgentBlock,
+  type TimelineItem,
 } from '@/components/ChatBox/MessageItem/TaskWorkLogAccordion';
 import { AgentStep, type AgentStepType } from '@/types/constants';
 import { describe, expect, it } from 'vitest';
 
-type TaggedLog = Parameters<typeof buildActionGroups>[0][number];
+type TaggedLog = Parameters<typeof buildAgentBlocks>[0][number];
 
 function tag(
   agentId: string,
@@ -37,8 +39,18 @@ function mk(
   return { step, data };
 }
 
-describe('buildActionGroups', () => {
-  it('starts a new group on ACTIVATE_AGENT and captures reasoning', () => {
+function findTool(items: TimelineItem[], idx: number) {
+  const tools = items.filter((i) => i.kind === 'tool');
+  return tools[idx];
+}
+
+function findMessage(items: TimelineItem[], idx: number) {
+  const messages = items.filter((i) => i.kind === 'message');
+  return messages[idx];
+}
+
+describe('buildAgentBlocks', () => {
+  it('starts a new block on ACTIVATE_AGENT and captures reasoning as the first message', () => {
     const logs = [
       tag(
         'a1',
@@ -57,49 +69,148 @@ describe('buildActionGroups', () => {
         })
       ),
     ];
-    const groups = buildActionGroups(logs);
-    expect(groups).toHaveLength(1);
-    expect(groups[0]?.reasoning).toBe('I will open the page.');
-    expect(groups[0]?.tools).toHaveLength(1);
-    expect(groups[0]?.tools[0]?.rowTitle).toBe('Browser Toolkit · Open');
+    const blocks = buildAgentBlocks(logs);
+    expect(blocks).toHaveLength(1);
+    const items = blocks[0]!.items;
+    const first = findMessage(items, 0);
+    expect(first?.kind).toBe('message');
+    expect(first?.kind === 'message' && first.source).toBe('reasoning');
+    expect(first?.kind === 'message' && first.text).toBe(
+      'I will open the page.'
+    );
+    const tool = findTool(items, 0);
+    expect(tool?.kind === 'tool' && tool.rowTitle).toBe(
+      'Browser Toolkit · Open'
+    );
   });
 
-  it('pairs DEACTIVATE_TOOLKIT with the matching running tool in the group', () => {
+  it('preserves chronological message → tool → message → tool ordering', () => {
     const logs = [
+      tag('a1', 'x', 'X', mk(AgentStep.ACTIVATE_AGENT, { message: 'plan' })),
       tag(
         'a1',
-        'browser_agent',
-        'Browser',
-        mk(AgentStep.ACTIVATE_AGENT, { message: 'Step one' })
-      ),
-      tag(
-        'a1',
-        'browser_agent',
-        'Browser',
+        'x',
+        'X',
         mk(AgentStep.ACTIVATE_TOOLKIT, {
-          toolkit_name: 'Search Toolkit',
-          method_name: 'query',
-          message: 'tennis',
+          toolkit_name: 'T',
+          method_name: 'one',
+          message: 'arg=1',
         })
       ),
       tag(
         'a1',
-        'browser_agent',
-        'Browser',
+        'x',
+        'X',
         mk(AgentStep.DEACTIVATE_TOOLKIT, {
-          toolkit_name: 'Search Toolkit',
-          method_name: 'query',
-          message: '12 results',
+          toolkit_name: 'T',
+          method_name: 'one',
+          message: 'ok',
+        })
+      ),
+      tag(
+        'a1',
+        'x',
+        'X',
+        mk(AgentStep.NOTICE, { notice: 'I found 12 results.' })
+      ),
+      tag(
+        'a1',
+        'x',
+        'X',
+        mk(AgentStep.ACTIVATE_TOOLKIT, {
+          toolkit_name: 'T',
+          method_name: 'two',
+          message: 'arg=2',
         })
       ),
     ];
-    const groups = buildActionGroups(logs);
-    expect(groups[0]?.tools[0]?.status).toBe('done');
-    expect(groups[0]?.tools[0]?.detail).toContain('tennis');
-    expect(groups[0]?.tools[0]?.detail).toContain('12 results');
+    const blocks = buildAgentBlocks(logs);
+    const kinds = blocks[0]!.items.map((i) =>
+      i.kind === 'message' ? `m:${i.source}` : `t:${i.method}`
+    );
+    expect(kinds).toEqual(['m:reasoning', 't:one', 'm:notice', 't:two']);
   });
 
-  it('opens a new group on agent-id change without requiring ACTIVATE_AGENT', () => {
+  it('inserts a sibling narration message above a prose toolkit message', () => {
+    const logs = [
+      tag('a1', 'x', 'X', mk(AgentStep.ACTIVATE_AGENT, { message: 'plan' })),
+      tag(
+        'a1',
+        'x',
+        'X',
+        mk(AgentStep.ACTIVATE_TOOLKIT, {
+          toolkit_name: 'Browser Toolkit',
+          method_name: 'clone',
+          message:
+            'Cloning session abc123 with shared user_data_dir at /tmp/foo',
+        })
+      ),
+    ];
+    const blocks = buildAgentBlocks(logs);
+    const items = blocks[0]!.items;
+    expect(items.map((i) => i.kind)).toEqual(['message', 'message', 'tool']);
+    const narration = items[1]!;
+    expect(narration.kind).toBe('message');
+    expect(narration.kind === 'message' && narration.source).toBe(
+      'toolkit_message'
+    );
+    expect(narration.kind === 'message' && narration.running).toBe(true);
+  });
+
+  it('does not add narration for kwargs-shaped toolkit messages', () => {
+    const logs = [
+      tag(
+        'a1',
+        'x',
+        'X',
+        mk(AgentStep.ACTIVATE_TOOLKIT, {
+          toolkit_name: 'Browser Toolkit',
+          method_name: 'open',
+          message: "url='https://example.com'",
+        })
+      ),
+    ];
+    const blocks = buildAgentBlocks(logs);
+    const items = blocks[0]!.items;
+    expect(items.map((i) => i.kind)).toEqual(['tool']);
+  });
+
+  it('settles the sibling narration when DEACTIVATE_TOOLKIT pairs with the tool', () => {
+    const logs = [
+      tag('a1', 'x', 'X', mk(AgentStep.ACTIVATE_AGENT, { message: 'plan' })),
+      tag(
+        'a1',
+        'x',
+        'X',
+        mk(AgentStep.ACTIVATE_TOOLKIT, {
+          toolkit_name: 'Browser Toolkit',
+          method_name: 'clone',
+          message:
+            'Cloning session abc123 with shared user_data_dir at /tmp/foo',
+        })
+      ),
+      tag(
+        'a1',
+        'x',
+        'X',
+        mk(AgentStep.DEACTIVATE_TOOLKIT, {
+          toolkit_name: 'Browser Toolkit',
+          method_name: 'clone',
+          message: 'session ready',
+        })
+      ),
+    ];
+    const blocks = buildAgentBlocks(logs);
+    const items = blocks[0]!.items;
+    const narration = items[1]!;
+    expect(narration.kind === 'message' && narration.running).toBe(false);
+    const tool = findTool(items, 0);
+    expect(tool?.kind === 'tool' && tool.status).toBe('done');
+    expect(tool?.kind === 'tool' && tool.detail).toContain('Cloning session');
+    expect(tool?.kind === 'tool' && tool.detail).toContain('session ready');
+  });
+
+  it('opens a new block on agent-id change without requiring ACTIVATE_AGENT', () => {
     const logs = [
       tag(
         'a1',
@@ -108,7 +219,7 @@ describe('buildActionGroups', () => {
         mk(AgentStep.ACTIVATE_TOOLKIT, {
           toolkit_name: 'Browser Toolkit',
           method_name: 'open',
-          message: 'x',
+          message: "url='x'",
         })
       ),
       tag(
@@ -122,14 +233,13 @@ describe('buildActionGroups', () => {
         })
       ),
     ];
-    const groups = buildActionGroups(logs);
-    expect(groups).toHaveLength(2);
-    expect(groups[0]?.agentId).toBe('a1');
-    expect(groups[1]?.agentId).toBe('a2');
-    expect(groups[0]?.reasoning).toBeNull();
+    const blocks = buildAgentBlocks(logs);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]?.agentId).toBe('a1');
+    expect(blocks[1]?.agentId).toBe('a2');
   });
 
-  it('marks every non-last group as done', () => {
+  it('marks every non-last block as done', () => {
     const logs = [
       tag('a1', 'x', 'X', mk(AgentStep.ACTIVATE_AGENT, { message: 'one' })),
       tag(
@@ -144,22 +254,35 @@ describe('buildActionGroups', () => {
       ),
       tag('a1', 'x', 'X', mk(AgentStep.ACTIVATE_AGENT, { message: 'two' })),
     ];
-    const groups = buildActionGroups(logs);
-    expect(groups).toHaveLength(2);
-    expect(groups[0]?.status).toBe('done');
-    expect(groups[1]?.status).toBe('running');
+    const blocks = buildAgentBlocks(logs);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]?.status).toBe('done');
+    expect(blocks[1]?.status).toBe('running');
   });
 
-  it('flips status to done on DEACTIVATE_AGENT for the current group', () => {
+  it('flips status to done on DEACTIVATE_AGENT for the current block', () => {
     const logs = [
       tag('a1', 'x', 'X', mk(AgentStep.ACTIVATE_AGENT, { message: 'r' })),
       tag('a1', 'x', 'X', mk(AgentStep.DEACTIVATE_AGENT, {})),
     ];
-    const groups = buildActionGroups(logs);
-    expect(groups[0]?.status).toBe('done');
+    const blocks = buildAgentBlocks(logs);
+    expect(blocks[0]?.status).toBe('done');
   });
 
-  it('drops NOTICE tool events into notices, not tools', () => {
+  it('drops NOTICE step into an inline notice message', () => {
+    const logs = [
+      tag('a1', 'x', 'X', mk(AgentStep.ACTIVATE_AGENT, { message: 'r' })),
+      tag('a1', 'x', 'X', mk(AgentStep.NOTICE, { notice: 'heads-up' })),
+    ];
+    const blocks = buildAgentBlocks(logs);
+    const items = blocks[0]!.items;
+    const notice = items[1]!;
+    expect(notice.kind).toBe('message');
+    expect(notice.kind === 'message' && notice.source).toBe('notice');
+    expect(notice.kind === 'message' && notice.text).toBe('heads-up');
+  });
+
+  it('drops `notice` toolkit messages into inline notice messages, not tools', () => {
     const logs = [
       tag('a1', 'x', 'X', mk(AgentStep.ACTIVATE_AGENT, { message: 'r' })),
       tag(
@@ -172,9 +295,11 @@ describe('buildActionGroups', () => {
         })
       ),
     ];
-    const groups = buildActionGroups(logs);
-    expect(groups[0]?.tools).toHaveLength(0);
-    expect(groups[0]?.notices).toEqual(['heads-up']);
+    const blocks = buildAgentBlocks(logs);
+    const items = blocks[0]!.items;
+    expect(items.filter((i) => i.kind === 'tool')).toHaveLength(0);
+    expect(items.filter((i) => i.kind === 'message')).toHaveLength(2);
+    expect(items[1]?.kind === 'message' && items[1].source).toBe('notice');
   });
 
   it('skips ACTIVATE_TOOLKIT events with neither method nor message', () => {
@@ -187,13 +312,13 @@ describe('buildActionGroups', () => {
         mk(AgentStep.ACTIVATE_TOOLKIT, { toolkit_name: 'T' })
       ),
     ];
-    const groups = buildActionGroups(logs);
-    expect(groups[0]?.tools).toHaveLength(0);
+    const blocks = buildAgentBlocks(logs);
+    expect(blocks[0]?.items.filter((i) => i.kind === 'tool')).toHaveLength(0);
   });
 });
 
-describe('buildActionGroups — preparation phase', () => {
-  it('collapses the leading run of `register agent` events into one Preparing group', () => {
+describe('buildAgentBlocks — preparation phase', () => {
+  it('collapses the leading run of `register agent` events into one Preparing block', () => {
     const logs = [
       tag(
         'a-browser',
@@ -236,17 +361,20 @@ describe('buildActionGroups — preparation phase', () => {
         })
       ),
     ];
-    const [prep, ...rest] = buildActionGroups(logs);
+    const [prep, ...rest] = buildAgentBlocks(logs);
     expect(rest).toHaveLength(0);
     expect(prep?.kind).toBe('preparation');
     expect(prep?.agentName).toBe('Preparing agents');
-    expect(prep?.tools).toHaveLength(3);
-    expect(prep?.tools[0]?.rowTitle).toBe('Browser Agent · Browser Toolkit');
-    expect(prep?.tools[0]?.status).toBe('done');
-    expect(prep?.tools[1]?.status).toBe('running');
+    const tools = prep!.items.filter(
+      (i): i is Extract<TimelineItem, { kind: 'tool' }> => i.kind === 'tool'
+    );
+    expect(tools).toHaveLength(3);
+    expect(tools[0]?.rowTitle).toBe('Browser Agent · Browser Toolkit');
+    expect(tools[0]?.status).toBe('done');
+    expect(tools[1]?.status).toBe('running');
   });
 
-  it('ends the Preparing group when a non-register event arrives', () => {
+  it('ends the Preparing block when a non-register event arrives', () => {
     const logs = [
       tag(
         'a-browser',
@@ -275,16 +403,19 @@ describe('buildActionGroups — preparation phase', () => {
         })
       ),
     ];
-    const groups = buildActionGroups(logs);
-    expect(groups).toHaveLength(2);
-    expect(groups[0]?.kind).toBe('preparation');
-    expect(groups[0]?.status).toBe('done');
-    expect(groups[1]?.kind).toBe('action');
-    expect(groups[1]?.reasoning).toBe('let me open the page');
-    expect(groups[1]?.tools[0]?.rowTitle).toBe('Browser Toolkit · Open');
+    const blocks = buildAgentBlocks(logs);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]?.kind).toBe('preparation');
+    expect(blocks[0]?.status).toBe('done');
+    expect(blocks[1]?.kind).toBe('action');
+    const reasoning = blocks[1]!.items[0];
+    expect(reasoning?.kind === 'message' && reasoning.source).toBe('reasoning');
+    expect(reasoning?.kind === 'message' && reasoning.text).toBe(
+      'let me open the page'
+    );
   });
 
-  it('routes mid-run register events to the Preparing group without interrupting the active agent', () => {
+  it('routes mid-run register events to the Preparing block without interrupting the active agent', () => {
     const logs = [
       tag(
         'a-dev',
@@ -322,9 +453,6 @@ describe('buildActionGroups — preparation phase', () => {
           message: 'https://example.com',
         })
       ),
-      // A specialist registered lazily after the browser agent already
-      // started acting. It must still land in the Preparing group, not
-      // inside the browser agent's action group.
       tag(
         'a-mm',
         'multi_modal_agent',
@@ -336,22 +464,69 @@ describe('buildActionGroups — preparation phase', () => {
         })
       ),
     ];
-    const groups = buildActionGroups(logs);
-    expect(groups).toHaveLength(2);
-    expect(groups[0]?.kind).toBe('preparation');
-    expect(groups[0]?.tools).toHaveLength(3);
-    expect(groups[0]?.tools.map((t) => t.rowTitle)).toEqual([
+    const blocks = buildAgentBlocks(logs);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]?.kind).toBe('preparation');
+    const prepTools = blocks[0]!.items.filter((i) => i.kind === 'tool');
+    expect(prepTools.map((t) => t.kind === 'tool' && t.rowTitle)).toEqual([
       'Developer Agent · Terminal Toolkit',
       'Browser Agent · Browser Toolkit',
       'Multi Modal Agent · Open Ai Image Toolkit',
     ]);
-    expect(groups[1]?.kind).toBe('action');
-    expect(groups[1]?.agentId).toBe('a-browser');
-    expect(groups[1]?.tools).toHaveLength(1);
-    expect(groups[1]?.tools[0]?.rowTitle).toBe('Browser Toolkit · Open');
+    expect(blocks[1]?.kind).toBe('action');
+    expect(blocks[1]?.agentId).toBe('a-browser');
+    const actionTools = blocks[1]!.items.filter((i) => i.kind === 'tool');
+    expect(actionTools).toHaveLength(1);
+    expect(actionTools[0]?.kind === 'tool' && actionTools[0].rowTitle).toBe(
+      'Browser Toolkit · Open'
+    );
   });
 
-  it('creates a Preparing group even when the first event is an action (for late registrations)', () => {
+  it('routes browser `clone for new session` events to the Preparing block', () => {
+    const logs = [
+      tag(
+        'a-browser',
+        'browser_agent',
+        'Browser Agent',
+        mk(AgentStep.ACTIVATE_AGENT, { message: 'opening the page' })
+      ),
+      tag(
+        'a-browser',
+        'browser_agent',
+        'Browser Agent',
+        mk(AgentStep.ACTIVATE_TOOLKIT, {
+          toolkit_name: 'Browser Toolkit',
+          method_name: 'clone for new session',
+          message: 'Cloning session abc123',
+        })
+      ),
+      tag(
+        'a-browser',
+        'browser_agent',
+        'Browser Agent',
+        mk(AgentStep.DEACTIVATE_TOOLKIT, {
+          toolkit_name: 'Browser Toolkit',
+          method_name: 'clone for new session',
+          message: 'session ready',
+        })
+      ),
+    ];
+    const blocks = buildAgentBlocks(logs);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]?.kind).toBe('preparation');
+    const prepTools = blocks[0]!.items.filter((i) => i.kind === 'tool');
+    expect(prepTools).toHaveLength(1);
+    expect(prepTools[0]?.kind === 'tool' && prepTools[0].rowTitle).toBe(
+      'Browser Agent · Browser Toolkit'
+    );
+    expect(prepTools[0]?.kind === 'tool' && prepTools[0].status).toBe('done');
+    // The browser agent's action block must not contain the clone event.
+    expect(blocks[1]?.kind).toBe('action');
+    const actionTools = blocks[1]!.items.filter((i) => i.kind === 'tool');
+    expect(actionTools).toHaveLength(0);
+  });
+
+  it('creates a Preparing block even when the first event is an action (for late registrations)', () => {
     const logs = [
       tag(
         'a1',
@@ -370,48 +545,154 @@ describe('buildActionGroups — preparation phase', () => {
         })
       ),
     ];
-    const groups = buildActionGroups(logs);
-    expect(groups).toHaveLength(2);
-    expect(groups[0]?.kind).toBe('preparation');
-    expect(groups[0]?.tools).toHaveLength(1);
-    expect(groups[1]?.kind).toBe('action');
-    expect(groups[1]?.tools).toHaveLength(0);
+    const blocks = buildAgentBlocks(logs);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]?.kind).toBe('preparation');
+    const prepTools = blocks[0]!.items.filter((i) => i.kind === 'tool');
+    expect(prepTools).toHaveLength(1);
+    expect(blocks[1]?.kind).toBe('action');
+    const actionTools = blocks[1]!.items.filter((i) => i.kind === 'tool');
+    expect(actionTools).toHaveLength(0);
   });
 });
 
-describe('getGroupTitle', () => {
-  it('prefers reasoning text', () => {
-    const [group] = buildActionGroups([
-      tag(
-        'a1',
-        'x',
-        'X',
-        mk(AgentStep.ACTIVATE_AGENT, { message: 'Reading the spec.' })
-      ),
+describe('getBlockHeaderParts', () => {
+  function makeBlock(
+    items: TimelineItem[],
+    status: 'running' | 'done' = 'running'
+  ): AgentBlock {
+    return {
+      id: 'b1',
+      agentId: 'a1',
+      agentType: 'document_agent',
+      agentName: 'Document Agent',
+      items,
+      status,
+      kind: 'action',
+    };
+  }
+
+  it('shows the latest tool title with a running shimmer when the tool is in flight', () => {
+    const block = makeBlock([
+      {
+        kind: 'tool',
+        id: 't1',
+        rowTitle: 'File Toolkit · Open',
+        toolkitName: 'File Toolkit',
+        method: 'open',
+        detail: '',
+        status: 'running',
+      },
     ]);
-    expect(getGroupTitle(group!)).toBe('Reading the spec.');
+    expect(getBlockHeaderParts(block)).toEqual({
+      agentLabel: 'Document Agent',
+      detail: 'File Toolkit · Open',
+      detailRunning: true,
+    });
   });
 
-  it('falls back to the most recent tool title', () => {
-    const [group] = buildActionGroups([
-      tag(
-        'a1',
-        'x',
-        'X',
-        mk(AgentStep.ACTIVATE_TOOLKIT, {
-          toolkit_name: 'Terminal Toolkit',
-          method_name: 'shell_exec',
-          message: 'ls',
-        })
-      ),
+  it('updates the detail to the most recent tool as new ones arrive', () => {
+    const block = makeBlock([
+      {
+        kind: 'tool',
+        id: 't1',
+        rowTitle: 'File Toolkit · Open',
+        toolkitName: 'File Toolkit',
+        method: 'open',
+        detail: '',
+        status: 'done',
+      },
+      {
+        kind: 'message',
+        id: 'm1',
+        text: 'opening DuckDuckGo',
+        source: 'reasoning',
+        running: false,
+        pairKey: null,
+      },
+      {
+        kind: 'tool',
+        id: 't2',
+        rowTitle: 'File Toolkit · Write',
+        toolkitName: 'File Toolkit',
+        method: 'write',
+        detail: '',
+        status: 'running',
+      },
     ]);
-    expect(getGroupTitle(group!)).toBe('Terminal Toolkit · Shell_exec');
+    const parts = getBlockHeaderParts(block);
+    expect(parts.detail).toBe('File Toolkit · Write');
+    expect(parts.detailRunning).toBe(true);
   });
 
-  it('shows a placeholder when a group has neither', () => {
-    const [group] = buildActionGroups([
-      tag('a1', 'x', 'X', mk(AgentStep.ACTIVATE_AGENT, {})),
+  it('drops the shimmer once the latest tool finishes', () => {
+    const block = makeBlock(
+      [
+        {
+          kind: 'tool',
+          id: 't1',
+          rowTitle: 'File Toolkit · Open',
+          toolkitName: 'File Toolkit',
+          method: 'open',
+          detail: '',
+          status: 'done',
+        },
+      ],
+      'done'
+    );
+    const parts = getBlockHeaderParts(block);
+    expect(parts.detail).toBe('File Toolkit · Open');
+    expect(parts.detailRunning).toBe(false);
+  });
+
+  it('shows "Thinking…" while a running block has no tool yet', () => {
+    const block = makeBlock([
+      {
+        kind: 'message',
+        id: 'm1',
+        text: 'plan',
+        source: 'reasoning',
+        running: false,
+        pairKey: null,
+      },
     ]);
-    expect(getGroupTitle(group!)).toBe('Thinking…');
+    const parts = getBlockHeaderParts(block);
+    expect(parts.detail).toBe('Thinking…');
+    expect(parts.detailRunning).toBe(true);
+  });
+
+  it('shows registered count for the preparation block', () => {
+    const prep: AgentBlock = {
+      id: 'b-prep',
+      agentId: '__prep__',
+      agentType: '__prep__',
+      agentName: 'Preparing agents',
+      items: [
+        {
+          kind: 'tool',
+          id: 't0',
+          rowTitle: 'A · B',
+          toolkitName: 'A',
+          method: 'register agent',
+          detail: '',
+          status: 'done',
+        },
+        {
+          kind: 'tool',
+          id: 't1',
+          rowTitle: 'C · D',
+          toolkitName: 'C',
+          method: 'register agent',
+          detail: '',
+          status: 'running',
+        },
+      ],
+      status: 'running',
+      kind: 'preparation',
+    };
+    const parts = getBlockHeaderParts(prep);
+    expect(parts.agentLabel).toBe('Preparing agents');
+    expect(parts.detail).toBe('2 Registered');
+    expect(parts.detailRunning).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
This PR improves the chat work-log timeline, side-panel execution context, and navigation from progress rows to the active task box.

## Commits
1. **fix(store)** — Mirror toolkit notices into the assignee agent log; add `taskBoxFocusRequestId` / `requestTaskBoxFocus()` for chat coordination.
2. **fix(side-panel)** — Rework `buildContextItems` (SkillToolkit args, normalized keys, skills hints); progress row clicks request task-box focus; minor execution context and progress styling.
3. **fix(chat)** — Refactor `TaskWorkLogAccordion` to agent blocks with inline narration and tool rows; scroll/expand task card on focus request.
4. **test** — Update `TaskWorkLogAccordion` unit tests for the new timeline model.

## Target
Merge into `test` for integration verification.

Made with [Cursor](https://cursor.com)