### PR TITLE
fix: correct social_medium_agent typo in ExpandedInputBox

### DIFF
--- a/src/components/ChatBox/BottomBox/ExpandedInputBox.tsx
+++ b/src/components/ChatBox/BottomBox/ExpandedInputBox.tsx
@@ -110,7 +110,7 @@ export const ExpandedInputBox = ({
     search_agent: <Globe className="h-3 w-3 text-blue-600" />,
     document_agent: <FileText className="h-3 w-3 text-yellow-600" />,
     multi_modal_agent: <Image className="h-3 w-3 text-fuchsia-600" />,
-    social_medium_agent: <Bird className="h-3 w-3 text-purple-600" />,
+    social_media_agent: <Bird className="h-3 w-3 text-purple-600" />,
   };
 
   // Build agent list same as WorkSpaceMenu


### PR DESCRIPTION
## Summary
- Fix typo in `agentIconMap` key from `social_medium_agent` to `social_media_agent` in `src/components/ChatBox/BottomBox/ExpandedInputBox.tsx`
- The agent type is defined as `social_media_agent` in `types/chatbox.d.ts` and `types/workspace.d.ts`, but the icon map used the wrong key `social_medium_agent`
- This caused the icon lookup to always miss for social media agents, falling back to the generic `Bot` icon instead of showing the `Bird` icon

## Test plan
- [ ] Verify that the `Bird` icon appears correctly for social media agents in the expanded input box
- [ ] Verify other agent icons (developer, browser, document, multi_modal) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)