### PR TITLE
fix: replace bare except clause with Exception in WebSocket heartbeat

### DIFF
--- a/server/app/domains/trigger/api/trigger_execution_controller.py
+++ b/server/app/domains/trigger/api/trigger_execution_controller.py
@@ -336,7 +336,7 @@ async def subscribe_executions(websocket: WebSocket):
                         "type": "heartbeat",
                         "timestamp": datetime.now(timezone.utc).isoformat()
                     })
-                except:
+                except Exception:
                     break
         
         # Run both tasks concurrently


### PR DESCRIPTION
## Summary
- Replace bare `except:` clause with `except Exception:` in `server/app/domains/trigger/api/trigger_execution_controller.py` line 339
- A bare `except:` catches **everything** including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which prevents graceful server shutdown and violates PEP 8
- Changed to `except Exception:` which still catches all runtime errors but allows system-level signals to propagate correctly

## Test plan
- [ ] Verify WebSocket heartbeat still breaks correctly on connection errors
- [ ] Verify server can be gracefully stopped with Ctrl+C (SIGINT) while WebSocket connections are active

🤖 Generated with [Claude Code](https://claude.com/claude-code)