### PR TITLE
fix: remove hardcoded OAuth client_secret from frontend

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -171,10 +171,10 @@ export default function Login() {
       formData.append('code_verifier', code_verifier || '');
       formData.append('code', code);
       formData.append('grant_type', 'authorization_code');
-      formData.append('client_id', 'aa49cdd0-318e-46bd-a540-0f1e5f2b391f');
+      formData.append('client_id', import.meta.env.VITE_STACK_CLIENT_ID || '');
       formData.append(
         'client_secret',
-        'pck_t13egrd9ve57tz52kfcd2s4h1zwya5502z43kr5xv5cx8'
+        import.meta.env.VITE_STACK_CLIENT_SECRET || ''
       );
 
       try {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -14,6 +14,15 @@
 
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_STACK_CLIENT_ID?: string;
+  readonly VITE_STACK_CLIENT_SECRET?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 interface Window {
   // expose in the `electron/preload/index.ts`
   ipcRenderer: import('electron').IpcRenderer;


### PR DESCRIPTION
## Summary
- Remove hardcoded Stack Auth `client_id` and `client_secret` from `src/pages/Login.tsx`
- Move both values to environment variables (`VITE_STACK_CLIENT_ID`, `VITE_STACK_CLIENT_SECRET`)
- Add TypeScript declarations for the new env vars in `src/vite-env.d.ts`
- The hardcoded secret `pck_t13egrd9ve57tz52kfcd2s4h1zwya5502z43kr5xv5cx8` was visible to anyone who could view the page source or inspect the bundled JS

## Security Impact
**HIGH** — OAuth client secrets should never be embedded in frontend code. This secret could be used to impersonate the application.

## Test plan
- [ ] Set `VITE_STACK_CLIENT_ID` and `VITE_STACK_CLIENT_SECRET` in `.env.development`
- [ ] Verify Stack Auth login flow still works end-to-end
- [ ] Verify the secret is no longer visible in the bundled JS output

🤖 Generated with [Claude Code](https://claude.com/claude-code)