### PR TITLE
feat: add configurable provider init params

### DIFF
--- a/backend/app/agent/agent_model.py
+++ b/backend/app/agent/agent_model.py
@@ -89,6 +89,15 @@ def agent_model(
         effective_config["api_url"], extra_params = patch_bedrock_cloud_config(
             effective_config["api_url"], extra_params
         )
+    # Cloud Azure: camel's AzureOpenAIModel raises ValueError if api_version
+    # is missing. The frontend doesn't pass one for cloud GPT models, so
+    # default it here.
+    if (
+        effective_config.get("model_platform") == "azure"
+        and options.is_cloud()
+    ):
+        extra_params = dict(extra_params)
+        extra_params.setdefault("api_version", "2024-12-01-preview")
     init_param_keys = {
         "api_version",
         "azure_ad_token",

--- a/backend/app/agent/factory/mcp.py
+++ b/backend/app/agent/factory/mcp.py
@@ -86,6 +86,11 @@ async def mcp_agent(options: Chat):
         api_url, extra_params = patch_bedrock_cloud_config(
             api_url, extra_params
         )
+    # Cloud Azure: camel's AzureOpenAIModel requires api_version; default it
+    # since the frontend doesn't pass one for cloud GPT models.
+    if options.model_platform == "azure" and options.is_cloud():
+        extra_params = dict(extra_params)
+        extra_params.setdefault("api_version", "2024-12-01-preview")
 
     # Build model_config_dict with prompt caching
     model_config_dict = {}

--- a/backend/app/model/chat.py
+++ b/backend/app/model/chat.py
@@ -116,7 +116,12 @@ class Chat(BaseModel):
         )
 
     def is_cloud(self):
-        return self.api_url is not None and "eigent-proxy" in self.api_url
+        if self.api_url is None:
+            return False
+        return any(
+            marker in self.api_url
+            for marker in ("eigent-proxy", "proxy.eigent.ai")
+        )
 
     def file_save_path(self, path: str | None = None):
         email = re.sub(r'[\\/*?:"<>|\s]', "_", self.email.split("@")[0]).strip(

--- a/backend/tests/app/model/test_chat.py
+++ b/backend/tests/app/model/test_chat.py
@@ -158,3 +158,38 @@ class TestModelPlatformMapping:
         assert config.model_platform == "mistral"
         config = AgentModelConfig(model_platform="samba-nova")
         assert config.model_platform == "samba-nova"
+
+
+class TestIsCloud:
+    """Tests for Chat.is_cloud detection of eigent-managed proxy URLs."""
+
+    def _chat_with_url(self, api_url: str | None) -> Chat:
+        return Chat(
+            task_id="t",
+            project_id="p",
+            question="q",
+            email="x@y.com",
+            model_platform="openai",
+            model_type="gpt-4o",
+            api_key="k",
+            api_url=api_url,
+        )
+
+    def test_is_cloud_matches_legacy_hyphenated_host(self):
+        assert self._chat_with_url(
+            "https://eigent-proxy.example.com"
+        ).is_cloud()
+
+    def test_is_cloud_matches_current_proxy_host(self):
+        # `proxy.eigent.ai` is the actual prod/dev hostname (no hyphen).
+        assert self._chat_with_url("https://proxy.eigent.ai").is_cloud()
+        assert self._chat_with_url("https://proxy.eigent.ai/").is_cloud()
+
+    def test_is_cloud_false_for_user_configured_endpoints(self):
+        assert not self._chat_with_url("https://api.openai.com/v1").is_cloud()
+        assert not self._chat_with_url(
+            "https://bedrock-runtime.us-west-2.amazonaws.com"
+        ).is_cloud()
+
+    def test_is_cloud_false_when_url_missing(self):
+        assert not self._chat_with_url(None).is_cloud()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

Closes #

### Description

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->
- Chat.is_cloud() also matches `proxy.eigent.ai` (was: only the
  literal `eigent-proxy` substring, which the real proxy host lacks)
- agent_model / mcp default `api_version` for cloud Azure so camel's
  AzureOpenAIModel doesn't raise "Must provide api_version"

### Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->
<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->
<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [x] No frontend/UI changes in this PR.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
