### PR TITLE
feat: add immutable folder workspace binding

### DIFF
--- a/backend/app/agent/toolkit/terminal_toolkit.py
+++ b/backend/app/agent/toolkit/terminal_toolkit.py
@@ -33,9 +33,11 @@ from app.service.task import (
     ActionTerminalData,
     Agents,
     get_task_lock,
+    get_task_lock_if_exists,
     process_task,
 )
 from app.utils.listen.toolkit_listen import auto_listen_toolkit
+from app.utils.workspace_paths import runtime_task_root
 
 logger = logging.getLogger("terminal_toolkit")
 
@@ -77,13 +79,29 @@ class TerminalToolkit(BaseTerminalToolkit, AbstractToolkit):
         if agent_name is not None:
             self.agent_name = agent_name
 
-        # Get base directory from environment
-        base_dir = env(
-            "file_save_path", os.path.expanduser("~/.eigent/terminal/")
+        task_lock = get_task_lock_if_exists(api_task_id)
+        current_task_id = (
+            getattr(task_lock, "current_task_id", None) if task_lock else None
         )
+        email = getattr(task_lock, "email", None) if task_lock else None
+        if email and current_task_id:
+            base_dir = str(
+                runtime_task_root(email, api_task_id, current_task_id)
+                / "venvs"
+            )
+        else:
+            base_dir = env(
+                "file_save_path", os.path.expanduser("~/.eigent/terminal/")
+            )
 
         if working_directory is None:
-            working_directory = base_dir
+            working_directory = (
+                getattr(task_lock, "working_directory", None)
+                if task_lock
+                else None
+            ) or env(
+                "file_save_path", os.path.expanduser("~/.eigent/terminal/")
+            )
         self._agent_venv_dir = os.path.join(base_dir, self.agent_name)
 
         logger.debug(
@@ -113,9 +131,6 @@ class TerminalToolkit(BaseTerminalToolkit, AbstractToolkit):
         )
 
         # Auto-register with TaskLock for cleanup when task ends
-        from app.service.task import get_task_lock_if_exists
-
-        task_lock = get_task_lock_if_exists(api_task_id)
         if task_lock:
             task_lock.register_toolkit(self)
             logger.info(

--- a/backend/app/controller/chat_controller.py
+++ b/backend/app/controller/chat_controller.py
@@ -16,7 +16,6 @@ import asyncio
 import inspect
 import logging
 import os
-import re
 import time
 from pathlib import Path
 
@@ -54,11 +53,13 @@ from app.service.task import (
     set_current_task_id,
     task_locks,
 )
+from app.service.upload.service import PartialUploadContext
 from app.utils.browser_launcher import (
     ensure_cdp_browser_endpoint,
     is_cdp_url_available,
     normalize_cdp_url,
 )
+from app.utils.workspace_resolver import get_workspace_resolver
 
 router = APIRouter()
 
@@ -67,6 +68,50 @@ chat_logger = logging.getLogger("chat_controller")
 
 # SSE timeout configuration (60 minutes in seconds)
 SSE_TIMEOUT_SECONDS = 60 * 60
+
+
+def _user_upload_ids(attaches: list[str] | None) -> list[str]:
+    return [
+        attach
+        for attach in (attaches or [])
+        if isinstance(attach, str) and attach.startswith("upload://")
+    ]
+
+
+def _remember_user_uploads(
+    task_lock,
+    task_id: str | None,
+    attaches: list[str] | None,
+) -> None:
+    if not task_id:
+        return
+    uploads = _user_upload_ids(attaches)
+    if not uploads:
+        return
+    by_task = getattr(task_lock, "user_upload_ids_by_task", None)
+    if by_task is None:
+        by_task = {}
+        task_lock.user_upload_ids_by_task = by_task
+    existing = by_task.setdefault(task_id, [])
+    for upload_id in uploads:
+        if upload_id not in existing:
+            existing.append(upload_id)
+
+
+def _email_from_task_lock_or_env(task_lock) -> str | None:
+    email = getattr(task_lock, "email", None)
+    if email:
+        return email
+    current_file_save_path = os.environ.get("file_save_path", "")
+    if not current_file_save_path:
+        return None
+    path_parts = Path(current_file_save_path).parts
+    for root_name in ("eigent", ".eigent"):
+        if root_name in path_parts:
+            root_index = path_parts.index(root_name)
+            if root_index + 1 < len(path_parts):
+                return path_parts[root_index + 1]
+    return None
 
 
 def _is_remote_browser_hands(request: Request | None) -> bool:
@@ -269,10 +314,29 @@ async def start_chat_stream(data: Chat, request: Request):
     if safe_env_path:
         load_dotenv(dotenv_path=safe_env_path)
 
+    resolver = get_workspace_resolver()
+    frozen_dirs = resolver.freeze_task_directories(data, task_lock)
+    try:
+        await asyncio.to_thread(
+            resolver.write_task_snapshot,
+            data.email,
+            frozen_dirs.snapshot,
+        )
+    except Exception:
+        chat_logger.warning(
+            "Failed to persist task workspace snapshot",
+            extra={"project_id": data.project_id, "task_id": data.task_id},
+            exc_info=True,
+        )
+
+    session_id = getattr(request.state, "session_id", "")
+    task_lock.session_id = session_id
+    _remember_user_uploads(task_lock, data.task_id, data.attaches)
+
     # TODO(multi-tenant): os.environ is global – concurrent sessions overwrite
     # each other's API keys, file paths, and browser ports.  Pass these values
     # through Chat / request context instead of mutating the process environment.
-    os.environ["file_save_path"] = data.file_save_path()
+    os.environ["file_save_path"] = str(frozen_dirs.working_directory)
     os.environ["browser_port"] = str(data.browser_port)
     # Web mode: reuse an existing CDP endpoint first, otherwise acquire browser
     # through RemoteHands or launch a local browser when available.
@@ -294,20 +358,18 @@ async def start_chat_stream(data: Chat, request: Request):
                     extra={"project_id": data.project_id},
                 )
 
-    email_sanitized = re.sub(
-        r'[\\/*?:"<>|\s]', "_", data.email.split("@")[0]
-    ).strip(".")
-    camel_log = (
-        Path.home()
-        / ".eigent"
-        / email_sanitized
-        / ("project_" + data.project_id)
-        / ("task_" + data.task_id)
-        / "camel_logs"
-    )
+    camel_log = resolver.log_root(data.project_id, data.task_id, data.email)
     camel_log.mkdir(parents=True, exist_ok=True)
 
     os.environ["CAMEL_LOG_DIR"] = str(camel_log)
+    task_lock.upload_context_partial = PartialUploadContext(
+        session_id=session_id,
+        raw_server_url=data.server_url or "",
+        authorization=request.headers.get("Authorization", ""),
+        task_output_root=frozen_dirs.task_output_root,
+        task_start_time=frozen_dirs.task_start_time,
+        camel_log_dir=camel_log,
+    )
 
     if data.is_cloud():
         os.environ["cloud_api_key"] = data.api_key
@@ -383,46 +445,66 @@ def improve(id: str, data: SupplementChat, request: Request):
                 f"[CONTEXT] Preserved task result: {result_len} chars"
             )
 
-    # If task_id is provided, optimistically update
-    # file_save_path (will be destroyed if task is
-    # not complex)
-    # this is because a NEW workforce instance may be created for this task
-    new_folder_path = None
+    # If task_id is provided, freeze the task-level workspace context before
+    # the action reaches the workforce.  project_root() intentionally stays
+    # project-scoped; agent execution reads TaskLock.working_directory.
     if data.task_id:
         try:
-            # Get current environment values needed to construct new path
-            current_email = None
-
-            # Extract email from current file_save_path if available
-            current_file_save_path = os.environ.get("file_save_path", "")
-            if current_file_save_path:
-                path_parts = Path(current_file_save_path).parts
-                if len(path_parts) >= 3 and "eigent" in path_parts:
-                    eigent_index = path_parts.index("eigent")
-                    if eigent_index + 1 < len(path_parts):
-                        current_email = path_parts[eigent_index + 1]
-
-            # If we have the necessary info, update
-            # the file_save_path
+            current_email = _email_from_task_lock_or_env(task_lock)
             if current_email and id:
-                # Create new path using the existing
-                # pattern: email/project_{id}/task_{id}
-                new_folder_path = (
-                    Path.home()
-                    / "eigent"
-                    / current_email
-                    / f"project_{id}"
-                    / f"task_{data.task_id}"
+                resolver = get_workspace_resolver()
+                frozen_dirs = resolver.freeze_task_directories_for(
+                    project_id=id,
+                    task_id=data.task_id,
+                    email=current_email,
+                    task_lock=task_lock,
                 )
-                new_folder_path.mkdir(parents=True, exist_ok=True)
-                os.environ["file_save_path"] = str(new_folder_path)
-                chat_logger.info(
-                    f"Updated file_save_path to: {new_folder_path}"
+                try:
+                    resolver.write_task_snapshot(
+                        current_email, frozen_dirs.snapshot
+                    )
+                except Exception:
+                    chat_logger.warning(
+                        "Failed to persist task workspace snapshot",
+                        extra={"project_id": id, "task_id": data.task_id},
+                        exc_info=True,
+                    )
+                os.environ["file_save_path"] = str(
+                    frozen_dirs.working_directory
+                )
+                camel_log = resolver.log_root(id, data.task_id, current_email)
+                camel_log.mkdir(parents=True, exist_ok=True)
+                os.environ["CAMEL_LOG_DIR"] = str(camel_log)
+                task_lock.new_folder_path = (
+                    frozen_dirs.working_directory
+                    if frozen_dirs.binding_source == "default"
+                    else None
                 )
 
-                # Store the new folder path in task_lock
-                # for potential cleanup and persistence
-                task_lock.new_folder_path = new_folder_path
+                previous_context = getattr(
+                    task_lock, "upload_context_partial", None
+                )
+                task_lock.upload_context_partial = PartialUploadContext(
+                    session_id=getattr(
+                        request.state,
+                        "session_id",
+                        getattr(task_lock, "session_id", "") or "",
+                    ),
+                    raw_server_url=getattr(
+                        previous_context, "raw_server_url", ""
+                    ),
+                    authorization=request.headers.get(
+                        "Authorization",
+                        getattr(previous_context, "authorization", ""),
+                    ),
+                    task_output_root=frozen_dirs.task_output_root,
+                    task_start_time=frozen_dirs.task_start_time,
+                    camel_log_dir=camel_log,
+                )
+                _remember_user_uploads(task_lock, data.task_id, data.attaches)
+                chat_logger.info(
+                    f"Updated working directory to: {frozen_dirs.working_directory}"
+                )
             else:
                 chat_logger.warning(
                     "Could not update"

--- a/backend/app/controller/file_controller.py
+++ b/backend/app/controller/file_controller.py
@@ -12,9 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import json
 import logging
 import mimetypes
-import re
 import time
 from pathlib import Path
 from typing import Annotated
@@ -23,8 +23,14 @@ from urllib.parse import quote
 from fastapi import APIRouter, File, Header, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
 
-from app.component.environment import env
 from app.utils.file_utils import list_files, resolve_under_base
+from app.utils.server.session import (
+    SessionIdError,
+    get_session_uploads_dir,
+    validate_session_id,
+)
+from app.utils.workspace_paths import get_workspace_root
+from app.utils.workspace_resolver import get_workspace_resolver
 
 router = APIRouter()
 file_logger = logging.getLogger("file_controller")
@@ -32,49 +38,23 @@ file_logger = logging.getLogger("file_controller")
 # Config
 MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024  # 50MB
 MAX_FILES_PER_SESSION = 20
-WORKSPACE_ROOT = env("EIGENT_WORKSPACE", "~/.eigent/workspace")
-SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
-
-
-def _get_eigent_root() -> Path:
-    """Base root for eigent storage (~/eigent). Do NOT use env file_save_path
-    here: chat overwrites it to task path, which would break list/stream."""
-    eigent = Path.home() / "eigent"
-    if eigent.exists():
-        return eigent
-    dot_eigent = Path.home() / ".eigent"
-    if dot_eigent.exists():
-        return dot_eigent
-    return eigent  # default to ~/eigent
-
-
-def _get_workspace_root() -> Path:
-    return Path(WORKSPACE_ROOT).expanduser()
 
 
 def _validate_session_id(session_id: str) -> str:
-    normalized = (session_id or "").strip()
-    if not SESSION_ID_PATTERN.fullmatch(normalized):
-        raise ValueError("Invalid X-Session-ID")
-    return normalized
+    return validate_session_id(session_id)
 
 
 def _get_session_uploads_dir(session_id: str) -> Path:
-    root = _get_workspace_root().resolve()
-    validated = _validate_session_id(session_id)
-    uploads_dir = (root / validated / "uploads").resolve()
-    try:
-        uploads_dir.relative_to(root)
-    except ValueError as exc:
-        raise ValueError("Invalid X-Session-ID") from exc
-    return uploads_dir
+    return get_session_uploads_dir(session_id, get_workspace_root())
 
 
 def _count_session_uploads(session_id: str) -> int:
     uploads_dir = _get_session_uploads_dir(session_id)
     if not uploads_dir.exists():
         return 0
-    return len(list(uploads_dir.iterdir()))
+    return sum(
+        1 for p in uploads_dir.iterdir() if not p.name.endswith(".meta.json")
+    )
 
 
 @router.post("/files")
@@ -93,7 +73,7 @@ async def upload_file(
         )
     try:
         validated_session_id = _validate_session_id(x_session_id)
-    except ValueError as exc:
+    except SessionIdError as exc:
         raise HTTPException(
             status_code=400, detail="Invalid X-Session-ID"
         ) from exc
@@ -127,6 +107,21 @@ async def upload_file(
     uploads_dir.mkdir(parents=True, exist_ok=True)
     target_path = uploads_dir / stored_name
     target_path.write_bytes(content)
+    meta_path = uploads_dir / f"{stored_name}.meta.json"
+    try:
+        meta_path.write_text(
+            json.dumps(
+                {
+                    "original_filename": file.filename or stored_name,
+                    "size": len(content),
+                    "uploaded_at": int(time.time()),
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+    except Exception:
+        file_logger.warning("Failed to write upload sidecar: %s", meta_path)
 
     file_id = f"upload://{stored_name}"
     file_logger.info(
@@ -140,53 +135,9 @@ async def upload_file(
     }
 
 
-def _sanitize_email(email: str) -> str:
-    """Sanitize email for use in path (match chat_controller logic)."""
-    return re.sub(r'[\\/*?:"<>|\s]', "_", email.split("@")[0]).strip(".")
-
-
 def _normalize_relative_path(path: str) -> str:
     """Normalize relative path to URL-safe POSIX style."""
     return path.replace("\\", "/")
-
-
-def _get_project_root(email: str, project_id: str) -> Path:
-    """Get project root path: ~/eigent/{email}/project_{project_id}/."""
-    root = _get_eigent_root()
-    email_sanitized = _sanitize_email(email)
-    return root / email_sanitized / f"project_{project_id}"
-
-
-def _resolve_project_root(email: str, project_id: str) -> Path:
-    """
-    Resolve project root, preferring the email-scoped path but falling back to
-    any local project_{project_id} directory when the stored email differs from
-    the current login identity.
-    """
-    preferred = _get_project_root(email, project_id)
-    if preferred.exists():
-        return preferred
-
-    root = _get_eigent_root()
-    candidate_name = f"project_{project_id}"
-    try:
-        for child in root.iterdir():
-            if not child.is_dir():
-                continue
-            candidate = child / candidate_name
-            if candidate.exists():
-                file_logger.info(
-                    "Resolved project root via fallback lookup: %s -> %s",
-                    preferred,
-                    candidate,
-                )
-                return candidate
-    except FileNotFoundError:
-        pass
-    except Exception as e:
-        file_logger.warning("project root fallback lookup failed: %s", e)
-
-    return preferred
 
 
 @router.get("/files")
@@ -207,17 +158,20 @@ async def list_project_files(
             status_code=400,
             detail="project_id and email are required",
         )
-    project_root = _resolve_project_root(email, project_id)
-    list_dir = str(project_root)
-    if task_id:
-        list_dir = str(project_root / f"task_{task_id}")
-    if not Path(list_dir).exists():
+    resolver = get_workspace_resolver()
+    base = (
+        resolver.task_output_root(project_id, task_id, email)
+        if task_id
+        else resolver.project_root(project_id, email)
+    )
+    list_dir = str(base)
+    if not base.exists():
         file_logger.debug(
             "list_project_files: path does not exist: %s",
             list_dir,
         )
         return []
-    base_path = str(project_root.resolve())
+    base_path = str(base.resolve())
     try:
         paths = list_files(list_dir, base=base_path, max_entries=500)
     except Exception as e:
@@ -231,10 +185,16 @@ async def list_project_files(
             )
             # URL-encode the relative path for stream endpoint
             path_param = quote(rel, safe="")
+            stream_url = (
+                f"/files/stream?path={path_param}&project_id={quote(project_id)}"
+                f"&email={quote(email)}"
+            )
+            if task_id:
+                stream_url = f"{stream_url}&task_id={quote(task_id)}"
             result.append(
                 {
                     "filename": Path(abs_path).name,
-                    "url": f"/files/stream?path={path_param}&project_id={quote(project_id)}&email={quote(email)}",
+                    "url": stream_url,
                     "relativePath": rel,
                 }
             )
@@ -248,6 +208,7 @@ async def stream_file(
     path: str = Query(..., description="Relative path from project root"),
     project_id: str = Query(..., description="Project ID"),
     email: str = Query(..., description="User email"),
+    task_id: str | None = Query(None, description="Optional task ID"),
 ):
     """
     Stream file content. Path must be relative to project root.
@@ -258,10 +219,15 @@ async def stream_file(
             status_code=400,
             detail="path, project_id and email are required",
         )
-    project_root = _resolve_project_root(email, project_id)
+    resolver = get_workspace_resolver()
+    base = (
+        resolver.task_output_root(project_id, task_id, email)
+        if task_id
+        else resolver.project_root(project_id, email)
+    )
     # Resolve path and ensure it stays under project root (security)
     try:
-        resolved = resolve_under_base(path, str(project_root.resolve()))
+        resolved = resolve_under_base(path, str(base.resolve()))
     except Exception as e:
         file_logger.warning("stream_file path validation failed: %s", e)
         raise HTTPException(status_code=400, detail="Invalid path") from e
@@ -285,6 +251,7 @@ async def preview_file(
     email: str,
     project_id: str,
     file_path: str,
+    task_id: str | None = Query(None, description="Optional task ID"),
 ):
     """
     Preview file content with a path-based URL so relative references inside
@@ -296,9 +263,14 @@ async def preview_file(
             detail="file_path, project_id and email are required",
         )
 
-    project_root = _resolve_project_root(email, project_id)
+    resolver = get_workspace_resolver()
+    base = (
+        resolver.task_output_root(project_id, task_id, email)
+        if task_id
+        else resolver.project_root(project_id, email)
+    )
     try:
-        resolved = resolve_under_base(file_path, str(project_root.resolve()))
+        resolved = resolve_under_base(file_path, str(base.resolve()))
     except Exception as e:
         file_logger.warning("preview_file path validation failed: %s", e)
         raise HTTPException(status_code=400, detail="Invalid path") from e

--- a/backend/app/controller/workspace_controller.py
+++ b/backend/app/controller/workspace_controller.py
@@ -1,0 +1,235 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from app.model.chat import Status
+from app.service.task import get_task_lock_if_exists
+from app.service.upload.service import BrainUploadService
+from app.utils.workspace_resolver import get_workspace_resolver
+
+router = APIRouter()
+logger = logging.getLogger("workspace_controller")
+
+
+class WorkspaceBindRequest(BaseModel):
+    project_id: str
+    email: str
+    path: str
+
+
+def _manifest_from_request(request: Request) -> dict[str, Any]:
+    hands = getattr(request.state, "hands", None)
+    get_manifest = getattr(hands, "get_capability_manifest", None)
+    if get_manifest is None:
+        return {}
+    try:
+        manifest = get_manifest()
+    except Exception:
+        logger.warning(
+            "Failed to read hands capability manifest", exc_info=True
+        )
+        return {}
+    return manifest if isinstance(manifest, dict) else {}
+
+
+def _binding_enabled(manifest: dict[str, Any]) -> bool:
+    return manifest.get("deployment") == "local"
+
+
+def _capability_payload(manifest: dict[str, Any]) -> dict[str, Any]:
+    binding_enabled = _binding_enabled(manifest)
+    return {
+        **manifest,
+        "binding_enabled": binding_enabled,
+        "label": "Local Brain" if binding_enabled else "Cloud workspace",
+        "binding_persistence": "brain_local" if binding_enabled else "none",
+    }
+
+
+def _has_active_task(project_id: str) -> bool:
+    task_lock = get_task_lock_if_exists(project_id)
+    if task_lock is None:
+        return False
+    return task_lock.status in {Status.confirmed, Status.processing}
+
+
+def _validate_bind_path(request: Request, path: str) -> Path:
+    def _status_for_reason(reason: str | None) -> int:
+        if reason in {
+            "filesystem_capability_denied",
+            "home_root_forbidden",
+            "home_resolve_failed",
+            "workspace_scope_denied",
+        }:
+            return 403
+        if reason and reason.startswith("sensitive_path:"):
+            return 403
+        return 400
+
+    hands = getattr(request.state, "hands", None)
+    validator = getattr(hands, "validate_workspace_binding_path", None)
+    if validator is not None:
+        ok, reason = validator(path)
+        if not ok:
+            raise HTTPException(
+                status_code=_status_for_reason(reason),
+                detail={
+                    "code": "invalid_workspace_path",
+                    "reason": reason or "path_not_allowed",
+                },
+            )
+    else:
+        can_access = getattr(hands, "can_access_filesystem", None)
+        if can_access is None or not can_access(path):
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "code": "invalid_workspace_path",
+                    "reason": "filesystem_capability_denied",
+                },
+            )
+        candidate = Path(path).expanduser()
+        if not candidate.exists() or not candidate.is_dir():
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "invalid_workspace_path",
+                    "reason": "path_not_directory",
+                },
+            )
+    try:
+        return Path(path).expanduser().resolve()
+    except (OSError, RuntimeError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_workspace_path",
+                "reason": "path_resolve_failed",
+            },
+        ) from exc
+
+
+def _same_workspace_path(left: str, right: str) -> bool:
+    try:
+        return (
+            Path(left).expanduser().resolve()
+            == Path(right).expanduser().resolve()
+        )
+    except (OSError, RuntimeError):
+        return False
+
+
+@router.get("/workspace/capabilities")
+async def workspace_capabilities(request: Request) -> dict[str, Any]:
+    return _capability_payload(_manifest_from_request(request))
+
+
+@router.get("/workspace/current")
+async def workspace_current(
+    project_id: str = Query(..., description="Project ID"),
+    email: str = Query(..., description="User email"),
+) -> dict[str, Any]:
+    resolver = get_workspace_resolver()
+    binding = resolver.store.get_binding(email, project_id)
+    binding_active = (
+        binding is not None
+        and Path(binding.workspace_root).expanduser().is_dir()
+    )
+    root = resolver.project_root(project_id, email)
+    return {
+        "project_id": project_id,
+        "email": email,
+        "bound": binding_active,
+        "workspace_root": str(root),
+        "binding": None if binding is None else binding.__dict__.copy(),
+    }
+
+
+@router.post("/workspace/bind")
+async def workspace_bind(
+    payload: WorkspaceBindRequest, request: Request
+) -> dict[str, Any]:
+    manifest = _manifest_from_request(request)
+    if not _binding_enabled(manifest):
+        raise HTTPException(
+            status_code=412,
+            detail={
+                "code": "workspace_binding_disabled",
+                "capabilities": _capability_payload(manifest),
+            },
+        )
+    if _has_active_task(payload.project_id):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "active_task_exists",
+                "message": "Cannot change workspace while a task is running.",
+            },
+        )
+
+    resolver = get_workspace_resolver()
+    existing = resolver.store.get_binding(payload.email, payload.project_id)
+    if existing is not None:
+        if _same_workspace_path(existing.workspace_root, payload.path):
+            return {
+                "project_id": payload.project_id,
+                "email": payload.email,
+                "bound": Path(existing.workspace_root).expanduser().is_dir(),
+                "workspace_root": existing.workspace_root,
+                "binding": existing.__dict__.copy(),
+            }
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "workspace_already_bound",
+                "message": (
+                    "This project already has a workspace folder. "
+                    "Create a new project to select another folder."
+                ),
+            },
+        )
+
+    resolved = _validate_bind_path(request, payload.path)
+    binding = resolver.store.save_binding(
+        payload.email,
+        payload.project_id,
+        str(resolved),
+    )
+    return {
+        "project_id": payload.project_id,
+        "email": payload.email,
+        "bound": True,
+        "workspace_root": binding.workspace_root,
+        "binding": binding.__dict__.copy(),
+    }
+
+
+@router.get("/upload/status")
+async def upload_status(
+    request: Request,
+    task_id: str = Query(..., description="Task ID"),
+) -> dict[str, Any]:
+    state = BrainUploadService.singleton().get_state(task_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="Upload state not found")
+    request_session_id = getattr(request.state, "session_id", None)
+    if request_session_id and state.session_id != request_session_id:
+        raise HTTPException(status_code=403, detail="Session mismatch")
+    return state.to_dict()

--- a/backend/app/hands/environment_hands.py
+++ b/backend/app/hands/environment_hands.py
@@ -19,6 +19,7 @@ Brain deployment env determines capability set; all Channels share one instance.
 Channel only handles message display format adaptation.
 """
 
+import platform
 from pathlib import Path
 
 from app.hands.capabilities import BrainCapabilities
@@ -72,6 +73,85 @@ class EnvironmentHands(IHands):
             except (OSError, RuntimeError):
                 return False
         return False  # none
+
+    def validate_workspace_binding_path(
+        self, path: str
+    ) -> tuple[bool, str | None]:
+        if not self.can_access_filesystem(path):
+            return False, "filesystem_capability_denied"
+        try:
+            resolved = Path(path).expanduser().resolve()
+        except (OSError, RuntimeError):
+            return False, "path_resolve_failed"
+        if not resolved.exists():
+            return False, "path_not_found"
+        if not resolved.is_dir():
+            return False, "path_not_directory"
+        try:
+            if resolved == Path.home().resolve():
+                return False, "home_root_forbidden"
+        except (OSError, RuntimeError):
+            return False, "home_resolve_failed"
+        for sensitive in self._sensitive_prefixes():
+            try:
+                resolved.relative_to(sensitive.resolve())
+                return False, f"sensitive_path:{sensitive}"
+            except ValueError:
+                continue
+            except (OSError, RuntimeError):
+                continue
+        if self._caps.filesystem_scope == "workspace_only":
+            try:
+                resolved.relative_to(self.workspace_root.resolve())
+            except ValueError:
+                return False, "workspace_scope_denied"
+        return True, None
+
+    def _sensitive_prefixes(self) -> list[Path]:
+        prefixes = [
+            Path("~/.ssh").expanduser(),
+            Path("~/.aws").expanduser(),
+            Path("~/.config/gh").expanduser(),
+            Path("~/.gnupg").expanduser(),
+        ]
+        system = platform.system()
+        if system == "Darwin":
+            prefixes.extend(
+                [
+                    Path("~/Library/Keychains").expanduser(),
+                    Path(
+                        "~/Library/Application Support/com.apple.TCC"
+                    ).expanduser(),
+                    Path("/etc"),
+                    Path("/System"),
+                    Path("/private"),
+                    Path("/var"),
+                    Path("/Library"),
+                ]
+            )
+        elif system == "Linux":
+            prefixes.extend(
+                [
+                    Path("/etc"),
+                    Path("/var"),
+                    Path("/sys"),
+                    Path("/proc"),
+                    Path("/boot"),
+                    Path("/root"),
+                ]
+            )
+        elif system == "Windows":
+            import os
+
+            for raw in (
+                r"C:\Windows",
+                r"C:\Program Files",
+                r"C:\Program Files (x86)",
+                r"%APPDATA%\Microsoft\Credentials",
+                r"%LOCALAPPDATA%\Microsoft\Credentials",
+            ):
+                prefixes.append(Path(os.path.expandvars(raw)))
+        return prefixes
 
     def can_use_mcp(self, mcp_name: str) -> bool:
         if self._caps.mcp_mode == "all":

--- a/backend/app/router.py
+++ b/backend/app/router.py
@@ -32,6 +32,7 @@ from app.controller import (
     skill_controller,
     task_controller,
     tool_controller,
+    workspace_controller,
 )
 
 logger = logging.getLogger("router")
@@ -60,6 +61,11 @@ def register_routers(app: FastAPI, prefix: str = "") -> None:
             "router": file_controller.router,
             "tags": ["Files"],
             "description": "File upload for Web/Channel clients",
+        },
+        {
+            "router": workspace_controller.router,
+            "tags": ["Workspace"],
+            "description": "Workspace binding and upload status",
         },
         {
             "router": mcp_controller.router,

--- a/backend/app/service/chat_service.py
+++ b/backend/app/service/chat_service.py
@@ -63,6 +63,7 @@ from app.service.task import (
     delete_task_lock,
     set_current_task_id,
 )
+from app.service.upload.service import BrainUploadService
 from app.utils.event_loop_utils import set_main_event_loop
 from app.utils.file_utils import get_working_directory, list_files
 from app.utils.server.sync_step import sync_step
@@ -1694,6 +1695,15 @@ async def step_solve(options: Chat, request: Request, task_lock: TaskLock):
                             options, task_lock
                         ),
                     },
+                )
+
+                upload_context = BrainUploadService.finalize_at_task_end(
+                    options, task_lock, request
+                )
+                BrainUploadService.singleton().register_and_start(
+                    upload_context,
+                    getattr(task_lock, "current_task_id", None)
+                    or options.task_id,
                 )
 
                 yield sse_json("end", final_result)

--- a/backend/app/service/task.py
+++ b/backend/app/service/task.py
@@ -371,6 +371,14 @@ class TaskLock:
         self.last_task_summary = ""
         self.question_agent = None
         self.current_task_id = None
+        self.session_id = None
+        self.email = None
+        self.project_id = id
+        self.working_directory = None
+        self.task_output_root = None
+        self.task_start_time = None
+        self.user_upload_ids_by_task = {}
+        self.upload_context_partial = None
 
         logger.info(
             "Task lock initialized",

--- a/backend/app/service/upload/__init__.py
+++ b/backend/app/service/upload/__init__.py
@@ -1,0 +1,29 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from app.service.upload.service import (
+    BrainUploadService,
+    FullUploadContext,
+    PartialUploadContext,
+    SkippedUploadContext,
+    UploadContext,
+)
+
+__all__ = [
+    "BrainUploadService",
+    "FullUploadContext",
+    "PartialUploadContext",
+    "SkippedUploadContext",
+    "UploadContext",
+]

--- a/backend/app/service/upload/file_access.py
+++ b/backend/app/service/upload/file_access.py
@@ -1,0 +1,25 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from app.file_access import LocalFileAccess
+from app.utils.workspace_paths import get_workspace_root
+
+_instance: LocalFileAccess | None = None
+
+
+def get_file_access() -> LocalFileAccess:
+    global _instance
+    if _instance is None:
+        _instance = LocalFileAccess(workspace_root=str(get_workspace_root()))
+    return _instance

--- a/backend/app/service/upload/service.py
+++ b/backend/app/service/upload/service.py
@@ -1,0 +1,658 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import time
+import zipfile
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+import httpx
+
+from app.component.environment import env
+from app.model.chat import Chat
+from app.service.upload.user_uploads import UploadIdError, resolve_user_upload
+from app.utils.server.url import normalize_server_url
+from app.utils.workspace_paths import workspace_state_root
+
+logger = logging.getLogger("brain_upload_service")
+
+EXCLUDED_DIRS = {
+    ".git",
+    "node_modules",
+    ".venv",
+    "venv",
+    "__pycache__",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    ".eigent",
+    "target",
+    "coverage",
+}
+EXCLUDED_FILES = {
+    ".DS_Store",
+    ".note_register",
+}
+HTTP_TIMEOUT = httpx.Timeout(60.0)
+HTTP_LIMITS = httpx.Limits(max_keepalive_connections=10, max_connections=20)
+MTIME_EPSILON_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class PartialUploadContext:
+    session_id: str
+    raw_server_url: str
+    authorization: str
+    task_output_root: Path
+    task_start_time: float
+    camel_log_dir: Path
+
+
+@dataclass(frozen=True)
+class _BaseUploadContext:
+    task_id: str
+    project_id: str
+    email: str
+    session_id: str
+
+
+@dataclass(frozen=True)
+class FullUploadContext(_BaseUploadContext):
+    server_url: str
+    authorization: str
+    task_output_root: Path
+    task_start_time: float
+    camel_log_dir: Path
+    user_upload_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SkippedUploadContext(_BaseUploadContext):
+    skip_reason: str
+
+
+UploadContext = FullUploadContext | SkippedUploadContext
+
+
+@dataclass
+class UploadItem:
+    kind: Literal[
+        "user_upload", "workspace_artifact", "camel_logs", "artifact_manifest"
+    ]
+    relative_path: str
+    display_name: str
+    size: int
+    status: Literal[
+        "pending",
+        "uploading",
+        "done",
+        "failed",
+        "missing",
+        "cancelled",
+        "invalid",
+    ]
+    error: str | None = None
+    sha256: str | None = None
+    remote_key: str | None = None
+
+
+@dataclass
+class UploadState:
+    task_id: str
+    project_id: str
+    email: str
+    session_id: str
+    started_at: float
+    completed_at: float | None
+    items: list[UploadItem] = field(default_factory=list)
+    overall_status: Literal[
+        "pending", "running", "succeeded", "partial", "failed", "skipped"
+    ] = "running"
+    truncated: bool = False
+    skipped_paths: list[str] = field(default_factory=list)
+    skip_reason: str | None = None
+
+    @classmethod
+    def from_context(cls, ctx: FullUploadContext) -> "UploadState":
+        return cls(
+            task_id=ctx.task_id,
+            project_id=ctx.project_id,
+            email=ctx.email,
+            session_id=ctx.session_id,
+            started_at=time.time(),
+            completed_at=None,
+        )
+
+    @classmethod
+    def skipped_from(cls, ctx: SkippedUploadContext) -> "UploadState":
+        now = time.time()
+        return cls(
+            task_id=ctx.task_id,
+            project_id=ctx.project_id,
+            email=ctx.email,
+            session_id=ctx.session_id,
+            started_at=now,
+            completed_at=now,
+            overall_status="skipped",
+            skip_reason=ctx.skip_reason,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "task_id": self.task_id,
+            "project_id": self.project_id,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "overall_status": self.overall_status,
+            "truncated": self.truncated,
+            "skipped_paths": list(self.skipped_paths),
+            "skip_reason": self.skip_reason,
+            "items": [item.__dict__.copy() for item in self.items],
+        }
+
+
+class BrainUploadService:
+    _instance: "BrainUploadService | None" = None
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, asyncio.Task] = {}
+        self._states: dict[str, UploadState] = {}
+        self._http_client: httpx.AsyncClient | None = None
+
+    @classmethod
+    def singleton(cls) -> "BrainUploadService":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def finalize_at_task_end(
+        cls, options: Chat, task_lock, request
+    ) -> UploadContext:
+        task_id = (
+            getattr(task_lock, "current_task_id", None) or options.task_id
+        )
+        partial = getattr(task_lock, "upload_context_partial", None)
+        session_id = (
+            getattr(partial, "session_id", None)
+            or getattr(task_lock, "session_id", "")
+            or getattr(getattr(request, "state", None), "session_id", "")
+        )
+        base = {
+            "task_id": task_id,
+            "project_id": options.project_id,
+            "email": getattr(task_lock, "email", None) or options.email,
+            "session_id": session_id,
+        }
+        if partial is None:
+            return SkippedUploadContext(**base, skip_reason="missing_context")
+
+        server_url = normalize_server_url(
+            partial.raw_server_url or env("SERVER_URL", "")
+        )
+        if not server_url:
+            return SkippedUploadContext(**base, skip_reason="no_server_url")
+
+        authorization = partial.authorization
+        if not authorization and request is not None:
+            authorization = request.headers.get("Authorization", "")
+        if not authorization:
+            return SkippedUploadContext(**base, skip_reason="no_authorization")
+
+        return FullUploadContext(
+            **base,
+            server_url=server_url,
+            authorization=authorization,
+            task_output_root=partial.task_output_root,
+            task_start_time=partial.task_start_time,
+            camel_log_dir=partial.camel_log_dir,
+            user_upload_ids=tuple(
+                getattr(task_lock, "user_upload_ids_by_task", {}).get(
+                    task_id, []
+                )
+            ),
+        )
+
+    def register_and_start(self, ctx: UploadContext, task_id: str) -> None:
+        self._prune_states()
+        if isinstance(ctx, SkippedUploadContext):
+            self._states[task_id] = UploadState.skipped_from(ctx)
+            return
+        state = UploadState.from_context(ctx)
+        self._states[ctx.task_id] = state
+        task = asyncio.create_task(
+            self._run(ctx, state), name=f"upload-{ctx.task_id}"
+        )
+        self._tasks[ctx.task_id] = task
+        task.add_done_callback(self._make_task_done_callback(ctx.task_id))
+
+    def get_state(self, task_id: str) -> UploadState | None:
+        self._prune_states()
+        return self._states.get(task_id)
+
+    def _make_task_done_callback(self, task_id: str):
+        def _done(_: asyncio.Task) -> None:
+            self._tasks.pop(task_id, None)
+            self._prune_states()
+
+        return _done
+
+    def _prune_states(self, now: float | None = None) -> None:
+        if not self._states:
+            return
+        ttl = self._state_ttl_seconds()
+        cutoff = (time.time() if now is None else now) - ttl
+        stale_task_ids = [
+            task_id
+            for task_id, state in self._states.items()
+            if state.completed_at is not None and state.completed_at < cutoff
+        ]
+        for task_id in stale_task_ids:
+            self._states.pop(task_id, None)
+
+    def _state_ttl_seconds(self) -> int:
+        raw = env("WORKSPACE_UPLOAD_STATE_TTL_SECONDS", "3600")
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            return 3600
+
+    def _get_http_client(self) -> httpx.AsyncClient:
+        if self._http_client is None or self._http_client.is_closed:
+            self._http_client = httpx.AsyncClient(
+                timeout=HTTP_TIMEOUT,
+                limits=HTTP_LIMITS,
+            )
+        return self._http_client
+
+    async def close(self) -> None:
+        if self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    async def _run(self, ctx: FullUploadContext, state: UploadState) -> None:
+        try:
+            await self._upload_user_files(ctx, state)
+            await self._upload_workspace_artifacts(ctx, state)
+            await self._upload_camel_logs(ctx, state)
+            self._set_terminal_status(state)
+            state.completed_at = time.time()
+            await self._upload_artifact_manifest(ctx, state)
+            self._set_terminal_status(state)
+        except asyncio.CancelledError:
+            state.overall_status = "partial"
+            raise
+        except Exception as exc:
+            state.overall_status = "failed"
+            logger.exception("upload failed: %s", exc)
+        finally:
+            state.completed_at = time.time()
+            await asyncio.to_thread(self._write_artifact_manifest, ctx, state)
+
+    def _set_terminal_status(self, state: UploadState) -> None:
+        if any(
+            item.status in {"failed", "missing", "invalid", "cancelled"}
+            for item in state.items
+        ):
+            state.overall_status = "partial"
+        else:
+            state.overall_status = "succeeded"
+
+    async def _upload_user_files(
+        self, ctx: FullUploadContext, state: UploadState
+    ) -> None:
+        for upload_id in ctx.user_upload_ids:
+            try:
+                abs_path, original_filename = resolve_user_upload(
+                    upload_id, ctx.session_id
+                )
+            except UploadIdError as exc:
+                state.items.append(
+                    UploadItem(
+                        kind="user_upload",
+                        relative_path=upload_id,
+                        display_name=upload_id,
+                        size=0,
+                        status="invalid",
+                        error=str(exc),
+                    )
+                )
+                continue
+            if not abs_path.exists() or not abs_path.is_file():
+                state.items.append(
+                    UploadItem(
+                        kind="user_upload",
+                        relative_path=upload_id,
+                        display_name=original_filename,
+                        size=0,
+                        status="missing",
+                    )
+                )
+                continue
+            await self._upload_item(
+                ctx,
+                state,
+                "user_upload",
+                abs_path,
+                original_filename,
+                original_filename,
+            )
+
+    async def _upload_workspace_artifacts(
+        self, ctx: FullUploadContext, state: UploadState
+    ) -> None:
+        root = ctx.task_output_root
+        if not root.exists() or not root.is_dir():
+            return
+        for path in self._enumerate_workspace_files(ctx, state):
+            rel = path.relative_to(root).as_posix()
+            await self._upload_item(
+                ctx,
+                state,
+                "workspace_artifact",
+                path,
+                rel,
+                path.name,
+            )
+
+    async def _upload_camel_logs(
+        self, ctx: FullUploadContext, state: UploadState
+    ) -> None:
+        log_dir = ctx.camel_log_dir
+        if not log_dir.exists() or not log_dir.is_dir():
+            return
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            zip_path = Path(tmp.name)
+        try:
+            await asyncio.to_thread(self._zip_dir, log_dir, zip_path)
+            item = UploadItem(
+                kind="camel_logs",
+                relative_path="camel_logs.zip",
+                display_name="camel_logs.zip",
+                size=zip_path.stat().st_size,
+                status="uploading",
+                sha256=self._sha256(zip_path),
+            )
+            state.items.append(item)
+            try:
+                await asyncio.shield(
+                    self._upload_logs_to_server(ctx, zip_path)
+                )
+                item.status = "done"
+            except Exception as exc:
+                item.status = "failed"
+                item.error = str(exc)
+        finally:
+            try:
+                zip_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    async def _upload_artifact_manifest(
+        self, ctx: FullUploadContext, state: UploadState
+    ) -> None:
+        manifest_path = await asyncio.to_thread(
+            self._write_artifact_manifest, ctx, state
+        )
+        item = UploadItem(
+            kind="artifact_manifest",
+            relative_path=manifest_path.name,
+            display_name="artifact_manifest.json",
+            size=manifest_path.stat().st_size,
+            status="uploading",
+            sha256=self._sha256(manifest_path),
+        )
+        state.items.append(item)
+        try:
+            remote_key = await asyncio.shield(
+                self._upload_to_server(ctx, manifest_path, item.display_name)
+            )
+            item.remote_key = remote_key
+            item.status = "done"
+        except Exception as exc:
+            item.status = "failed"
+            item.error = str(exc)
+        finally:
+            await asyncio.to_thread(self._write_artifact_manifest, ctx, state)
+
+    def _enumerate_workspace_files(
+        self, ctx: FullUploadContext, state: UploadState
+    ) -> Iterable[Path]:
+        max_file_size = int(
+            env("WORKSPACE_UPLOAD_MAX_FILE_SIZE", str(500 * 1024 * 1024))
+        )
+        max_total_size = int(
+            env("WORKSPACE_UPLOAD_MAX_TOTAL_SIZE", str(2 * 1024 * 1024 * 1024))
+        )
+        max_file_count = int(env("WORKSPACE_UPLOAD_MAX_FILE_COUNT", "500"))
+        max_walk_entries = int(
+            env("WORKSPACE_UPLOAD_MAX_WALK_ENTRIES", "20000")
+        )
+        candidates: list[Path] = []
+        walked = 0
+        root = ctx.task_output_root
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in EXCLUDED_DIRS]
+            for filename in filenames:
+                if filename in EXCLUDED_FILES:
+                    continue
+                walked += 1
+                if walked > max_walk_entries:
+                    state.truncated = True
+                    return self._select_candidates(
+                        candidates, root, state, max_file_count, max_total_size
+                    )
+                path = Path(dirpath) / filename
+                try:
+                    stat = path.stat()
+                    if stat.st_mtime < (
+                        ctx.task_start_time - MTIME_EPSILON_SECONDS
+                    ):
+                        continue
+                    if stat.st_size > max_file_size:
+                        state.skipped_paths.append(
+                            path.relative_to(root).as_posix()
+                        )
+                        continue
+                except OSError:
+                    continue
+                candidates.append(path)
+        candidates = self._filter_gitignore(root, candidates)
+        return self._select_candidates(
+            candidates, root, state, max_file_count, max_total_size
+        )
+
+    def _select_candidates(
+        self,
+        candidates: list[Path],
+        root: Path,
+        state: UploadState,
+        max_file_count: int,
+        max_total_size: int,
+    ) -> list[Path]:
+        selected: list[Path] = []
+        total = 0
+        for path in sorted(
+            candidates, key=lambda p: p.stat().st_mtime, reverse=True
+        ):
+            try:
+                size = path.stat().st_size
+            except OSError:
+                continue
+            if (
+                len(selected) >= max_file_count
+                or total + size > max_total_size
+            ):
+                state.truncated = True
+                try:
+                    state.skipped_paths.append(
+                        path.relative_to(root).as_posix()
+                    )
+                except ValueError:
+                    pass
+                continue
+            selected.append(path)
+            total += size
+        return selected
+
+    def _filter_gitignore(
+        self, root: Path, candidates: list[Path]
+    ) -> list[Path]:
+        gitignore = root / ".gitignore"
+        if not gitignore.exists():
+            return candidates
+        try:
+            import pathspec
+
+            spec = pathspec.PathSpec.from_lines(
+                "gitwildmatch",
+                gitignore.read_text(
+                    encoding="utf-8", errors="ignore"
+                ).splitlines(),
+            )
+            return [
+                p
+                for p in candidates
+                if not spec.match_file(str(p.relative_to(root)))
+            ]
+        except Exception:
+            logger.warning("Failed to apply .gitignore filter", exc_info=True)
+            return candidates
+
+    async def _upload_item(
+        self,
+        ctx: FullUploadContext,
+        state: UploadState,
+        kind: Literal["user_upload", "workspace_artifact"],
+        abs_path: Path,
+        relative_path: str,
+        display_name: str,
+    ) -> None:
+        item = UploadItem(
+            kind=kind,
+            relative_path=relative_path,
+            display_name=display_name,
+            size=abs_path.stat().st_size,
+            status="uploading",
+            sha256=self._sha256(abs_path),
+        )
+        state.items.append(item)
+        try:
+            remote_key = await asyncio.shield(
+                self._upload_to_server(ctx, abs_path, display_name)
+            )
+            item.remote_key = remote_key
+            item.status = "done"
+        except asyncio.CancelledError:
+            item.status = "cancelled"
+            raise
+        except Exception as exc:
+            item.status = "failed"
+            item.error = str(exc)
+
+    async def _upload_to_server(
+        self, ctx: FullUploadContext, abs_path: Path, display_name: str
+    ) -> str | None:
+        with abs_path.open("rb") as fp:
+            files = {"file": (display_name, fp, "application/octet-stream")}
+            data = {"task_id": ctx.task_id}
+            client = self._get_http_client()
+            resp = await client.post(
+                f"{ctx.server_url}/chat/files/upload",
+                data=data,
+                files=files,
+                headers={"Authorization": ctx.authorization},
+            )
+            resp.raise_for_status()
+            return self._extract_remote_key(resp)
+
+    async def _upload_logs_to_server(
+        self, ctx: FullUploadContext, zip_path: Path
+    ) -> None:
+        with zip_path.open("rb") as fp:
+            files = {"file": ("camel_logs.zip", fp, "application/zip")}
+            data = {"task_id": ctx.task_id}
+            client = self._get_http_client()
+            resp = await client.post(
+                f"{ctx.server_url}/chat/logs",
+                data=data,
+                files=files,
+                headers={"Authorization": ctx.authorization},
+            )
+            resp.raise_for_status()
+
+    def _zip_dir(self, source: Path, target: Path) -> None:
+        with zipfile.ZipFile(target, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path in source.rglob("*"):
+                if path.is_file():
+                    zf.write(path, path.relative_to(source))
+
+    def _write_artifact_manifest(
+        self, ctx: FullUploadContext, state: UploadState
+    ) -> Path:
+        path = (
+            workspace_state_root(ctx.email)
+            / "tasks"
+            / f"{ctx.task_id}.artifacts.json"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "version": 1,
+            "task_id": ctx.task_id,
+            "project_id": ctx.project_id,
+            "workspace_name": ctx.task_output_root.name,
+            "task_start_time": ctx.task_start_time,
+            "created_at": state.started_at,
+            "completed_at": state.completed_at,
+            "overall_status": state.overall_status,
+            "truncated": state.truncated,
+            "skipped_paths": list(state.skipped_paths),
+            "items": [item.__dict__.copy() for item in state.items],
+        }
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        tmp_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        tmp_path.replace(path)
+        return path
+
+    def _sha256(self, path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as fp:
+            for chunk in iter(lambda: fp.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _extract_remote_key(self, resp: httpx.Response) -> str | None:
+        try:
+            data = resp.json()
+        except ValueError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        for key in ("s3_key", "key", "path"):
+            value = data.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None

--- a/backend/app/service/upload/user_uploads.py
+++ b/backend/app/service/upload/user_uploads.py
@@ -1,0 +1,72 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import json
+import unicodedata
+from pathlib import Path
+
+from app.utils.server.session import SessionIdError, get_session_uploads_dir
+from app.utils.workspace_paths import get_workspace_root
+
+
+class UploadIdError(Exception):
+    pass
+
+
+def _is_safe_stored_name(name: str) -> bool:
+    if not name:
+        return False
+    if "/" in name or "\\" in name:
+        return False
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in name):
+        return False
+    if name in {".", ".."}:
+        return False
+    if name.startswith(".."):
+        return False
+    if unicodedata.normalize("NFKC", name) != name:
+        return False
+    return True
+
+
+def resolve_user_upload(upload_id: str, session_id: str) -> tuple[Path, str]:
+    if not upload_id.startswith("upload://"):
+        raise UploadIdError(f"invalid_prefix:{upload_id!r}")
+
+    stored_name = upload_id[len("upload://") :]
+    if not _is_safe_stored_name(stored_name):
+        raise UploadIdError(f"invalid_stored_name:{stored_name!r}")
+    if stored_name.endswith(".meta.json"):
+        raise UploadIdError(f"sidecar_not_uploadable:{stored_name!r}")
+
+    try:
+        uploads_dir = get_session_uploads_dir(session_id, get_workspace_root())
+    except SessionIdError as exc:
+        raise UploadIdError(f"session_id_invalid:{exc}") from exc
+
+    abs_path = (uploads_dir / stored_name).resolve()
+    try:
+        abs_path.relative_to(uploads_dir)
+    except ValueError as exc:
+        raise UploadIdError(f"escapes_uploads_dir:{stored_name!r}") from exc
+
+    original = stored_name
+    meta_path = uploads_dir / f"{stored_name}.meta.json"
+    if meta_path.exists():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            original = meta.get("original_filename") or stored_name
+        except Exception:
+            original = stored_name
+    return abs_path, original

--- a/backend/app/utils/file_utils.py
+++ b/backend/app/utils/file_utils.py
@@ -276,6 +276,12 @@ def get_working_directory(options: Chat, task_lock=None) -> str:
     raw: Path | str
     if (
         task_lock
+        and hasattr(task_lock, "working_directory")
+        and task_lock.working_directory
+    ):
+        raw = Path(task_lock.working_directory)
+    elif (
+        task_lock
         and hasattr(task_lock, "new_folder_path")
         and task_lock.new_folder_path
     ):

--- a/backend/app/utils/server/session.py
+++ b/backend/app/utils/server/session.py
@@ -1,0 +1,40 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import re
+from pathlib import Path
+
+SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
+class SessionIdError(ValueError):
+    pass
+
+
+def validate_session_id(session_id: str) -> str:
+    normalized = (session_id or "").strip()
+    if not SESSION_ID_PATTERN.fullmatch(normalized):
+        raise SessionIdError("Invalid X-Session-ID")
+    return normalized
+
+
+def get_session_uploads_dir(session_id: str, workspace_root: Path) -> Path:
+    root = workspace_root.expanduser().resolve()
+    validated = validate_session_id(session_id)
+    uploads_dir = (root / validated / "uploads").resolve()
+    try:
+        uploads_dir.relative_to(root)
+    except ValueError as exc:
+        raise SessionIdError("Invalid X-Session-ID") from exc
+    return uploads_dir

--- a/backend/app/utils/server/sync_step.py
+++ b/backend/app/utils/server/sync_step.py
@@ -30,6 +30,7 @@ import httpx
 
 from app.component.environment import env
 from app.service.task import get_task_lock_if_exists
+from app.utils.server.url import normalize_server_url
 
 logger = logging.getLogger("sync_step")
 
@@ -44,16 +45,6 @@ _logged_sync_targets: set[str] = set()
 _logged_first_sync_tasks: set[str] = set()
 
 
-def _normalize_server_url(server_url: str | None) -> str:
-    if not server_url:
-        return ""
-
-    trimmed = server_url.rstrip("/")
-    if trimmed.endswith("/api/v1"):
-        return trimmed
-    return f"{trimmed}/api/v1"
-
-
 def _get_config(args):
     server_url = (
         getattr(args[0], "server_url", None)
@@ -64,7 +55,7 @@ def _get_config(args):
     if not server_url:
         server_url = env("SERVER_URL", "")
 
-    server_url = _normalize_server_url(server_url)
+    server_url = normalize_server_url(server_url)
 
     if not server_url:
         return None

--- a/backend/app/utils/server/url.py
+++ b/backend/app/utils/server/url.py
@@ -1,0 +1,22 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+
+def normalize_server_url(server_url: str | None) -> str:
+    if not server_url:
+        return ""
+    trimmed = server_url.rstrip("/")
+    if trimmed.endswith("/api/v1"):
+        return trimmed
+    return f"{trimmed}/api/v1"

--- a/backend/app/utils/workspace_paths.py
+++ b/backend/app/utils/workspace_paths.py
@@ -1,0 +1,84 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import re
+from pathlib import Path
+
+from app.component.environment import env
+
+
+def get_workspace_root() -> Path:
+    return Path(env("EIGENT_WORKSPACE", "~/.eigent/workspace")).expanduser()
+
+
+def get_eigent_root() -> Path:
+    eigent = Path.home() / "eigent"
+    if eigent.exists():
+        return eigent
+    dot_eigent = Path.home() / ".eigent"
+    if dot_eigent.exists():
+        return dot_eigent
+    return eigent
+
+
+def sanitize_email(email: str) -> str:
+    return re.sub(r'[\\/*?:"<>|\s]', "_", email.split("@")[0]).strip(".")
+
+
+def project_root(email: str, project_id: str) -> Path:
+    return get_eigent_root() / sanitize_email(email) / f"project_{project_id}"
+
+
+def project_task_root(email: str, project_id: str, task_id: str) -> Path:
+    return project_root(email, project_id) / f"task_{task_id}"
+
+
+def legacy_task_root(email: str, task_id: str) -> Path:
+    return get_eigent_root() / sanitize_email(email) / f"task_{task_id}"
+
+
+def camel_log_root(email: str, project_id: str, task_id: str) -> Path:
+    return (
+        Path.home()
+        / ".eigent"
+        / sanitize_email(email)
+        / f"project_{project_id}"
+        / f"task_{task_id}"
+        / "camel_logs"
+    )
+
+
+def legacy_camel_log_root(email: str, task_id: str) -> Path:
+    return (
+        Path.home()
+        / ".eigent"
+        / sanitize_email(email)
+        / f"task_{task_id}"
+        / "camel_logs"
+    )
+
+
+def runtime_task_root(email: str, project_id: str, task_id: str) -> Path:
+    return (
+        Path.home()
+        / ".eigent"
+        / sanitize_email(email)
+        / "runtime"
+        / f"project_{project_id}"
+        / f"task_{task_id}"
+    )
+
+
+def workspace_state_root(email: str) -> Path:
+    return Path.home() / ".eigent" / "workspaces" / sanitize_email(email)

--- a/backend/app/utils/workspace_resolver.py
+++ b/backend/app/utils/workspace_resolver.py
@@ -1,0 +1,249 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.model.chat import Chat
+from app.utils.workspace_paths import (
+    camel_log_root,
+    legacy_camel_log_root,
+    legacy_task_root,
+    project_root,
+    project_task_root,
+    workspace_state_root,
+)
+
+logger = logging.getLogger("workspace_resolver")
+
+
+@dataclass(frozen=True)
+class WorkspaceBinding:
+    project_id: str
+    workspace_root: str
+    source: str
+    created_at: str
+    updated_at: str
+    version: int = 1
+
+
+@dataclass(frozen=True)
+class TaskSnapshot:
+    task_id: str
+    project_id: str
+    working_directory: str
+    task_output_root: str
+    task_start_time: float
+    binding_source: str
+    created_at: str
+    version: int = 1
+
+
+class WorkspaceStore:
+    def _project_path(self, email: str, project_id: str) -> Path:
+        return workspace_state_root(email) / "projects" / f"{project_id}.json"
+
+    def _task_path(self, email: str, task_id: str) -> Path:
+        return workspace_state_root(email) / "tasks" / f"{task_id}.json"
+
+    def get_binding(
+        self, email: str, project_id: str
+    ) -> WorkspaceBinding | None:
+        path = self._project_path(email, project_id)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return WorkspaceBinding(**data)
+        except Exception:
+            logger.warning("Failed to read workspace binding: %s", path)
+            return None
+
+    def save_binding(
+        self, email: str, project_id: str, workspace_root: str
+    ) -> WorkspaceBinding:
+        now = datetime.now(UTC).isoformat()
+        existing = self.get_binding(email, project_id)
+        binding = WorkspaceBinding(
+            project_id=project_id,
+            workspace_root=workspace_root,
+            source="local_brain",
+            created_at=existing.created_at if existing else now,
+            updated_at=now,
+        )
+        path = self._project_path(email, project_id)
+        self._atomic_write(path, asdict(binding))
+        return binding
+
+    def delete_binding(self, email: str, project_id: str) -> None:
+        path = self._project_path(email, project_id)
+        if path.exists():
+            path.unlink()
+
+    def get_snapshot(self, email: str, task_id: str) -> TaskSnapshot | None:
+        path = self._task_path(email, task_id)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return TaskSnapshot(**data)
+        except Exception:
+            logger.warning("Failed to read task snapshot: %s", path)
+            return None
+
+    def save_snapshot(self, email: str, snapshot: TaskSnapshot) -> None:
+        self._atomic_write(
+            self._task_path(email, snapshot.task_id), asdict(snapshot)
+        )
+
+    def _atomic_write(self, path: Path, data: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        tmp_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        tmp_path.replace(path)
+
+
+@dataclass(frozen=True)
+class FrozenTaskDirectories:
+    working_directory: Path
+    task_output_root: Path
+    task_start_time: float
+    binding_source: str
+    snapshot: TaskSnapshot
+
+
+class WorkspaceResolver:
+    def __init__(self, store: WorkspaceStore | None = None) -> None:
+        self.store = store or WorkspaceStore()
+
+    def project_root(self, project_id: str, email: str) -> Path:
+        binding = self.store.get_binding(email, project_id)
+        if binding:
+            bound_path = Path(binding.workspace_root).expanduser()
+            if bound_path.is_dir():
+                return bound_path
+
+        legacy_project = project_root(email, project_id)
+        if legacy_project.exists():
+            return legacy_project
+        return legacy_project
+
+    def task_output_root(
+        self, project_id: str, task_id: str, email: str
+    ) -> Path:
+        snapshot = self.store.get_snapshot(email, task_id)
+        if snapshot:
+            return Path(snapshot.task_output_root).expanduser()
+
+        old_project_task = project_task_root(email, project_id, task_id)
+        if old_project_task.exists():
+            return old_project_task
+
+        old_legacy_task = legacy_task_root(email, task_id)
+        if old_legacy_task.exists():
+            return old_legacy_task
+
+        binding = self.store.get_binding(email, project_id)
+        if binding:
+            bound_path = Path(binding.workspace_root).expanduser()
+            if bound_path.is_dir():
+                return bound_path
+
+        return old_project_task
+
+    def log_root(self, project_id: str, task_id: str, email: str) -> Path:
+        root = camel_log_root(email, project_id, task_id)
+        if root.exists():
+            return root
+        legacy = legacy_camel_log_root(email, task_id)
+        if legacy.exists():
+            return legacy
+        return root
+
+    def freeze_task_directories(
+        self, options: Chat, task_lock
+    ) -> FrozenTaskDirectories:
+        return self.freeze_task_directories_for(
+            project_id=options.project_id,
+            task_id=options.task_id,
+            email=options.email,
+            task_lock=task_lock,
+            fallback_task_root=options.file_save_path(),
+        )
+
+    def freeze_task_directories_for(
+        self,
+        project_id: str,
+        task_id: str,
+        email: str,
+        task_lock,
+        fallback_task_root: str | Path | None = None,
+    ) -> FrozenTaskDirectories:
+        binding = self.store.get_binding(email, project_id)
+        if binding and Path(binding.workspace_root).expanduser().is_dir():
+            directory = Path(binding.workspace_root).expanduser()
+            binding_source = "local_brain"
+        elif fallback_task_root is not None:
+            directory = Path(fallback_task_root).expanduser()
+            binding_source = "default"
+        else:
+            directory = project_task_root(email, project_id, task_id)
+            binding_source = "default"
+
+        directory.mkdir(parents=True, exist_ok=True)
+        task_start_time = time.time()
+        snapshot = TaskSnapshot(
+            task_id=task_id,
+            project_id=project_id,
+            working_directory=str(directory),
+            task_output_root=str(directory),
+            task_start_time=task_start_time,
+            binding_source=binding_source,
+            created_at=datetime.now(UTC).isoformat(),
+        )
+
+        task_lock.working_directory = str(directory)
+        task_lock.task_output_root = str(directory)
+        task_lock.task_start_time = task_start_time
+        task_lock.email = email
+        task_lock.project_id = project_id
+        task_lock.current_task_id = task_id
+
+        return FrozenTaskDirectories(
+            working_directory=directory,
+            task_output_root=directory,
+            task_start_time=task_start_time,
+            binding_source=binding_source,
+            snapshot=snapshot,
+        )
+
+    def write_task_snapshot(self, email: str, snapshot: TaskSnapshot) -> None:
+        self.store.save_snapshot(email, snapshot)
+
+
+_resolver: WorkspaceResolver | None = None
+
+
+def get_workspace_resolver() -> WorkspaceResolver:
+    global _resolver
+    if _resolver is None:
+        _resolver = WorkspaceResolver()
+    return _resolver

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "opentelemetry-api>=1.34.1",
     "opentelemetry-sdk>=1.34.1",
     "opentelemetry-exporter-otlp-proto-http>=1.34.1",
+    "pathspec>=0.12.0",
 ]
 
 

--- a/backend/tests/app/controller/test_workspace_controller.py
+++ b/backend/tests/app/controller/test_workspace_controller.py
@@ -1,0 +1,243 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+import app.utils.workspace_resolver as workspace_resolver_module
+from app.controller.workspace_controller import router
+from app.model.chat import Status
+from app.service.task import get_or_create_task_lock, task_locks
+
+
+class DummyHands:
+    def __init__(
+        self,
+        deployment: str = "local",
+        validation: tuple[bool, str | None] = (True, None),
+    ) -> None:
+        self.deployment = deployment
+        self.validation = validation
+
+    def get_capability_manifest(self) -> dict[str, Any]:
+        return {
+            "deployment": self.deployment,
+            "filesystem": "full",
+            "workspace_root": "/tmp/workspace",
+        }
+
+    def validate_workspace_binding_path(
+        self, path: str
+    ) -> tuple[bool, str | None]:
+        return self.validation
+
+    def can_access_filesystem(self, path: str) -> bool:
+        return self.validation[0]
+
+
+def _client(hands: DummyHands) -> TestClient:
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _inject_state(request: Request, call_next):
+        request.state.hands = hands
+        request.state.session_id = "sess_test"
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(workspace_resolver_module, "_resolver", None)
+    task_locks.clear()
+    yield
+    task_locks.clear()
+    monkeypatch.setattr(workspace_resolver_module, "_resolver", None)
+
+
+@pytest.mark.unit
+def test_capabilities_do_not_advertise_folder_chooser():
+    response = _client(DummyHands()).get("/workspace/capabilities")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["binding_enabled"] is True
+    assert data["label"] == "Local Brain"
+    assert "folder_chooser" not in data
+
+
+@pytest.mark.unit
+def test_bind_disabled_for_cloud_workspace(tmp_path: Path):
+    folder = tmp_path / "project"
+    folder.mkdir()
+
+    response = _client(DummyHands(deployment="cloud_vm")).post(
+        "/workspace/bind",
+        json={
+            "project_id": "project-1",
+            "email": "alice@example.com",
+            "path": str(folder),
+        },
+    )
+
+    assert response.status_code == 412
+    assert response.json()["detail"]["code"] == "workspace_binding_disabled"
+
+
+@pytest.mark.unit
+def test_bind_rejects_active_task(tmp_path: Path):
+    folder = tmp_path / "project"
+    folder.mkdir()
+    lock = get_or_create_task_lock("project-1")
+    lock.status = Status.processing
+
+    response = _client(DummyHands()).post(
+        "/workspace/bind",
+        json={
+            "project_id": "project-1",
+            "email": "alice@example.com",
+            "path": str(folder),
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "active_task_exists"
+
+
+@pytest.mark.unit
+def test_bind_maps_sensitive_path_to_forbidden(tmp_path: Path):
+    folder = tmp_path / "project"
+    folder.mkdir()
+
+    response = _client(
+        DummyHands(validation=(False, f"sensitive_path:{folder}"))
+    ).post(
+        "/workspace/bind",
+        json={
+            "project_id": "project-1",
+            "email": "alice@example.com",
+            "path": str(folder),
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["reason"].startswith("sensitive_path:")
+
+
+@pytest.mark.unit
+def test_bind_maps_invalid_folder_to_bad_request(tmp_path: Path):
+    missing = tmp_path / "missing"
+
+    response = _client(DummyHands(validation=(False, "path_not_found"))).post(
+        "/workspace/bind",
+        json={
+            "project_id": "project-1",
+            "email": "alice@example.com",
+            "path": str(missing),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["reason"] == "path_not_found"
+
+
+@pytest.mark.unit
+def test_bind_current_and_delete_is_not_allowed(tmp_path: Path):
+    folder = tmp_path / "project"
+    folder.mkdir()
+    client = _client(DummyHands())
+
+    bind_response = client.post(
+        "/workspace/bind",
+        json={
+            "project_id": "project-1",
+            "email": "alice@example.com",
+            "path": str(folder),
+        },
+    )
+    assert bind_response.status_code == 200
+    assert bind_response.json()["workspace_root"] == str(folder.resolve())
+
+    current_response = client.get(
+        "/workspace/current",
+        params={"project_id": "project-1", "email": "alice@example.com"},
+    )
+    assert current_response.status_code == 200
+    assert current_response.json()["bound"] is True
+
+    delete_response = client.delete(
+        "/workspace/bind",
+        params={"project_id": "project-1", "email": "alice@example.com"},
+    )
+    assert delete_response.status_code == 405
+
+    current_after_delete_response = client.get(
+        "/workspace/current",
+        params={"project_id": "project-1", "email": "alice@example.com"},
+    )
+    assert current_after_delete_response.status_code == 200
+    assert current_after_delete_response.json()["bound"] is True
+
+
+@pytest.mark.unit
+def test_bind_same_project_to_new_folder_is_rejected(tmp_path: Path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    client = _client(DummyHands())
+
+    bind_response = client.post(
+        "/workspace/bind",
+        json={
+            "project_id": "project-1",
+            "email": "alice@example.com",
+            "path": str(first),
+        },
+    )
+    assert bind_response.status_code == 200
+
+    same_response = client.post(
+        "/workspace/bind",
+        json={
+            "project_id": "project-1",
+            "email": "alice@example.com",
+            "path": str(first),
+        },
+    )
+    assert same_response.status_code == 200
+
+    changed_response = client.post(
+        "/workspace/bind",
+        json={
+            "project_id": "project-1",
+            "email": "alice@example.com",
+            "path": str(second),
+        },
+    )
+
+    assert changed_response.status_code == 409
+    assert (
+        changed_response.json()["detail"]["code"] == "workspace_already_bound"
+    )

--- a/backend/tests/app/hands/test_environment_workspace_binding.py
+++ b/backend/tests/app/hands/test_environment_workspace_binding.py
@@ -1,0 +1,106 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from pathlib import Path
+
+import pytest
+
+from app.hands.capabilities import BrainCapabilities
+from app.hands.environment_hands import EnvironmentHands
+
+
+def _hands(
+    workspace_root: Path,
+    filesystem_scope: str = "full",
+) -> EnvironmentHands:
+    return EnvironmentHands(
+        BrainCapabilities(
+            filesystem_scope=filesystem_scope,
+            workspace_root=workspace_root,
+            deployment_type="local",
+        )
+    )
+
+
+@pytest.mark.unit
+def test_validate_workspace_binding_rejects_home_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    hands = _hands(home / "workspace")
+    monkeypatch.setattr(hands, "_sensitive_prefixes", lambda: [])
+
+    ok, reason = hands.validate_workspace_binding_path(str(home))
+
+    assert ok is False
+    assert reason == "home_root_forbidden"
+
+
+@pytest.mark.unit
+def test_validate_workspace_binding_rejects_sensitive_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    home = tmp_path / "home"
+    sensitive = home / ".ssh"
+    sensitive.mkdir(parents=True)
+    project = sensitive / "project"
+    project.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    hands = _hands(home / "workspace")
+    monkeypatch.setattr(hands, "_sensitive_prefixes", lambda: [sensitive])
+
+    ok, reason = hands.validate_workspace_binding_path(str(project))
+
+    assert ok is False
+    assert reason is not None
+    assert reason.startswith("sensitive_path:")
+
+
+@pytest.mark.unit
+def test_validate_workspace_binding_rejects_outside_workspace_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    hands = _hands(workspace, filesystem_scope="workspace_only")
+    monkeypatch.setattr(hands, "_sensitive_prefixes", lambda: [])
+
+    ok, reason = hands.validate_workspace_binding_path(str(outside))
+
+    assert ok is False
+    assert reason == "filesystem_capability_denied"
+
+
+@pytest.mark.unit
+def test_validate_workspace_binding_accepts_regular_home_subdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    home = tmp_path / "home"
+    project = home / "project"
+    project.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    hands = _hands(home / "workspace")
+    monkeypatch.setattr(hands, "_sensitive_prefixes", lambda: [])
+
+    ok, reason = hands.validate_workspace_binding_path(str(project))
+
+    assert ok is True
+    assert reason is None

--- a/backend/tests/app/service/upload/test_brain_upload_service.py
+++ b/backend/tests/app/service/upload/test_brain_upload_service.py
@@ -1,0 +1,187 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from app.service.upload.service import (
+    BrainUploadService,
+    FullUploadContext,
+    SkippedUploadContext,
+    UploadState,
+)
+
+
+@pytest.mark.unit
+def test_skipped_upload_state_is_pruned(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("WORKSPACE_UPLOAD_STATE_TTL_SECONDS", "1")
+    service = BrainUploadService()
+    service.register_and_start(
+        SkippedUploadContext(
+            task_id="task-1",
+            project_id="project-1",
+            email="alice@example.com",
+            session_id="sess_ok",
+            skip_reason="no_authorization",
+        ),
+        "task-1",
+    )
+
+    state = service.get_state("task-1")
+    assert state is not None
+    state.completed_at = time.time() - 5
+
+    assert service.get_state("task-1") is None
+
+
+@pytest.mark.unit
+def test_workspace_file_mtime_uses_epsilon(tmp_path: Path):
+    service = BrainUploadService()
+    root = tmp_path / "workspace"
+    root.mkdir()
+    task_start = time.time()
+    recent = root / "recent.txt"
+    recent.write_text("recent", encoding="utf-8")
+    old = root / "old.txt"
+    old.write_text("old", encoding="utf-8")
+    internal_note = root / ".note_register"
+    internal_note.write_text("internal", encoding="utf-8")
+    os.utime(recent, (task_start - 1, task_start - 1))
+    os.utime(old, (task_start - 10, task_start - 10))
+    os.utime(internal_note, (task_start - 1, task_start - 1))
+    ctx = FullUploadContext(
+        task_id="task-1",
+        project_id="project-1",
+        email="alice@example.com",
+        session_id="sess_ok",
+        server_url="http://localhost:3001/api/v1",
+        authorization="Bearer token",
+        task_output_root=root,
+        task_start_time=task_start,
+        camel_log_dir=tmp_path / "logs",
+        user_upload_ids=(),
+    )
+    state = UploadState.from_context(ctx)
+
+    paths = list(service._enumerate_workspace_files(ctx, state))
+
+    assert recent in paths
+    assert old not in paths
+    assert internal_note not in paths
+
+
+@pytest.mark.unit
+def test_http_client_is_reused():
+    service = BrainUploadService()
+
+    first = service._get_http_client()
+    second = service._get_http_client()
+
+    assert first is second
+    asyncio.run(service.close())
+
+
+@pytest.mark.unit
+def test_workspace_upload_uses_task_id(tmp_path: Path):
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, str]:
+            return {"s3_key": "remote/key.txt"}
+
+    class _Client:
+        def __init__(self) -> None:
+            self.data: dict[str, str] | None = None
+
+        async def post(self, *_args, data=None, **_kwargs):
+            self.data = data
+            return _Response()
+
+    service = BrainUploadService()
+    client = _Client()
+    service._get_http_client = lambda: client  # type: ignore[method-assign]
+    source = tmp_path / "report.py"
+    source.write_text("print('hello')", encoding="utf-8")
+    ctx = FullUploadContext(
+        task_id="task-1",
+        project_id="project-1",
+        email="alice@example.com",
+        session_id="sess_ok",
+        server_url="http://localhost:3001/api/v1",
+        authorization="Bearer token",
+        task_output_root=tmp_path,
+        task_start_time=time.time(),
+        camel_log_dir=tmp_path / "logs",
+        user_upload_ids=(),
+    )
+
+    remote_key = asyncio.run(
+        service._upload_to_server(ctx, source, source.name)
+    )
+
+    assert client.data == {"task_id": "task-1"}
+    assert remote_key == "remote/key.txt"
+
+
+@pytest.mark.unit
+def test_artifact_manifest_is_written_and_uploaded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, str]:
+            return {"s3_key": "remote/manifest.json"}
+
+    class _Client:
+        async def post(self, *_args, **_kwargs):
+            return _Response()
+
+    monkeypatch.setattr(
+        "app.service.upload.service.workspace_state_root",
+        lambda _email: tmp_path / "state",
+    )
+    service = BrainUploadService()
+    service._get_http_client = lambda: _Client()  # type: ignore[method-assign]
+    ctx = FullUploadContext(
+        task_id="task-1",
+        project_id="project-1",
+        email="alice@example.com",
+        session_id="sess_ok",
+        server_url="http://localhost:3001/api/v1",
+        authorization="Bearer token",
+        task_output_root=tmp_path / "workspace",
+        task_start_time=time.time(),
+        camel_log_dir=tmp_path / "logs",
+        user_upload_ids=(),
+    )
+    state = UploadState.from_context(ctx)
+
+    asyncio.run(service._upload_artifact_manifest(ctx, state))
+
+    manifest_path = tmp_path / "state" / "tasks" / "task-1.artifacts.json"
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert data["task_id"] == "task-1"
+    assert data["project_id"] == "project-1"
+    assert data["items"][0]["kind"] == "artifact_manifest"
+    assert data["items"][0]["remote_key"] == "remote/manifest.json"

--- a/backend/tests/app/service/upload/test_user_uploads.py
+++ b/backend/tests/app/service/upload/test_user_uploads.py
@@ -1,0 +1,81 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.service.upload.user_uploads import UploadIdError, resolve_user_upload
+
+
+@pytest.mark.unit
+def test_resolve_user_upload_allows_unicode_stored_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    workspace = tmp_path / "workspace"
+    monkeypatch.setenv("EIGENT_WORKSPACE", str(workspace))
+    uploads = workspace / "sess_ok" / "uploads"
+    uploads.mkdir(parents=True)
+    stored_name = "报告.pdf_123"
+    upload_path = uploads / stored_name
+    upload_path.write_bytes(b"ok")
+    (uploads / f"{stored_name}.meta.json").write_text(
+        json.dumps({"original_filename": "报告.pdf"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    path, original = resolve_user_upload(f"upload://{stored_name}", "sess_ok")
+
+    assert path == upload_path.resolve()
+    assert original == "报告.pdf"
+
+
+@pytest.mark.unit
+def test_resolve_user_upload_allows_middle_dotdot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    workspace = tmp_path / "workspace"
+    monkeypatch.setenv("EIGENT_WORKSPACE", str(workspace))
+    uploads = workspace / "sess_ok" / "uploads"
+    uploads.mkdir(parents=True)
+    stored_name = "version..1.txt_123"
+    upload_path = uploads / stored_name
+    upload_path.write_bytes(b"ok")
+
+    path, original = resolve_user_upload(f"upload://{stored_name}", "sess_ok")
+
+    assert path == upload_path.resolve()
+    assert original == stored_name
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("upload_id", "session_id"),
+    [
+        ("upload://../secret.txt", "sess_ok"),
+        ("upload://file.txt.meta.json", "sess_ok"),
+        ("upload://file.txt", "../sess_bad"),
+    ],
+)
+def test_resolve_user_upload_rejects_traversal_and_sidecars(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    upload_id: str,
+    session_id: str,
+):
+    monkeypatch.setenv("EIGENT_WORKSPACE", str(tmp_path / "workspace"))
+
+    with pytest.raises(UploadIdError):
+        resolve_user_upload(upload_id, session_id)

--- a/backend/tests/app/utils/test_workspace_resolver.py
+++ b/backend/tests/app/utils/test_workspace_resolver.py
@@ -1,0 +1,75 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from pathlib import Path
+
+import pytest
+
+from app.utils.workspace_paths import project_task_root
+from app.utils.workspace_resolver import WorkspaceResolver, WorkspaceStore
+
+
+@pytest.mark.unit
+def test_task_output_root_prefers_existing_old_task_over_binding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    old_task = project_task_root("alice@example.com", "project-1", "task-1")
+    old_task.mkdir(parents=True)
+    bound_root = tmp_path / "selected"
+    bound_root.mkdir()
+
+    resolver = WorkspaceResolver(WorkspaceStore())
+    resolver.store.save_binding(
+        "alice@example.com",
+        "project-1",
+        str(bound_root),
+    )
+
+    assert (
+        resolver.task_output_root("project-1", "task-1", "alice@example.com")
+        == old_task
+    )
+
+
+@pytest.mark.unit
+def test_frozen_task_snapshot_wins_for_bound_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    bound_root = tmp_path / "selected"
+    bound_root.mkdir()
+
+    resolver = WorkspaceResolver(WorkspaceStore())
+    resolver.store.save_binding(
+        "alice@example.com",
+        "project-1",
+        str(bound_root),
+    )
+
+    class TaskLock:
+        pass
+
+    frozen = resolver.freeze_task_directories_for(
+        project_id="project-1",
+        task_id="task-2",
+        email="alice@example.com",
+        task_lock=TaskLock(),
+    )
+    resolver.write_task_snapshot("alice@example.com", frozen.snapshot)
+
+    assert (
+        resolver.task_output_root("project-1", "task-2", "alice@example.com")
+        == bound_root
+    )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -225,6 +225,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
+    { name = "pathspec" },
     { name = "pip" },
     { name = "pydantic-i18n" },
     { name = "pydash" },
@@ -256,6 +257,7 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.34.1" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.34.1" },
     { name = "opentelemetry-sdk", specifier = ">=1.34.1" },
+    { name = "pathspec", specifier = ">=0.12.0" },
     { name = "pip", specifier = ">=23.0" },
     { name = "pydantic-i18n", specifier = ">=0.4.5" },
     { name = "pydash", specifier = ">=8.0.5" },
@@ -1809,6 +1811,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/cf/0f4e268e1f5062e44a6bda9f925806721cd4c95c2b808a4c82ebe914f96b/pandas-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:60a80bb4feacbef5e1447a3f82c33209c8b7e07f28d805cfd1fb951e5cb443aa", size = 12337623, upload-time = "2026-03-31T06:46:23.754Z" },
     { url = "https://files.pythonhosted.org/packages/44/a0/97a6339859d4acb2536efb24feb6708e82f7d33b2ed7e036f2983fcced82/pandas-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:ed72cb3f45190874eb579c64fa92d9df74e98fd63e2be7f62bce5ace0ade61df", size = 9897372, upload-time = "2026-03-31T06:46:26.703Z" },
     { url = "https://files.pythonhosted.org/packages/8f/eb/781516b808a99ddf288143cec46b342b3016c3414d137da1fdc3290d8860/pandas-3.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:f12b1a9e332c01e09510586f8ca9b108fd631fd656af82e452d7315ef6df5f9f", size = 9154922, upload-time = "2026-03-31T06:46:30.284Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1443,6 +1443,27 @@ function registerIpcHandlers() {
     };
   });
 
+  ipcMain.handle('select-folder', async (event, options = {}) => {
+    const result = await dialog.showOpenDialog(win!, {
+      properties: ['openDirectory'],
+      ...options,
+    });
+
+    if (!result.canceled && result.filePaths.length > 0) {
+      const folderPath = result.filePaths[0];
+      return {
+        success: true,
+        folderPath,
+        folderName: folderPath.split(/[/\\]/).pop() || folderPath,
+      };
+    }
+
+    return {
+      success: false,
+      canceled: result.canceled,
+    };
+  });
+
   // Handle drag-and-drop files - convert File objects to file paths
   ipcMain.handle(
     'process-dropped-files',

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -37,6 +37,7 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
 });
 
 contextBridge.exposeInMainWorld('electronAPI', {
+  isDesktopShell: true,
   closeWindow: (isForceQuit?: boolean) =>
     ipcRenderer.send('window-close', {
       isForceQuit: isForceQuit ?? false,
@@ -53,6 +54,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onExecuteAction: (callback: (action: string) => void) =>
     ipcRenderer.on('execute-action', (event, action) => callback(action)),
   getPlatform: () => process.platform,
+  selectFolder: (options?: any) => ipcRenderer.invoke('select-folder', options),
   getHomeDir: () => ipcRenderer.invoke('get-home-dir'),
   createWebView: (id: string, url: string) =>
     ipcRenderer.invoke('create-webview', id, url),

--- a/server/app/domains/chat/service/chat_service.py
+++ b/server/app/domains/chat/service/chat_service.py
@@ -32,6 +32,10 @@ ALLOWED_EXTENSIONS = {
     "pdf", "txt", "md", "csv",
     "json", "xml", "yaml", "yml",
     "doc", "docx", "xls", "xlsx",
+    "html", "htm", "svg",
+    "py", "ipynb", "js", "jsx", "ts", "tsx",
+    "css", "scss", "sh", "sql",
+    "log", "toml", "ini", "cfg", "conf",
     "zip",
 }
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB

--- a/src/components/Folder/index.tsx
+++ b/src/components/Folder/index.tsx
@@ -496,14 +496,14 @@ export const FileTree: React.FC<FileTreeProps> = ({
                   onSelectFile(fileInfo);
                 }
               }}
-              className={`mb-1 min-w-0 gap-2 rounded-lg px-2 py-1.5 hover:bg-ds-bg-neutral-subtle-hover flex w-full flex-row items-center justify-start text-left transition-colors ${
+              className={`mb-1 flex w-full min-w-0 flex-row items-center justify-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-ds-bg-neutral-subtle-hover ${
                 isRowSelected
                   ? 'bg-ds-bg-neutral-default-default text-ds-text-neutral-default-default'
-                  : 'text-ds-text-neutral-muted-default bg-transparent'
+                  : 'bg-transparent text-ds-text-neutral-muted-default'
               }`}
             >
               {child.isFolder ? (
-                <span className="w-4 inline-flex shrink-0 items-center justify-start">
+                <span className="inline-flex w-4 shrink-0 items-center justify-start">
                   {isExpanded ? (
                     <ChevronDown className={rowIconClass} />
                   ) : (
@@ -522,13 +522,13 @@ export const FileTree: React.FC<FileTreeProps> = ({
                 )
               )}
 
-              <span className="min-w-0 text-body-sm font-medium leading-normal flex-1 truncate text-left">
+              <span className="min-w-0 flex-1 truncate text-left text-body-sm font-medium leading-normal">
                 {child.name}
               </span>
             </button>
 
             {hasNested ? (
-              <div className="ml-4 pl-1 border-ds-border-neutral-subtle-default border-y-0 border-r-0 border-l border-solid">
+              <div className="ml-4 border-y-0 border-l border-r-0 border-solid border-ds-border-neutral-subtle-default pl-1">
                 <FileTree
                   node={child}
                   level={level + 1}
@@ -1112,15 +1112,50 @@ export default function Folder({ data: _data }: { data?: Agent }) {
 
   useEffect(() => {
     if (!chatStore || !projectId || !authStore.email) return;
+    const email = authStore.email;
 
     const setFileList = async () => {
       let res: FileInfo[] = [];
 
-      if (ipcRenderer) {
+      try {
+        const baseURL = await getBaseURL();
+        if (!baseURL) {
+          console.warn('[Folder] Brain not connected, cannot fetch files');
+        } else {
+          const params: Record<string, string> = {
+            project_id: projectId,
+            email,
+          };
+          if (activeTaskId) {
+            params.task_id = activeTaskId;
+          }
+          const listRes = await fetchGet('/files', params);
+
+          if (Array.isArray(listRes)) {
+            res = listRes.map((item: any) => {
+              const filename = item.filename || '';
+              const url = item.url?.startsWith('http')
+                ? item.url
+                : `${baseURL}${item.url || ''}`;
+              return {
+                name: filename,
+                type: filename.split('.').pop() || '',
+                path: url,
+                relativePath: item.relativePath || filename,
+                isRemote: true,
+              };
+            });
+          }
+        }
+      } catch (error) {
+        console.warn('[Folder] Failed to fetch files from Brain:', error);
+      }
+
+      if (!res.length && ipcRenderer) {
         try {
           const localFiles = await ipcRenderer.invoke(
             'get-project-file-list',
-            authStore.email,
+            email,
             projectId
           );
           if (Array.isArray(localFiles)) {
@@ -1128,42 +1163,6 @@ export default function Folder({ data: _data }: { data?: Agent }) {
           }
         } catch (error) {
           console.warn('[Folder] Failed to fetch local project files:', error);
-        }
-      }
-
-      if (
-        !res.length ||
-        !ipcRenderer ||
-        import.meta.env.VITE_USE_LOCAL_PROXY === 'true'
-      ) {
-        try {
-          const baseURL = await getBaseURL();
-          if (!baseURL) {
-            console.warn('[Folder] Brain not connected, cannot fetch files');
-          } else {
-            const listRes = await fetchGet('/files', {
-              project_id: projectId,
-              email: authStore.email,
-            });
-
-            if (Array.isArray(listRes)) {
-              res = listRes.map((item: any) => {
-                const filename = item.filename || '';
-                const url = item.url?.startsWith('http')
-                  ? item.url
-                  : `${baseURL}${item.url || ''}`;
-                return {
-                  name: filename,
-                  type: filename.split('.').pop() || '',
-                  path: url,
-                  relativePath: item.relativePath || filename,
-                  isRemote: true,
-                };
-              });
-            }
-          }
-        } catch (error) {
-          console.warn('[Folder] Failed to fetch files from Brain:', error);
         }
       }
 
@@ -1333,15 +1332,15 @@ export default function Folder({ data: _data }: { data?: Agent }) {
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
       {/* header */}
-      <div className="gap-2 border-ds-border-neutral-subtle-default p-2 flex w-full shrink-0 items-center border-x-0 border-t-0 border-b-1 border-solid">
-        <div className="min-w-0 flex max-w-[min(20rem,45%)] items-center">
+      <div className="border-b-1 flex w-full shrink-0 items-center gap-2 border-x-0 border-t-0 border-solid border-ds-border-neutral-subtle-default p-2">
+        <div className="flex min-w-0 max-w-[min(20rem,45%)] items-center">
           <Button
             type="button"
             variant="ghost"
             size="sm"
             buttonContent="icon-only"
             aria-pressed={isFileSidebarOpen}
-            className="text-ds-icon-neutral-default-default shrink-0"
+            className="shrink-0 text-ds-icon-neutral-default-default"
             aria-label={
               isFileSidebarOpen
                 ? t('chat.hide-file-sidebar', {
@@ -1369,21 +1368,21 @@ export default function Folder({ data: _data }: { data?: Agent }) {
             )}
           </Button>
           <span
-            className="min-w-0 text-body-sm font-semibold text-ds-text-neutral-default-default truncate leading-none"
+            className="min-w-0 truncate text-body-sm font-semibold leading-none text-ds-text-neutral-default-default"
             title={workingFolderPath ?? undefined}
           >
             {folderHeaderTitle}
           </span>
         </div>
-        <div className="min-w-0 gap-2 ml-auto flex items-center">
-          <div className="h-7 w-32 max-w-xs rounded-lg relative min-w-[10rem] shrink-0">
-            <Search className="left-2 h-3.5 w-3.5 text-ds-text-brand-default-default pointer-events-none absolute top-1/2 -translate-y-1/2" />
+        <div className="ml-auto flex min-w-0 items-center gap-2">
+          <div className="relative h-7 w-32 min-w-[10rem] max-w-xs shrink-0 rounded-lg">
+            <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-ds-text-brand-default-default" />
             <input
               type="text"
               value={fileSearchQuery}
               onChange={(e) => setFileSearchQuery(e.target.value)}
               placeholder={t('chat.search')}
-              className="h-7 rounded-lg border-ds-border-neutral-subtle-default py-0 pl-7 pr-2 text-sm focus:ring-ds-ring-brand-default-focus w-full border border-solid leading-none focus:ring-2 focus:ring-offset-0 focus:outline-none"
+              className="h-7 w-full rounded-lg border border-solid border-ds-border-neutral-subtle-default py-0 pl-7 pr-2 text-sm leading-none focus:outline-none focus:ring-2 focus:ring-ds-ring-brand-default-focus focus:ring-offset-0"
               aria-label={t('chat.search')}
             />
           </div>
@@ -1404,18 +1403,18 @@ export default function Folder({ data: _data }: { data?: Agent }) {
               </DropdownMenuTrigger>
               <DropdownMenuContent
                 align="end"
-                className="border-ds-border-neutral-default-default bg-ds-bg-neutral-strong-default z-50"
+                className="z-50 border-ds-border-neutral-default-default bg-ds-bg-neutral-strong-default"
               >
                 <DropdownMenuItem
                   onClick={() => handleOpenInIDE('system')}
-                  className="bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover cursor-pointer"
+                  className="cursor-pointer bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
                 >
                   <FolderIcon className="size-4 shrink-0" aria-hidden />
                   {t('chat.open-in-file-manager')}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => handleOpenInIDE('cursor')}
-                  className="bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover cursor-pointer"
+                  className="cursor-pointer bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
                 >
                   <img
                     src={cursorIcon}
@@ -1427,7 +1426,7 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => handleOpenInIDE('vscode')}
-                  className="bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover cursor-pointer"
+                  className="cursor-pointer bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
                 >
                   <img
                     src={vsCodeIcon}
@@ -1443,11 +1442,11 @@ export default function Folder({ data: _data }: { data?: Agent }) {
         </div>
       </div>
 
-      <div className="min-h-0 flex flex-1 overflow-hidden">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* sidebar */}
         {isFileSidebarOpen ? (
-          <div className="w-64 border-ds-border-neutral-subtle-default flex h-full flex-shrink-0 flex-col border-y-0 border-r border-l-0 border-solid">
-            <div className="h-8 px-1 flex items-center">
+          <div className="flex h-full w-64 flex-shrink-0 flex-col border-y-0 border-l-0 border-r border-solid border-ds-border-neutral-subtle-default">
+            <div className="flex h-8 items-center px-1">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
@@ -1456,7 +1455,7 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                     size="sm"
                     buttonContent="text"
                   >
-                    <span className="min-w-0 font-bold truncate text-left">
+                    <span className="min-w-0 truncate text-left font-bold">
                       {t('chat.files')}
                     </span>
                     <ChevronDown className="size-3.5 shrink-0 opacity-70" />
@@ -1465,7 +1464,7 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                 <DropdownMenuContent
                   side="bottom"
                   align="start"
-                  className="border-ds-border-neutral-default-default bg-ds-bg-neutral-strong-default z-50 min-w-[10rem]"
+                  className="z-50 min-w-[10rem] border-ds-border-neutral-default-default bg-ds-bg-neutral-strong-default"
                 >
                   <DropdownMenuRadioGroup
                     value={fileTreeScope}
@@ -1475,7 +1474,7 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                   >
                     <DropdownMenuRadioItem
                       value="all"
-                      className="bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover cursor-pointer"
+                      className="cursor-pointer bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
                     >
                       {t('folder.files-scope-all', {
                         defaultValue: 'All files',
@@ -1483,7 +1482,7 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                     </DropdownMenuRadioItem>
                     <DropdownMenuRadioItem
                       value="new"
-                      className="bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover cursor-pointer"
+                      className="cursor-pointer bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
                     >
                       {t('folder.files-scope-new', {
                         defaultValue: 'New files',
@@ -1494,7 +1493,7 @@ export default function Folder({ data: _data }: { data?: Agent }) {
               </DropdownMenu>
             </div>
             <div className="scrollbar-always-visible min-h-0 flex-1 overflow-y-auto">
-              <div className="pl-1.5 h-full">
+              <div className="h-full pl-1.5">
                 <FileTree
                   node={sidebarFileTree}
                   selectedFile={selectedFile}
@@ -1511,10 +1510,10 @@ export default function Folder({ data: _data }: { data?: Agent }) {
         ) : null}
 
         {/* content */}
-        <div className="min-w-0 bg-ds-bg-neutral-subtle-default flex flex-1 flex-col overflow-hidden">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-ds-bg-neutral-subtle-default">
           {/* head */}
           {selectedFile && (
-            <div className="h-8 gap-2 pl-3 pr-2 flex flex-shrink-0 items-center justify-between">
+            <div className="flex h-8 flex-shrink-0 items-center justify-between gap-2 pl-3 pr-2">
               <div
                 onClick={() => {
                   // if file is remote, don't call reveal-in-folder
@@ -1524,10 +1523,10 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                   }
                   ipcRenderer?.invoke('reveal-in-folder', selectedFile.path);
                 }}
-                className="min-w-0 flex flex-1 cursor-pointer items-center overflow-hidden"
+                className="flex min-w-0 flex-1 cursor-pointer items-center overflow-hidden"
               >
                 <nav
-                  className="scrollbar-always-visible min-w-0 gap-1 text-body-sm text-ds-text-neutral-muted-default flex max-w-full items-center overflow-x-auto"
+                  className="scrollbar-always-visible flex min-w-0 max-w-full items-center gap-1 overflow-x-auto text-body-sm text-ds-text-neutral-muted-default"
                   aria-label={t('folder.file-path-breadcrumb', {
                     defaultValue: 'File path',
                   })}
@@ -1538,15 +1537,15 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                       <Fragment key={`${index}-${segment}`}>
                         {index > 0 ? (
                           <ChevronRight
-                            className="h-3.5 w-3.5 text-ds-icon-neutral-muted-default shrink-0"
+                            className="h-3.5 w-3.5 shrink-0 text-ds-icon-neutral-muted-default"
                             aria-hidden
                           />
                         ) : null}
                         <span
                           className={
                             isLast
-                              ? 'font-bold text-ds-text-neutral-default-default shrink-0'
-                              : 'font-normal shrink-0'
+                              ? 'shrink-0 font-bold text-ds-text-neutral-default-default'
+                              : 'shrink-0 font-normal'
                           }
                         >
                           {segment}
@@ -1556,7 +1555,7 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                   })}
                 </nav>
               </div>
-              <div className="gap-0.5 flex flex-shrink-0 items-center">
+              <div className="flex flex-shrink-0 items-center gap-0.5">
                 <Button
                   size="icon"
                   variant="ghost"
@@ -1585,7 +1584,7 @@ export default function Folder({ data: _data }: { data?: Agent }) {
 
           {/* content */}
           <div
-            className={`min-h-0 flex flex-1 flex-col ${
+            className={`flex min-h-0 flex-1 flex-col ${
               selectedFile?.type === 'html' && !isShowSourceCode
                 ? 'overflow-hidden'
                 : 'scrollbar-always-visible overflow-y-auto'
@@ -1594,8 +1593,8 @@ export default function Folder({ data: _data }: { data?: Agent }) {
             <div
               className={`flex flex-col ${
                 selectedFile?.type === 'html' && !isShowSourceCode
-                  ? 'min-h-0 h-full'
-                  : 'py-2 pl-4 pr-2 min-h-full'
+                  ? 'h-full min-h-0'
+                  : 'min-h-full py-2 pl-4 pr-2'
               } file-viewer-content`}
             >
               {selectedFile ? (
@@ -1632,9 +1631,9 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                       />
                     )
                   ) : selectedFile.type === 'zip' ? (
-                    <div className="text-ds-text-neutral-muted-default flex h-full w-full items-center justify-center">
+                    <div className="flex h-full w-full items-center justify-center text-ds-text-neutral-muted-default">
                       <div className="text-center">
-                        <FileText className="mb-4 h-12 w-12 text-ds-text-neutral-muted-default mx-auto" />
+                        <FileText className="mx-auto mb-4 h-12 w-12 text-ds-text-neutral-muted-default" />
                         <p className="text-sm">
                           {t('folder.zip-file-is-not-supported-yet')}
                         </p>
@@ -1653,14 +1652,14 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                       <ImageLoader selectedFile={selectedFile} />
                     </div>
                   ) : (
-                    <pre className="font-mono text-sm text-ds-text-neutral-default-default overflow-auto break-words whitespace-pre-wrap">
+                    <pre className="overflow-auto whitespace-pre-wrap break-words font-mono text-sm text-ds-text-neutral-default-default">
                       {selectedFile.content}
                     </pre>
                   )
                 ) : (
                   <div className="flex h-full w-full items-center justify-center">
                     <div className="text-center">
-                      <div className="mb-4 h-8 w-8 animate-spin mx-auto rounded-full"></div>
+                      <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full"></div>
                       <p className="text-body-sm text-ds-text-neutral-muted-default">
                         {t('chat.loading')}
                       </p>
@@ -1668,9 +1667,9 @@ export default function Folder({ data: _data }: { data?: Agent }) {
                   </div>
                 )
               ) : (
-                <div className="text-ds-text-neutral-muted-default flex h-full w-full flex-1 items-center justify-center">
+                <div className="flex h-full w-full flex-1 items-center justify-center text-ds-text-neutral-muted-default">
                   <div className="text-center">
-                    <FileText className="mb-4 h-12 w-12 text-ds-text-neutral-muted-default mx-auto" />
+                    <FileText className="mx-auto mb-4 h-12 w-12 text-ds-text-neutral-muted-default" />
                     <p className="text-sm">
                       {t('chat.select-a-file-to-view-its-contents')}
                     </p>
@@ -1762,7 +1761,7 @@ function AudioLoader({ selectedFile }: { selectedFile: FileInfo }) {
   }, [selectedFile]);
 
   return (
-    <div className="gap-4 px-8 flex w-full flex-col items-center">
+    <div className="flex w-full flex-col items-center gap-4 px-8">
       <p className="text-sm font-medium text-ds-text-neutral-default-default">
         {selectedFile.name}
       </p>
@@ -2213,6 +2212,7 @@ function getRemotePreviewUrl(file: FileInfo): string | undefined {
     const url = new URL(file.path, window.location.origin);
     const email = url.searchParams.get('email');
     const projectId = url.searchParams.get('project_id');
+    const taskId = url.searchParams.get('task_id');
     if (!email || !projectId) {
       return undefined;
     }
@@ -2221,7 +2221,13 @@ function getRemotePreviewUrl(file: FileInfo): string | undefined {
     const routePrefix =
       filesIndex >= 0 ? url.pathname.substring(0, filesIndex) : '';
 
-    return `${url.origin}${routePrefix}/files/preview/${encodeURIComponent(email)}/${encodeURIComponent(projectId)}/${encodePathSegments(relativePath)}`;
+    const previewUrl = new URL(
+      `${url.origin}${routePrefix}/files/preview/${encodeURIComponent(email)}/${encodeURIComponent(projectId)}/${encodePathSegments(relativePath)}`
+    );
+    if (taskId) {
+      previewUrl.searchParams.set('task_id', taskId);
+    }
+    return previewUrl.toString();
   } catch {
     return undefined;
   }
@@ -2587,7 +2593,7 @@ function HtmlRenderer({
   if (selectedFile.content && !processedHtml) {
     return (
       <div className="flex h-full w-full items-center justify-center">
-        <div className="mb-4 h-8 w-8 animate-spin mx-auto rounded-full" />
+        <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full" />
       </div>
     );
   }
@@ -2604,7 +2610,7 @@ function HtmlRenderer({
 
       {/* Content area with zoom */}
       <div
-        className="min-h-0 bg-code-surface flex-1 overflow-hidden"
+        className="min-h-0 flex-1 overflow-hidden bg-code-surface"
         onWheel={handleWheel}
       >
         <div

--- a/src/components/Workspace/WorkspaceProjectPicker.tsx
+++ b/src/components/Workspace/WorkspaceProjectPicker.tsx
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import { fetchGet, fetchPost } from '@/api/http';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -24,8 +25,10 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import useChatStoreAdapter from '@/hooks/useChatStoreAdapter';
-import { loadProjectFromHistory } from '@/lib';
+import { createHost } from '@/host/createHost';
+import { generateUniqueId, loadProjectFromHistory } from '@/lib';
 import { fetchGroupedHistoryTasks } from '@/service/historyApi';
+import { useAuthStore } from '@/store/authStore';
 import { usePageTabStore } from '@/store/pageTabStore';
 import type { ProjectGroup } from '@/types/history';
 import {
@@ -38,6 +41,80 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+type WorkspaceCapabilities = {
+  binding_enabled?: boolean;
+  binding_persistence?: string;
+  deployment?: string;
+  label?: string;
+};
+
+type WorkspaceCurrent = {
+  bound?: boolean;
+  workspace_root?: string;
+};
+
+function getFolderNameFromPath(path?: string): string {
+  if (!path) return '';
+  const normalized = path.replace(/[\\/]+$/, '');
+  return normalized.split(/[\\/]/).filter(Boolean).pop() || normalized;
+}
+
+function isDesktopShell(electronAPI: any, ipcRenderer: any): boolean {
+  return (
+    electronAPI?.isDesktopShell === true &&
+    typeof ipcRenderer?.invoke === 'function'
+  );
+}
+
+function workspaceBindErrorMessage(
+  error: any,
+  t: ReturnType<typeof useTranslation>['t']
+): string {
+  const status = error?.response?.status;
+  const detail = error?.response?.data?.detail;
+  const code = typeof detail === 'object' ? detail?.code : undefined;
+  const reason =
+    typeof detail === 'object'
+      ? detail?.reason || detail?.message || detail?.code
+      : typeof detail === 'string'
+        ? detail
+        : error?.message;
+
+  switch (status) {
+    case 400:
+      return t('layout.workspace-folder-invalid-path', {
+        defaultValue: 'The selected path is not a valid folder.',
+      });
+    case 403:
+      return t('layout.workspace-folder-denied', {
+        defaultValue: `This folder cannot be used as a workspace${reason ? `: ${reason}` : '.'}`,
+      });
+    case 409:
+      if (code === 'workspace_already_bound') {
+        return t('layout.workspace-folder-already-bound', {
+          defaultValue:
+            'This project already has a workspace folder. Start from scratch to select another folder.',
+        });
+      }
+      return t('layout.workspace-folder-active-task', {
+        defaultValue:
+          'Please wait for the current task to finish before changing the workspace folder.',
+      });
+    case 412:
+      return t('layout.workspace-folder-cloud-disabled', {
+        defaultValue: 'Folder selection is only available for Local Brain.',
+      });
+    default:
+      return (
+        reason ||
+        t('layout.workspace-folder-select-failed', {
+          defaultValue: 'Failed to select workspace folder.',
+        })
+      );
+  }
+}
 
 /**
  * Project / task switcher for the workspace landing: opens the agent folder
@@ -48,35 +125,95 @@ export function WorkspaceProjectPicker() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { chatStore, projectStore } = useChatStoreAdapter();
+  const userEmail = useAuthStore((s) => s.email);
   const setActiveWorkspaceTab = usePageTabStore((s) => s.setActiveWorkspaceTab);
+  const host = useMemo(() => createHost(), []);
+  const electronAPI = host.electronAPI;
+  const ipcRenderer = host.ipcRenderer;
 
   const [historyTasks, setHistoryTasks] = useState<ProjectGroup[]>([]);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [workspaceCapabilities, setWorkspaceCapabilities] =
+    useState<WorkspaceCapabilities | null>(null);
+  const [currentWorkspace, setCurrentWorkspace] =
+    useState<WorkspaceCurrent | null>(null);
+  const [folderBindingBusy, setFolderBindingBusy] = useState(false);
 
   useEffect(() => {
     if (!chatStore) return;
     fetchGroupedHistoryTasks(setHistoryTasks);
   }, [chatStore, chatStore?.updateCount]);
 
+  useEffect(() => {
+    let cancelled = false;
+    fetchGet('/workspace/capabilities')
+      .then((capabilities) => {
+        if (!cancelled) {
+          setWorkspaceCapabilities(capabilities);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setWorkspaceCapabilities(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!projectStore.activeProjectId || !userEmail) {
+      setCurrentWorkspace(null);
+      return;
+    }
+    let cancelled = false;
+    fetchGet('/workspace/current', {
+      project_id: projectStore.activeProjectId,
+      email: userEmail,
+    })
+      .then((workspace) => {
+        if (!cancelled) {
+          setCurrentWorkspace(workspace);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCurrentWorkspace(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectStore.activeProjectId, userEmail]);
+
   const summaryTask =
     chatStore?.tasks[chatStore?.activeTaskId as string]?.summaryTask;
+  const hasBoundWorkspace = Boolean(currentWorkspace?.bound);
+  const boundFolderName = getFolderNameFromPath(
+    currentWorkspace?.workspace_root
+  );
 
   const activeTaskTitle = useMemo(() => {
     const defaultLabel = t('layout.workspace-select-project', {
       defaultValue: 'Select a project',
     });
+    if (hasBoundWorkspace && boundFolderName) {
+      return boundFolderName;
+    }
     if (!chatStore) return defaultLabel;
     if (chatStore.activeTaskId && summaryTask) {
       return summaryTask.split('|')[0];
     }
     return defaultLabel;
-  }, [chatStore, summaryTask, t]);
+  }, [boundFolderName, chatStore, hasBoundWorkspace, summaryTask, t]);
 
   const handleLoadProject = async (
     projectId: string,
     question: string,
     historyId: string
   ) => {
+    setCurrentWorkspace(null);
     setMenuOpen(false);
     const project = historyTasks.find((p) => p.project_id === projectId);
     const taskIdsList = project?.tasks.map((task) => task.task_id) || [
@@ -90,6 +227,7 @@ export function WorkspaceProjectPicker() {
         projectId
       );
       navigate('/');
+      setActiveWorkspaceTab('session');
       return;
     }
 
@@ -102,6 +240,7 @@ export function WorkspaceProjectPicker() {
       taskIdsList,
       project?.project_name
     );
+    setActiveWorkspaceTab('session');
   };
 
   const handleSetActive = (
@@ -111,9 +250,11 @@ export function WorkspaceProjectPicker() {
   ) => {
     const project = projectStore.getProjectById(projectId);
     if (project) {
+      setCurrentWorkspace(null);
       projectStore.setHistoryId(projectId, historyId);
       projectStore.setActiveProject(projectId);
       navigate(`/`);
+      setActiveWorkspaceTab('session');
       setMenuOpen(false);
     } else {
       void handleLoadProject(projectId, question, historyId);
@@ -132,17 +273,83 @@ export function WorkspaceProjectPicker() {
   };
 
   const handleStartFromScratch = () => {
-    projectStore.createProject('new project');
+    projectStore.createProject('new project', undefined, generateUniqueId());
+    setCurrentWorkspace(null);
+    setActiveWorkspaceTab('session');
     navigate('/');
     setMenuOpen(false);
   };
 
-  const openAgentFolderTab = () => {
-    const pid = projectStore.activeProjectId;
+  const canSelectFolder =
+    Boolean(workspaceCapabilities?.binding_enabled) &&
+    isDesktopShell(electronAPI, ipcRenderer) &&
+    typeof electronAPI?.selectFolder === 'function';
+
+  const openWorkspaceContext = (projectId?: string | null) => {
     setActiveWorkspaceTab('inbox', {
-      clearInboxForProjectId: pid ?? undefined,
+      clearInboxForProjectId: projectId ?? undefined,
     });
     setMenuOpen(false);
+  };
+
+  const handleSelectFolder = async () => {
+    if (hasBoundWorkspace) {
+      openWorkspaceContext(projectStore.activeProjectId);
+      return;
+    }
+    if (!canSelectFolder) {
+      toast.error(
+        t('layout.workspace-select-folder-desktop-only', {
+          defaultValue: 'Folder selection is available in Desktop mode only.',
+        })
+      );
+      return;
+    }
+    if (!userEmail) {
+      toast.error(
+        t('layout.workspace-select-folder-login-required', {
+          defaultValue: 'Please sign in before selecting a folder.',
+        })
+      );
+      return;
+    }
+
+    setFolderBindingBusy(true);
+    try {
+      const result = await electronAPI.selectFolder({
+        title: t('layout.workspace-select-folder', {
+          defaultValue: 'Select a folder',
+        }),
+      });
+      if (!result?.success || !result.folderPath) {
+        return;
+      }
+
+      const projectId =
+        projectStore.activeProjectId ??
+        projectStore.createProject(result.folderName || 'new project');
+      await fetchPost('/workspace/bind', {
+        project_id: projectId,
+        email: userEmail,
+        path: result.folderPath,
+      });
+      setCurrentWorkspace({
+        bound: true,
+        workspace_root: result.folderPath,
+      });
+      navigate('/');
+      openWorkspaceContext(projectId);
+      toast.success(
+        t('layout.workspace-folder-selected', {
+          defaultValue: 'Workspace folder selected.',
+        })
+      );
+      setMenuOpen(false);
+    } catch (error: any) {
+      toast.error(workspaceBindErrorMessage(error, t));
+    } finally {
+      setFolderBindingBusy(false);
+    }
   };
 
   if (!chatStore) {
@@ -159,12 +366,12 @@ export function WorkspaceProjectPicker() {
           size="md"
           buttonContent="text"
           buttonRadius="full"
-          className="no-drag bg-ds-bg-neutral-subtle-default shadow-workspace-project-picker px-3 py-1 font-semibold hover:bg-ds-bg-neutral-default-hover inline-flex h-auto w-fit max-w-[300px] min-w-[180px] justify-between"
+          className="no-drag inline-flex h-auto w-fit min-w-[180px] max-w-[300px] justify-between bg-ds-bg-neutral-subtle-default px-3 py-1 font-semibold shadow-workspace-project-picker hover:bg-ds-bg-neutral-default-hover"
           aria-expanded={menuOpen}
           aria-haspopup="menu"
         >
           <FolderIcon className="size-4 shrink-0" aria-hidden />
-          <span className="text-ds-text-neutral-default-default min-w-0 text-label-sm truncate">
+          <span className="min-w-0 truncate text-label-sm text-ds-text-neutral-default-default">
             {activeTaskTitle}
           </span>
           <ChevronDown className="shrink-0 opacity-80" aria-hidden />
@@ -176,7 +383,7 @@ export function WorkspaceProjectPicker() {
         sideOffset={6}
       >
         <DropdownMenuItem
-          className="gap-2 cursor-pointer"
+          className="cursor-pointer gap-2"
           onSelect={(e) => {
             e.preventDefault();
             handleStartFromScratch();
@@ -189,16 +396,33 @@ export function WorkspaceProjectPicker() {
         </DropdownMenuItem>
 
         <DropdownMenuItem
-          className="gap-2 cursor-pointer"
+          className="cursor-pointer gap-2"
+          disabled={
+            folderBindingBusy || (!hasBoundWorkspace && !canSelectFolder)
+          }
           onSelect={(e) => {
             e.preventDefault();
-            openAgentFolderTab();
+            void handleSelectFolder();
           }}
+          title={
+            hasBoundWorkspace
+              ? currentWorkspace?.workspace_root
+              : t('layout.workspace-select-folder', {
+                  defaultValue: 'Select a folder',
+                })
+          }
         >
           <FolderOpen className="h-4 w-4 shrink-0" aria-hidden />
-          {t('layout.workspace-select-folder', {
-            defaultValue: 'Select a folder',
-          })}
+          <span className="min-w-0 truncate">
+            {hasBoundWorkspace
+              ? boundFolderName ||
+                t('layout.workspace-bound-folder', {
+                  defaultValue: 'Selected folder',
+                })
+              : t('layout.workspace-select-folder', {
+                  defaultValue: 'Select a folder',
+                })}
+          </span>
         </DropdownMenuItem>
 
         <DropdownMenuSeparator className="bg-ds-border-neutral-default-default" />
@@ -211,12 +435,12 @@ export function WorkspaceProjectPicker() {
             })}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent
-            className="max-h-64 p-1 w-[min(100vw-2rem,280px)] overflow-y-auto"
+            className="max-h-64 w-[min(100vw-2rem,280px)] overflow-y-auto p-1"
             sideOffset={6}
             alignOffset={-4}
           >
             {historyTasks.length === 0 ? (
-              <div className="text-ds-text-neutral-muted-default px-2 py-3 text-body-sm text-center">
+              <div className="px-2 py-3 text-center text-body-sm text-ds-text-neutral-muted-default">
                 {t('layout.workspace-no-history-projects', {
                   defaultValue: 'No history projects yet',
                 })}
@@ -225,7 +449,7 @@ export function WorkspaceProjectPicker() {
               historyTasks.map((project) => (
                 <DropdownMenuItem
                   key={project.project_id}
-                  className="min-h-9 gap-0.5 py-2 cursor-pointer flex-col items-start"
+                  className="min-h-9 cursor-pointer flex-col items-start gap-0.5 py-2"
                   onSelect={(e) => {
                     e.preventDefault();
                     onSelectHistoryProject(project);

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -27,7 +27,7 @@ import {
 import { showCreditsToast } from '@/components/Toast/creditsToast';
 import { showStorageToast } from '@/components/Toast/storageToast';
 import type { AppHost } from '@/host/types';
-import { generateUniqueId, uploadLog } from '@/lib';
+import { generateUniqueId } from '@/lib';
 import {
   normalizeRemoteSubAgentProvider,
   REMOTE_SUB_AGENT_PROVIDER_ID,
@@ -581,11 +581,13 @@ function buildRemoteFileInfoPath({
   baseURL,
   email,
   projectId,
+  taskId,
   relativePath,
 }: {
   baseURL?: string;
   email?: string;
   projectId?: string;
+  taskId?: string;
   relativePath?: string;
 }): string | undefined {
   if (!baseURL || !email || !projectId || !relativePath) {
@@ -597,6 +599,9 @@ function buildRemoteFileInfoPath({
     project_id: projectId,
     email,
   });
+  if (taskId) {
+    params.set('task_id', taskId);
+  }
 
   return `${baseURL.replace(/\/$/, '')}/files/stream?${params.toString()}`;
 }
@@ -605,7 +610,8 @@ function extractFinalOutputFileList(
   content: string,
   projectId?: string,
   email?: string,
-  baseURL?: string
+  baseURL?: string,
+  taskId?: string
 ): FileInfo[] {
   if (!content) {
     return [];
@@ -631,6 +637,7 @@ function extractFinalOutputFileList(
       baseURL,
       email,
       projectId,
+      taskId,
       relativePath,
     });
     const identity = normalizeOutputPath(relativePath || filePath);
@@ -2594,7 +2601,6 @@ const chatStore = (initial?: Partial<ChatStore>) =>
             console.log('error', agentMessages.data);
             showCreditsToast();
             setStatus(currentTaskId, ChatTaskStatus.PAUSE);
-            uploadLog(currentTaskId, type);
             return;
           }
 
@@ -2616,7 +2622,6 @@ const chatStore = (initial?: Partial<ChatStore>) =>
             // Set flag to block input and set status to pause
             setIsContextExceeded(currentTaskId, true);
             setStatus(currentTaskId, ChatTaskStatus.PAUSE);
-            uploadLog(currentTaskId, type);
             return;
           }
 
@@ -2683,7 +2688,6 @@ const chatStore = (initial?: Partial<ChatStore>) =>
                 role: 'agent',
                 content: `❌ **Error**: ${errorMessage}`,
               });
-              uploadLog(currentTaskId, type);
               // Update trigger execution status to Failed on error
               updateTriggerExecutionStatus(
                 getCurrentChatStore(),
@@ -2820,69 +2824,6 @@ const chatStore = (initial?: Partial<ChatStore>) =>
               )
             );
 
-            const uploadTargetId = (project_id ||
-              projectStore.activeProjectId) as string | undefined;
-            if (!type && import.meta.env.VITE_USE_LOCAL_PROXY !== 'true') {
-              if (!uploadTargetId) {
-                console.warn(
-                  'Skip file upload because no active project ID was found'
-                );
-              } else {
-                const hostIpcRenderer = getHostIpcRenderer();
-                if (!hostIpcRenderer?.invoke) {
-                  console.warn(
-                    'Skip file upload because IPC renderer is unavailable'
-                  );
-                } else {
-                  try {
-                    const generatedFiles =
-                      ((await hostIpcRenderer.invoke(
-                        'get-file-list',
-                        email,
-                        currentTaskId,
-                        uploadTargetId
-                      )) as GeneratedUploadFile[]) || [];
-                    const filesToUpload = collectTaskUploadFiles(
-                      generatedFiles,
-                      tasks[currentTaskId].messages,
-                      tasks[currentTaskId].attaches,
-                      currentTaskId
-                    );
-
-                    if (filesToUpload.length > 0) {
-                      const uploadResults = await uploadTaskFiles(
-                        filesToUpload,
-                        uploadTargetId
-                      );
-                      const failedUploads = uploadResults.filter(
-                        (result) => !result.success
-                      );
-                      if (failedUploads.length > 0) {
-                        console.error('Failed to upload files:', failedUploads);
-                      }
-
-                      const generatedSuccessCount = uploadResults.filter(
-                        (result) =>
-                          result.success && result.source === 'project_output'
-                      ).length;
-
-                      if (generatedSuccessCount > 0) {
-                        proxyFetchPost(`/api/v1/user/stat`, {
-                          action: 'file_generate_count',
-                          value: generatedSuccessCount,
-                        });
-                      }
-                    }
-                  } catch (error) {
-                    console.error(
-                      'Failed to prepare task files for upload:',
-                      error
-                    );
-                  }
-                }
-              }
-            }
-
             if (!type && historyId) {
               try {
                 const st = tasks[currentTaskId].summaryTask || '';
@@ -2911,8 +2852,6 @@ const chatStore = (initial?: Partial<ChatStore>) =>
                 console.warn('History update failed on END:', e);
               }
             }
-            uploadLog(currentTaskId, type);
-
             let taskRunning = [...tasks[currentTaskId].taskRunning];
             let taskAssigning = [...tasks[currentTaskId].taskAssigning];
             taskAssigning = taskAssigning.map((agent) => {
@@ -2992,7 +2931,8 @@ const chatStore = (initial?: Partial<ChatStore>) =>
               endMessage,
               outputProjectId,
               email || undefined,
-              outputBaseURL || undefined
+              outputBaseURL || undefined,
+              currentTaskId
             );
             const mergedFileList = mergeFileInfoLists(
               fileList,

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -23,6 +23,7 @@ interface IpcRenderer {
 }
 
 interface ElectronAPI {
+  isDesktopShell: boolean;
   closeWindow: () => void;
   minimizeWindow: () => void;
   toggleMaximizeWindow: () => void;
@@ -35,6 +36,13 @@ interface ElectronAPI {
     }>;
     fileCount?: number;
     canceled?: boolean;
+  }>;
+  selectFolder: (options?: any) => Promise<{
+    success: boolean;
+    folderPath?: string;
+    folderName?: string;
+    canceled?: boolean;
+    error?: string;
   }>;
   processDroppedFiles: (
     fileData: Array<{ name: string; path?: string }>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

Closes #

### Description

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->
Adds desktop folder workspace selection with immutable project-level binding.

Users can now select a local folder for a project in desktop mode. Once selected, that folder becomes the project workspace and cannot be changed for the same project. New projects can still choose a different folder or start from scratch.

Key changes:
- Added Brain workspace APIs for capabilities, folder binding, and workspace state.
- Added immutable local workspace binding stored by sanitized email + project id.
- Added task directory snapshots so historical tasks resolve to the correct output root.
- Updated agent execution working directory resolution:
  - bound projects run directly in the selected folder
  - unbound projects keep the legacy task directory behavior
- Added async Brain-side artifact handling for user uploads, workspace outputs, `camel_logs`, `sync_steps`, and artifact manifests.
- Updated `/files` listing, preview, and stream paths to resolve through project/task workspace context.
- Added desktop-only folder picker through Electron, while website mode keeps the existing flow.
- Updated project picker UI to show the selected folder name and route users to create a new project when the current one is already bound.
- Added tests for workspace binding, path resolution, artifact handling, and environment working directory behavior.

### Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->
<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->
<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- [x] I have included human-verified testing evidence in this PR.
- [x] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
