### PR TITLE
bug fix for agent folder file naming missalignment

### DIFF
--- a/electron/main/fileReader.ts
+++ b/electron/main/fileReader.ts
@@ -1040,41 +1040,21 @@ export class FileReader {
         return [];
       }
 
-      const allFiles: FileInfo[] = [];
-      const taskDirs = fs.readdirSync(projectPath);
+      const allFiles = this.getFilesRecursive(projectPath, projectPath).map(
+        (file) => {
+          const relativePath = path.relative(projectPath, file.path);
+          const taskMatch = relativePath.match(/^task_([^/\\]+)/);
 
-      for (const taskDir of taskDirs) {
-        if (!taskDir.startsWith('task_')) continue;
-
-        const taskPath = path.join(projectPath, taskDir);
-        const stats = fs.statSync(taskPath);
-
-        if (stats.isDirectory()) {
-          const taskId = taskDir.replace('task_', '');
-          const taskFiles = this.getFilesRecursive(taskPath, taskPath);
-
-          const enrichedFiles = taskFiles.map((file) => {
-            const fileDir = path.dirname(file.path);
-            const relativeParentPath = path.relative(projectPath, fileDir);
-
-            return {
-              ...file,
-              task_id: taskId,
-              project_id: projectId,
-              relativePath:
-                relativeParentPath === '.' ? '' : relativeParentPath,
-            };
-          });
-
-          allFiles.push(...enrichedFiles);
+          return {
+            ...file,
+            task_id: taskMatch?.[1],
+            project_id: projectId,
+            relativePath: relativePath === '.' ? '' : relativePath,
+          };
         }
-      }
+      );
 
       return allFiles.sort((a, b) => {
-        // Sort by task_id first, then by file path
-        if (a.task_id !== b.task_id) {
-          return a.task_id!.localeCompare(b.task_id!);
-        }
         return a.path.localeCompare(b.path);
       });
     } catch (err) {

--- a/src/components/Folder/index.tsx
+++ b/src/components/Folder/index.tsx
@@ -365,8 +365,12 @@ interface FileInfo {
 
 function getNormalizedTreeRelativePath(file: FileInfo): string {
   const rel = (file.relativePath || '').replace(/\\/g, '/').replace(/^\/+/, '');
-  if (rel) return rel;
-  return (file.path || file.name || '').replace(/\\/g, '/').replace(/^\/+/, '');
+  const name = (file.name || '').replace(/\\/g, '/').replace(/^\/+/, '');
+  if (rel) {
+    const relBasename = rel.split('/').filter(Boolean).at(-1);
+    return relBasename === name || !name ? rel : `${rel}/${name}`;
+  }
+  return name || (file.path || '').replace(/\\/g, '/').replace(/^\/+/, '');
 }
 
 function getComparableRelativePath(file?: FileInfo | null): string {
@@ -434,9 +438,10 @@ function getFileBreadcrumbSegments(
   if (file.isRemote) {
     return [options.remoteRootLabel, file.name];
   }
-  const rel = (file.relativePath || '').replace(/\\/g, '/').trim();
-  const folders = rel ? rel.split('/').filter(Boolean) : [];
-  return [options.projectRootLabel, ...folders, file.name];
+  const segments = getNormalizedTreeRelativePath(file)
+    .split('/')
+    .filter(Boolean);
+  return [options.projectRootLabel, ...segments];
 }
 
 // FileTree component to render nested file structure
@@ -959,29 +964,11 @@ export default function Folder({ data: _data }: { data?: Agent }) {
     const folderMap = new Map<string, FileTreeNode>();
     folderMap.set('', root);
 
-    const sortedFiles = [...files].sort((left, right) => {
-      const leftRelativePath = getNormalizedTreeRelativePath(left);
-      const rightRelativePath = getNormalizedTreeRelativePath(right);
-      const leftDepth = leftRelativePath.split('/').filter(Boolean).length;
-      const rightDepth = rightRelativePath.split('/').filter(Boolean).length;
-
-      if (leftDepth !== rightDepth) {
-        return leftDepth - rightDepth;
-      }
-
-      return leftRelativePath.localeCompare(rightRelativePath);
-    });
-
-    for (const file of sortedFiles) {
-      const normalizedRelativePath = getNormalizedTreeRelativePath(file);
-      const pathSegments = normalizedRelativePath.split('/').filter(Boolean);
-      const folderSegments = pathSegments.slice(0, -1);
-      const fileName = pathSegments[pathSegments.length - 1] || file.name;
-
+    const ensureFolderNode = (segments: string[]): FileTreeNode => {
       let parentNode = root;
       let currentFolderPath = '';
 
-      for (const segment of folderSegments) {
+      for (const segment of segments) {
         currentFolderPath = currentFolderPath
           ? `${currentFolderPath}/${segment}`
           : segment;
@@ -1001,6 +988,36 @@ export default function Folder({ data: _data }: { data?: Agent }) {
 
         parentNode = folderNode;
       }
+
+      return parentNode;
+    };
+
+    const sortedFiles = [...files].sort((left, right) => {
+      const leftRelativePath = getNormalizedTreeRelativePath(left);
+      const rightRelativePath = getNormalizedTreeRelativePath(right);
+      const leftDepth = leftRelativePath.split('/').filter(Boolean).length;
+      const rightDepth = rightRelativePath.split('/').filter(Boolean).length;
+
+      if (leftDepth !== rightDepth) {
+        return leftDepth - rightDepth;
+      }
+
+      return leftRelativePath.localeCompare(rightRelativePath);
+    });
+
+    for (const file of sortedFiles) {
+      const normalizedRelativePath = getNormalizedTreeRelativePath(file);
+      const pathSegments = normalizedRelativePath.split('/').filter(Boolean);
+      if (!pathSegments.length) continue;
+
+      if (file.isFolder) {
+        ensureFolderNode(pathSegments);
+        continue;
+      }
+
+      const folderSegments = pathSegments.slice(0, -1);
+      const fileName = pathSegments[pathSegments.length - 1] || file.name;
+      const parentNode = ensureFolderNode(folderSegments);
 
       parentNode.children!.push({
         name: fileName || file.name,


### PR DESCRIPTION
This branch fixes mismatched paths and labels between the Electron-side project file listing and the Folder tree (agent workspace): files were grouped or shown under the wrong segments because relativePath and the UI’s notion of “tree path” did not always include the file name the same way, and listing only immediate task_* directories did not match a full recursive layout.

`electron/main/fileReader.ts`
Before: Only scanned top-level task_* folders, walked each with getFilesRecursive, and set relativePath to the path relative to the project root but without consistently encoding the same shape the UI expects.

After: Recursively lists the whole project from the project root, sets relativePath to the full path from the project root, and parses task_id from the first task_<id> segment in that relative path. Sorting is simplified to a single path sort.

`src/components/Folder/index.tsx`
getNormalizedTreeRelativePath: When relativePath points at a directory but the file’s name is not already the last segment, it appends the file name so the tree path is not “missing” the leaf.

Breadcrumbs: Built from the same normalized path segments so labels match the tree.

Tree build: Refactors folder creation into ensureFolderNode, sorts files as before, and handles folder entries (isFolder) by creating folder nodes only (no bogus file leaf). Files are attached under the parent derived from the normalized path segments.