### PR TITLE
fix: provider update silently drops model_type and endpoint_url

### DIFF
--- a/server/app/domains/model_provider/service/provider_service.py
+++ b/server/app/domains/model_provider/service/provider_service.py
@@ -65,8 +65,18 @@ class ProviderService:
             ).first()
             if not model:
                 return {"success": False, "error_code": "PROVIDER_NOT_FOUND"}
-            # H10: only allow updating safe fields
-            _UPDATABLE_FIELDS = {"provider_name", "api_key", "api_base", "extra_config", "prefer", "is_vaild"}
+            # H10: only allow updating safe fields. Field names must match the
+            # `Provider` ORM model (and `ProviderIn` request schema) verbatim —
+            # `setattr(model, key, value)` silently no-ops on a missing field.
+            _UPDATABLE_FIELDS = {
+                "provider_name",
+                "api_key",
+                "model_type",
+                "endpoint_url",
+                "encrypted_config",
+                "prefer",
+                "is_vaild",
+            }
             for key, value in data.items():
                 if key in _UPDATABLE_FIELDS:
                     setattr(model, key, value)


### PR DESCRIPTION
### Related Issue

Closes #1627

### Description

Fix `ProviderService.update()`'s `_UPDATABLE_FIELDS` whitelist so it matches the real `Provider` ORM field names. Before this fix, edits to `model_type`, `endpoint_url`, and `encrypted_config` via PUT `/api/v1/provider/{id}` were silently dropped — the request returned 200 OK but the DB row stayed unchanged.

| Whitelist entry (before) | Actual model field | Result |
|---|---|---|
| `api_base` | doesn't exist (real: `endpoint_url`) | dead code |
| `extra_config` | doesn't exist (real: `encrypted_config`) | dead code |
| _(missing)_ | `model_type` | silently rejected on update |
| _(missing)_ | `endpoint_url` | silently rejected on update |
| _(missing)_ | `encrypted_config` | silently rejected on update |

The H10 security-by-design intent (whitelist instead of blanket update) is preserved; only the field names are corrected. Identity / audit fields (`id`, `user_id`, timestamps) are still excluded.

The pre-existing project-wide `is_vaild` typo (`Provider.is_vaild`, `VaildStatus`, etc.) is kept as-is — out of scope for this fix.

### Testing Evidence (REQUIRED)

Repro on `main` before the fix and on this branch after the fix; diff between the two:

```diff
-_UPDATABLE_FIELDS = {"provider_name", "api_key", "api_base", "extra_config", "prefer", "is_vaild"}
+_UPDATABLE_FIELDS = {
+    "provider_name",
+    "api_key",
+    "model_type",
+    "endpoint_url",
+    "encrypted_config",
+    "prefer",
+    "is_vaild",
+}
```

Manual repro (described in #1627):

1. Create a BYOK provider with `model_type = claude-opus-4-6`, set as default.
2. Edit the card → change `model_type` to `gpt-4o` → Save.
3. **Before fix**: `GET /api/v1/providers` shows the row still has `model_type: "claude-opus-4-6"`; agent runs continue using Claude.
4. **After fix**: `GET /api/v1/providers` shows `model_type: "gpt-4o"`; agent runs use GPT-4o.

`ruff check` on the changed file reports the same 1 pre-existing I001 (import order) issue both before and after — this PR introduces 0 new lint findings.

- [x] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [x] No frontend/UI changes in this PR.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)