### PR TITLE
fix: map deepseek and z.ai to openai-compatible-model in platform alias

### DIFF
--- a/backend/app/model/model_platform.py
+++ b/backend/app/model/model_platform.py
@@ -17,11 +17,12 @@ from typing import Annotated, Final
 from pydantic import BeforeValidator
 
 PLATFORM_ALIAS_MAPPING: Final[dict[str, str]] = {
-    "z.ai": "zhipu",
+    "z.ai": "openai-compatible-model",
     "ModelArk": "openai-compatible-model",
     "grok": "openai-compatible-model",
     "ernie": "qianfan",
     "llama.cpp": "openai-compatible-model",
+    "deepseek": "openai-compatible-model",
 }
 
 # Bedrock Converse requires a region during model initialization.

--- a/backend/tests/app/model/test_model_platform.py
+++ b/backend/tests/app/model/test_model_platform.py
@@ -24,10 +24,11 @@ from app.model.model_platform import (
 
 def test_normalize_model_platform_maps_known_aliases():
     assert normalize_model_platform("grok") == "openai-compatible-model"
-    assert normalize_model_platform("z.ai") == "zhipu"
+    assert normalize_model_platform("z.ai") == "openai-compatible-model"
     assert normalize_model_platform("ModelArk") == "openai-compatible-model"
     assert normalize_model_platform("ernie") == "qianfan"
     assert normalize_model_platform("llama.cpp") == "openai-compatible-model"
+    assert normalize_model_platform("deepseek") == "openai-compatible-model"
 
 
 def test_normalize_model_platform_keeps_non_alias_unchanged():


### PR DESCRIPTION
### Related Issue

Closes #1578
Closes #1556

### Description

both issues report BYOK validation failing with "unknown model platform: <name>"
`deepseek` falls through `PLATFORM_ALIAS_MAPPING` because there's no entry, so camel's `ModelPlatformType` receives the bare string `"deepseek"` and raises
`z.ai` is currently mapped to `"zhipu"` which camel also doesn't recognize
both providers expose openai-compatible apis and `src/lib/llm.ts` already sends the platform strings as-is, so the fix is two entries in the mapping: change `z.ai` from `zhipu` to `openai-compatible-model`, and add `deepseek` mapped to the same target
matches the existing pattern used by `grok`, `ModelArk`, and `llama.cpp`

discussed first on #1578
the issue author proposed exactly this fix in the body, and i confirmed the change locally before opening the pr

### Testing Evidence (REQUIRED)

ran the full backend suite per `.github/workflows/test.yml`:

```
$ uv sync
$ uv run pytest tests/app -q
403 passed, 11 skipped, 30 warnings in 10.52s
```

ran ruff against the whole backend per `.github/workflows/pre-commit.yml`, version pinned to match `.pre-commit-config.yaml` (ruff-pre-commit v0.14.3):

```
$ ruff --version
ruff 0.14.3
$ ruff check .
All checks passed!
$ ruff format --check .
142 files already formatted
```

targeted run on the touched test file:

```
$ pytest tests/app/model/test_model_platform.py -v
tests/app/model/test_model_platform.py::test_normalize_model_platform_maps_known_aliases PASSED
tests/app/model/test_model_platform.py::test_normalize_model_platform_keeps_non_alias_unchanged PASSED
tests/app/model/test_model_platform.py::test_normalize_optional_model_platform_handles_none PASSED
tests/app/model/test_model_platform.py::test_normalized_model_platform_type_applies_in_pydantic_model PASSED
4 passed in 0.03s
```

- [x] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [x] No frontend/UI changes in this PR.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
