### PR TITLE
restructure ux rendering flow and ui bugs for single agent harness

### DIFF
--- a/src/components/ChatBox/MessageItem/PreparingToExecuteTasks.tsx
+++ b/src/components/ChatBox/MessageItem/PreparingToExecuteTasks.tsx
@@ -21,7 +21,7 @@ export function PreparingToExecuteTasks() {
 
   return (
     <div
-      className="my-2 min-w-0 flex w-full items-center"
+      className="py-2 min-w-0 flex w-full items-center"
       role="status"
       aria-live="polite"
     >

--- a/src/components/ChatBox/MessageItem/TaskWorkLogAccordion.tsx
+++ b/src/components/ChatBox/MessageItem/TaskWorkLogAccordion.tsx
@@ -21,6 +21,7 @@ import {
   AgentStep,
   ChatTaskStatus,
   type ChatTaskStatusType,
+  SessionMode,
 } from '@/types/constants';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronDown, ChevronRight } from 'lucide-react';
@@ -89,6 +90,12 @@ function mergeTaggedAgentLogs(taskAssigning: Agent[] | undefined): TaggedLog[] {
 function titleCaseMethod(method: string): string {
   if (!method) return '';
   return method.charAt(0).toUpperCase() + method.slice(1);
+}
+
+/** Uppercase the first character of agent narration so rows read cleanly. */
+function capitalizeFirst(text: string): string {
+  if (!text) return text;
+  return text.charAt(0).toUpperCase() + text.slice(1);
 }
 
 function truncateText(text: string, max: number): string {
@@ -175,6 +182,7 @@ export type AgentBlock = {
 
 const PREPARATION_BLOCK_ID = 'b-prep';
 const PREPARATION_BLOCK_LABEL = 'Preparing agents';
+const PREPARATION_BLOCK_LABEL_SINGLE = 'Preparing agent';
 
 function pairKey(toolkit: string, method: string): string {
   return `${toolkit}::${method}`;
@@ -211,10 +219,16 @@ function isPreparationEvent(entry: AgentMessage): boolean {
  * `AgentBlock[]`, preserving the wall-clock order of messages and tools
  * inside each block.
  */
-export function buildAgentBlocks(tagged: TaggedLog[]): AgentBlock[] {
+export function buildAgentBlocks(
+  tagged: TaggedLog[],
+  isSingleAgent = false
+): AgentBlock[] {
   const blocks: AgentBlock[] = [];
   const cursor: { current: AgentBlock | null } = { current: null };
   let prep: AgentBlock | null = null;
+  const prepLabel = isSingleAgent
+    ? PREPARATION_BLOCK_LABEL_SINGLE
+    : PREPARATION_BLOCK_LABEL;
 
   // The workforce factory wires up agents via `register agent` toolkit calls.
   // Those calls can appear as a leading burst *and* sprinkled in mid-run
@@ -228,7 +242,7 @@ export function buildAgentBlocks(tagged: TaggedLog[]): AgentBlock[] {
         id: PREPARATION_BLOCK_ID,
         agentId: '__prep__',
         agentType: '__prep__',
-        agentName: PREPARATION_BLOCK_LABEL,
+        agentName: prepLabel,
         items: [],
         status: 'running',
         kind: 'preparation',
@@ -534,7 +548,8 @@ function useTaskWorkLogData(
   }
   const t = chatStore.getState().tasks[taskId];
   const tagged = mergeTaggedAgentLogs(t?.taskAssigning);
-  const blocks = buildAgentBlocks(tagged);
+  const isSingleAgent = t?.sessionMode === SessionMode.SINGLE_AGENT;
+  const blocks = buildAgentBlocks(tagged, isSingleAgent);
   return { task: t, blocks };
 }
 
@@ -661,10 +676,11 @@ const InlineMessageRow = memo(function InlineMessageRow({
   source: MessageItem['source'];
   running: boolean;
 }) {
-  const display =
+  const display = capitalizeFirst(
     source === 'toolkit_message'
       ? truncateText(text, TOOL_INLINE_PREVIEW_MAX)
-      : text;
+      : text
+  );
   // Reasoning is the agent's primary narration ("open DuckDuckGo to search
   // for…"); render at default text intensity. Notices and toolkit-message
   // narration stay subtle so the eye stays on tool titles + reasoning.
@@ -709,11 +725,15 @@ const AgentBlockRow = memo(function AgentBlockRow({
   open: boolean;
   onToggle: () => void;
 }) {
-  const { agentLabel, detail, detailRunning } = getBlockHeaderParts(block);
+  const { agentLabel, detail } = getBlockHeaderParts(block);
 
-  // Agent label is static. The detail tracks the latest toolkit/method for
-  // this agent and shimmers while that tool is still running — that's the
-  // user's "live" cue, in the row that owns the work.
+  // While this block is the active, currently-running step, the whole header
+  // — agent name · toolkit · action — shimmers as one ShinyText so the
+  // gradient sweeps across all three as a continuous "running" indicator.
+  // (ShinyText needs `color: transparent`, so no text-color class here.)
+  const headerRunning = taskRunning && block.status === 'running';
+  const headerText = detail ? `${agentLabel} · ${detail}` : agentLabel;
+
   return (
     <div className="min-w-0 flex w-full flex-col">
       <button
@@ -723,27 +743,29 @@ const AgentBlockRow = memo(function AgentBlockRow({
         className="min-w-0 gap-2 py-1 px-0 my-1 flex w-fit max-w-full items-center text-left transition-opacity hover:opacity-80"
       >
         <span className="min-w-0 gap-1.5 inline-flex max-w-full items-baseline truncate">
-          <span className="text-label-sm font-normal text-ds-text-neutral-muted-default">
-            {agentLabel}
-          </span>
-          {detail ? (
+          {headerRunning ? (
+            <ShinyText
+              text={headerText}
+              speed={2.5}
+              className="!text-label-sm font-normal truncate"
+            />
+          ) : (
             <>
-              <span className="text-label-sm text-ds-text-neutral-subtle-default">
-                ·
+              <span className="text-label-sm font-normal text-ds-text-neutral-muted-default">
+                {agentLabel}
               </span>
-              {detailRunning ? (
-                <ShinyText
-                  text={detail}
-                  speed={2.5}
-                  className="text-label-sm font-normal text-ds-text-neutral-subtle-default truncate"
-                />
-              ) : (
-                <span className="text-label-sm font-normal text-ds-text-neutral-subtle-default truncate">
-                  {detail}
-                </span>
-              )}
+              {detail ? (
+                <>
+                  <span className="text-label-sm text-ds-text-neutral-subtle-default">
+                    ·
+                  </span>
+                  <span className="text-label-sm font-normal text-ds-text-neutral-subtle-default truncate">
+                    {detail}
+                  </span>
+                </>
+              ) : null}
             </>
-          ) : null}
+          )}
         </span>
         {open ? (
           <ChevronDown

--- a/src/components/ChatBox/MessageItem/TaskWorkLogAccordion.tsx
+++ b/src/components/ChatBox/MessageItem/TaskWorkLogAccordion.tsx
@@ -42,8 +42,6 @@ const HEIGHT_MOTION = {
   height: { duration: 0.22, ease: CONTENT_EASE },
   opacity: { duration: 0.16, ease: CONTENT_EASE },
 } as const;
-const MARKDOWN_DEFER_THRESHOLD = 1200;
-const MARKDOWN_DEFER_MS = 180;
 const TOOL_INLINE_PREVIEW_MAX = 200;
 
 function normalizeToolkitMessage(value: unknown): string {
@@ -584,25 +582,6 @@ const ToolDetailRow = memo(function ToolDetailRow({
   status: 'running' | 'done';
 }) {
   const [open, setOpen] = useState(false);
-  const [renderMarkdown, setRenderMarkdown] = useState(false);
-
-  useEffect(() => {
-    if (!open) {
-      setRenderMarkdown(false);
-      return;
-    }
-
-    if (detail.length <= MARKDOWN_DEFER_THRESHOLD) {
-      setRenderMarkdown(true);
-      return;
-    }
-
-    const timer = window.setTimeout(
-      () => setRenderMarkdown(true),
-      MARKDOWN_DEFER_MS
-    );
-    return () => window.clearTimeout(timer);
-  }, [open, detail]);
 
   return (
     <div className="min-w-0 flex w-full flex-col items-start">
@@ -642,21 +621,15 @@ const ToolDetailRow = memo(function ToolDetailRow({
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={HEIGHT_MOTION}
-            className="min-w-0 mt-1 w-full overflow-hidden"
+            className="min-w-0 w-full overflow-hidden"
           >
             {detail ? (
-              <div className="p-2 bg-ds-bg-neutral-muted-default rounded-md w-full opacity-60">
-                {renderMarkdown ? (
-                  <MarkDown
-                    content={detail}
-                    enableTypewriter={false}
-                    pTextSize="text-label-xs text-ds-text-neutral-default-default"
-                  />
-                ) : (
-                  <p className="text-label-xs text-ds-text-neutral-default-default m-0">
-                    Rendering details...
-                  </p>
-                )}
+              <div className="mt-1 p-2 bg-ds-bg-neutral-muted-default rounded-md w-full opacity-60">
+                <MarkDown
+                  content={detail}
+                  enableTypewriter={false}
+                  pTextSize="text-label-xs text-ds-text-neutral-default-default"
+                />
               </div>
             ) : null}
           </motion.div>

--- a/src/components/ChatBox/UserQueryGroup.tsx
+++ b/src/components/ChatBox/UserQueryGroup.tsx
@@ -48,26 +48,26 @@ const AgentResultCard: React.FC<{
   const label = agentName || 'Agent';
 
   return (
-    <div className="overflow-hidden px-2">
+    <div className="px-2 overflow-hidden">
       {/* Header (always visible) */}
       <button
         type="button"
-        className="focus-visible:ring-ds-border-brand-default-focus/40 flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-semibold text-ds-text-neutral-default-default transition-colors hover:bg-ds-bg-neutral-default-hover focus-visible:outline-none focus-visible:ring-2 active:bg-ds-bg-neutral-default-active"
+        className="focus-visible:ring-ds-border-brand-default-focus/40 gap-2 rounded-xl px-3 py-2 text-sm font-semibold text-ds-text-neutral-default-default hover:bg-ds-bg-neutral-default-hover active:bg-ds-bg-neutral-default-active flex w-full items-center text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
         onClick={() => setIsOpen((v) => !v)}
       >
         <span className="min-w-0 flex-1 truncate">{label}</span>
         <ChevronDown
           size={14}
           aria-hidden
-          className={`shrink-0 text-ds-icon-neutral-default-default transition-transform duration-200 ${isOpen ? 'rotate-180' : 'rotate-0'}`}
+          className={`text-ds-icon-neutral-default-default shrink-0 transition-transform duration-200 ${isOpen ? 'rotate-180' : 'rotate-0'}`}
         />
       </button>
 
       {/* Collapsible body */}
       <div
-        className={`overflow-hidden transition-all duration-200 ease-in-out ${isOpen ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}`}
+        className={`ease-in-out overflow-hidden transition-all duration-200 ${isOpen ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}`}
       >
-        <div className="border-t border-ds-border-neutral-default-default px-1 py-1">
+        <div className="border-ds-border-neutral-default-default px-1 py-1 border-t">
           <AgentMessageCard
             id={id}
             content={content}
@@ -226,8 +226,12 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
       (m: any) => m.step === AgentStep.TO_SUB_TASKS && !m.isConfirm
     )
   );
+  // Single agent has no task-splitting/confirm step — it runs directly — so it
+  // never has a planning phase. Skipping this avoids the splitting card
+  // showing during the PENDING window after the backend `confirmed` event.
   const isPlanningPhase = Boolean(
     activeTask &&
+    !isSingleAgentTask &&
     !activeTask.hasWaitComfirm &&
     (isPlanSplittingPhase(activeTask) ||
       streamingDecomposeText.length > 0 ||
@@ -239,15 +243,17 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
   // in the normal running/input path.
   const shouldShowFallbackTask =
     isLastUserQuery && activeTaskId && isPlanningPhase;
+  // Single agent has no split/confirm step: once the task is the current
+  // query and past planning, show its task-card area immediately — even while
+  // PENDING — so the "Preparing to execute" item can render before the work
+  // log. `TaskWorkLogAccordion` self-hides until the task reaches RUNNING.
   const shouldShowSingleAgentWorkLog =
     isCurrentUserQuery &&
     activeTaskId &&
     activeTask &&
     isSingleAgentTask &&
     !isPlanningPhase &&
-    !isHumanReply &&
-    (activeTask.status !== ChatTaskStatus.PENDING ||
-      (activeTask.taskAssigning?.length ?? 0) > 0);
+    !isHumanReply;
 
   const task =
     (queryGroup.taskMessage ||
@@ -321,8 +327,9 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
     };
   }, [task]);
 
-  // Check if we're in skeleton phase
-  const isSkeletonPhase = task && isPlanSplittingPhase(task);
+  // Check if we're in skeleton phase — never for single agent (no splitting).
+  const isSkeletonPhase =
+    task && !isSingleAgentTask && isPlanSplittingPhase(task);
 
   /** Task card visible (user message is sticky alone in this mode). */
   const taskCardVisible = Boolean(task) && !isSkeletonPhase && !isHumanReply;
@@ -334,10 +341,12 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
     )
   );
   const showPreparingExecute =
-    showTaskPlanCard &&
     Boolean(activeTaskId && task) &&
-    hasConfirmedSubTasks &&
-    task!.status === ChatTaskStatus.PENDING;
+    task!.status === ChatTaskStatus.PENDING &&
+    // Workforce: after the user confirms the plan, before the work log.
+    ((showTaskPlanCard && hasConfirmedSubTasks) ||
+      // Single agent: from submit until the first `todo_state` arrives.
+      shouldShowSingleAgentWorkLog);
 
   return (
     <motion.div
@@ -372,7 +381,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
       {taskCardVisible && queryGroup.userMessage && (
         <motion.div
           ref={taskBoxRef}
-          className="sticky top-0 z-20"
+          className="top-0 sticky z-20"
           style={{
             position: 'sticky',
             top: 0,
@@ -469,7 +478,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
-                className="flex flex-col gap-4"
+                className="gap-4 flex flex-col"
               >
                 <AgentMessageCard
                   typewriter={shouldUseLiveAgentTypewriter(task, message.id)}
@@ -479,7 +488,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                   onMarkdownRenderComplete={onTaskCompletionMarkdownReady}
                   deferredFooter={
                     message.fileList?.length ? (
-                      <div className="my-2 flex flex-wrap gap-2">
+                      <div className="my-2 gap-2 flex flex-wrap">
                         {message.fileList.map(
                           (file: any, fileIndex: number) => (
                             <motion.div
@@ -490,14 +499,14 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                               onClick={() => {
                                 openFilePreview(file);
                               }}
-                              className="flex w-[140px] cursor-pointer items-center gap-2 rounded-lg bg-ds-bg-neutral-default-default px-3 py-2 transition-colors hover:bg-ds-bg-neutral-default-hover"
+                              className="gap-2 rounded-lg bg-ds-bg-neutral-default-default px-3 py-2 hover:bg-ds-bg-neutral-default-hover flex w-[140px] cursor-pointer items-center transition-colors"
                             >
                               <FileText
                                 size={16}
-                                className="flex-shrink-0 text-ds-icon-neutral-default-default"
+                                className="text-ds-icon-neutral-default-default flex-shrink-0"
                               />
                               <div className="flex flex-col">
-                                <div className="max-w-[100px] overflow-hidden text-ellipsis whitespace-nowrap text-body-sm font-bold text-ds-text-neutral-default-default">
+                                <div className="text-body-sm font-bold text-ds-text-neutral-default-default max-w-[100px] overflow-hidden text-ellipsis whitespace-nowrap">
                                   {file.name.split('.')[0]}
                                 </div>
                                 <div className="text-label-xs font-medium text-ds-text-neutral-muted-default">
@@ -520,7 +529,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
-                className="flex flex-col gap-4"
+                className="gap-4 flex flex-col"
               >
                 <AgentMessageCard
                   key={message.id}
@@ -555,7 +564,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
-                className="flex flex-col gap-4"
+                className="gap-4 flex flex-col"
               >
                 <AgentMessageCard
                   key={message.id}
@@ -575,10 +584,10 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ delay: 0.2 }}
-              className="flex flex-col gap-4"
+              className="gap-4 flex flex-col"
             >
               {message.fileList && (
-                <div className="flex flex-wrap gap-2">
+                <div className="gap-2 flex flex-wrap">
                   {message.fileList.map((file: any, fileIndex: number) => (
                     <motion.div
                       key={`file-${message.id}-${file.name}-${fileIndex}`}
@@ -588,14 +597,14 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                       onClick={() => {
                         openFilePreview(file);
                       }}
-                      className="flex w-[120px] cursor-pointer items-center gap-2 rounded-2xl bg-ds-bg-neutral-default-default px-2 py-1 transition-colors hover:bg-ds-bg-neutral-default-hover"
+                      className="gap-2 rounded-2xl bg-ds-bg-neutral-default-default px-2 py-1 hover:bg-ds-bg-neutral-default-hover flex w-[120px] cursor-pointer items-center transition-colors"
                     >
                       <FileText
                         size={16}
-                        className="flex-shrink-0 text-ds-icon-neutral-default-default"
+                        className="text-ds-icon-neutral-default-default flex-shrink-0"
                       />
                       <div className="flex flex-col">
-                        <div className="text-body max-w-48 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-bold text-ds-text-neutral-default-default">
+                        <div className="text-body max-w-48 text-sm font-bold text-ds-text-neutral-default-default overflow-hidden text-ellipsis whitespace-nowrap">
                           {file.name.split('.')[0]}
                         </div>
                         <div className="text-xs font-medium leading-29 text-ds-text-neutral-default-default">
@@ -631,7 +640,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.25 }}
-            className="mb-md flex flex-col gap-4 px-sm"
+            className="mb-md gap-4 px-sm flex flex-col"
           >
             <TaskCompletionCard
               taskPrompt={queryGroup.userMessage?.content}

--- a/src/components/ChatBox/index.tsx
+++ b/src/components/ChatBox/index.tsx
@@ -68,12 +68,13 @@ export default function ChatBox(): JSX.Element {
   const activeTask = chatStore?.activeTaskId
     ? chatStore.tasks[chatStore.activeTaskId]
     : undefined;
-  // `null` = mode not yet determined (existing session still loading).
+  // Session mode in three forms (see naming convention shared with
+  // Session/Workspace): `inferred` is the raw, nullable inference;
+  // `effective` always resolves to a concrete mode; `display` stays nullable
+  // so a still-loading session renders empty instead of the wrong mode.
   const inferredSessionMode = inferSessionModeFromTask(activeTask, null);
-  // Concrete mode for the fresh-session input and for starting a task.
-  const submitSessionMode = inferredSessionMode ?? sessionSidePanelMode;
-  // Read-only input chip: hidden while an existing session resolves its mode.
-  const inputSessionMode = inferredSessionMode ?? undefined;
+  const effectiveSessionMode = inferredSessionMode ?? sessionSidePanelMode;
+  const displaySessionMode = inferredSessionMode ?? undefined;
   const { hasModel, isConfigLoaded } = useModelConfigCheck();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const bottomBoxOverlayRef = useRef<HTMLDivElement>(null);
@@ -530,7 +531,7 @@ export default function ChatBox(): JSX.Element {
                 attachesToSend,
                 executionId,
                 undefined,
-                submitSessionMode
+                effectiveSessionMode
               );
               chatStore.setAttaches(_taskId, []);
             } catch (err: any) {
@@ -594,7 +595,7 @@ export default function ChatBox(): JSX.Element {
               attachesToSend,
               executionId,
               undefined,
-              submitSessionMode
+              effectiveSessionMode
             );
             chatStore.setHasWaitComfirm(_taskId as string, true);
             chatStore.setAttaches(_taskId, []);
@@ -979,7 +980,7 @@ export default function ChatBox(): JSX.Element {
                     textareaRef: textareaRef,
                     allowDragDrop: true,
                     useCloudModelInDev: useCloudModelInDev,
-                    sessionMode: submitSessionMode,
+                    sessionMode: effectiveSessionMode,
                     sessionModeSelectInteractive: false,
                   }}
                 />
@@ -1061,7 +1062,7 @@ export default function ChatBox(): JSX.Element {
                   textareaRef: textareaRef,
                   allowDragDrop: true,
                   useCloudModelInDev: useCloudModelInDev,
-                  sessionMode: inputSessionMode,
+                  sessionMode: displaySessionMode,
                   sessionModeSelectInteractive: false,
                 }}
               />

--- a/src/components/ChatBox/index.tsx
+++ b/src/components/ChatBox/index.tsx
@@ -63,15 +63,17 @@ export default function ChatBox(): JSX.Element {
     (s) => s.workspaceChatFocusRequestId
   );
   const sessionSidePanelMode = usePageTabStore(
-    (s) => s.sessionSidePanelMode ?? SessionMode.WORKFORCE
+    (s) => s.sessionSidePanelMode ?? SessionMode.SINGLE_AGENT
   );
   const activeTask = chatStore?.activeTaskId
     ? chatStore.tasks[chatStore.activeTaskId]
     : undefined;
-  const effectiveSessionMode = inferSessionModeFromTask(
-    activeTask,
-    sessionSidePanelMode
-  );
+  // `null` = mode not yet determined (existing session still loading).
+  const inferredSessionMode = inferSessionModeFromTask(activeTask, null);
+  // Concrete mode for the fresh-session input and for starting a task.
+  const submitSessionMode = inferredSessionMode ?? sessionSidePanelMode;
+  // Read-only input chip: hidden while an existing session resolves its mode.
+  const inputSessionMode = inferredSessionMode ?? undefined;
   const { hasModel, isConfigLoaded } = useModelConfigCheck();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const bottomBoxOverlayRef = useRef<HTMLDivElement>(null);
@@ -528,7 +530,7 @@ export default function ChatBox(): JSX.Element {
                 attachesToSend,
                 executionId,
                 undefined,
-                effectiveSessionMode
+                submitSessionMode
               );
               chatStore.setAttaches(_taskId, []);
             } catch (err: any) {
@@ -592,7 +594,7 @@ export default function ChatBox(): JSX.Element {
               attachesToSend,
               executionId,
               undefined,
-              effectiveSessionMode
+              submitSessionMode
             );
             chatStore.setHasWaitComfirm(_taskId as string, true);
             chatStore.setAttaches(_taskId, []);
@@ -933,10 +935,10 @@ export default function ChatBox(): JSX.Element {
   const chatColumn = (
     <>
       {/* Main: scroll (scrollbar on panel edge) + BottomBox overlay when chatting */}
-      <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="min-h-0 min-w-0 relative flex flex-1 flex-col overflow-hidden">
         <div
           ref={scrollContainerRef}
-          className="scrollbar-always-visible min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden"
+          className="scrollbar-always-visible min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto"
         >
           {hasAnyMessages ? (
             <ProjectChatContainer
@@ -946,8 +948,8 @@ export default function ChatBox(): JSX.Element {
               isPauseResumeLoading={isPauseResumeLoading}
             />
           ) : (
-            <div className="mx-auto flex min-h-full w-full max-w-[600px] flex-col pl-4 pr-2">
-              <div className="flex flex-1 flex-col items-center justify-end gap-1 pb-4"></div>
+            <div className="pl-4 pr-2 mx-auto flex min-h-full w-full max-w-[600px] flex-col">
+              <div className="gap-1 pb-4 flex flex-1 flex-col items-center justify-end"></div>
 
               {chatStore.activeTaskId && (
                 <BottomBox
@@ -977,7 +979,7 @@ export default function ChatBox(): JSX.Element {
                     textareaRef: textareaRef,
                     allowDragDrop: true,
                     useCloudModelInDev: useCloudModelInDev,
-                    sessionMode: effectiveSessionMode,
+                    sessionMode: submitSessionMode,
                     sessionModeSelectInteractive: false,
                   }}
                 />
@@ -993,9 +995,9 @@ export default function ChatBox(): JSX.Element {
           <div
             ref={bottomBoxOverlayRef}
             data-bottom-box-overlay
-            className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex justify-center"
+            className="inset-x-0 bottom-0 pointer-events-none absolute z-30 flex justify-center"
           >
-            <div className="pointer-events-auto w-full max-w-[600px] px-sm">
+            <div className="px-sm pointer-events-auto w-full max-w-[600px]">
               <BottomBox
                 state={getBottomBoxState()}
                 queuedMessages={queuedMessages}
@@ -1059,7 +1061,7 @@ export default function ChatBox(): JSX.Element {
                   textareaRef: textareaRef,
                   allowDragDrop: true,
                   useCloudModelInDev: useCloudModelInDev,
-                  sessionMode: effectiveSessionMode,
+                  sessionMode: inputSessionMode,
                   sessionModeSelectInteractive: false,
                 }}
               />
@@ -1071,7 +1073,7 @@ export default function ChatBox(): JSX.Element {
   );
 
   return (
-    <div className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden">
+    <div className="min-h-0 relative flex h-full w-full flex-1 flex-col overflow-hidden">
       {chatColumn}
     </div>
   );

--- a/src/components/Session/index.tsx
+++ b/src/components/Session/index.tsx
@@ -97,10 +97,12 @@ export default function Session() {
     }
   }, [hasSessionStarted, setActiveWorkspaceTab]);
 
-  // While a saved session is still loading, the mode is briefly unknown —
-  // render the side panel empty rather than defaulting to workforce and
-  // flickering once the real mode resolves. Fresh sessions use the toggle.
-  const effectiveSessionMode: SessionModeType | null =
+  // Nullable "display" form of the session mode (see the naming convention
+  // shared with ChatBox/Workspace). `null` while a saved session is still
+  // loading — the side panel renders empty rather than defaulting to
+  // workforce and flickering once the real mode resolves. Fresh sessions
+  // fall back to the toggle's mode.
+  const displaySessionMode: SessionModeType | null =
     inferredSessionMode ?? (hasSessionStarted ? null : sessionMode);
 
   useEffect(() => {
@@ -149,9 +151,9 @@ export default function Session() {
             : cn(SESSION_SIDE_PANEL_FOLDED_OUTER_CLASS, 'rounded-l-xl')
         )}
       >
-        {effectiveSessionMode ? (
+        {displaySessionMode ? (
           <SessionSidePanel
-            mode={effectiveSessionMode}
+            mode={displaySessionMode}
             workforcePanelKey={workforcePanelKey}
             hasAnyMessages={hasAnyMessages}
             isSidePanelVisible={isSidePanelVisible}

--- a/src/components/Session/index.tsx
+++ b/src/components/Session/index.tsx
@@ -18,7 +18,11 @@ import useChatStoreAdapter from '@/hooks/useChatStoreAdapter';
 import { inferSessionModeFromTask } from '@/lib/sessionMode';
 import { cn } from '@/lib/utils';
 import { usePageTabStore } from '@/store/pageTabStore';
-import { ChatTaskStatus, SessionMode } from '@/types/constants';
+import {
+  ChatTaskStatus,
+  SessionMode,
+  type SessionModeType,
+} from '@/types/constants';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { SessionSidePanel } from './SessionSidePanel';
 import {
@@ -36,15 +40,13 @@ export default function Session() {
   const activeWorkspaceTab = usePageTabStore((s) => s.activeWorkspaceTab);
   const setActiveWorkspaceTab = usePageTabStore((s) => s.setActiveWorkspaceTab);
   const sessionMode = usePageTabStore(
-    (s) => s.sessionSidePanelMode ?? SessionMode.WORKFORCE
+    (s) => s.sessionSidePanelMode ?? SessionMode.SINGLE_AGENT
   );
   const activeTask = chatStore?.activeTaskId
     ? chatStore.tasks[chatStore.activeTaskId]
     : undefined;
-  const effectiveSessionMode = inferSessionModeFromTask(
-    activeTask,
-    sessionMode
-  );
+  // `null` = mode not yet determined (session still loading its events).
+  const inferredSessionMode = inferSessionModeFromTask(activeTask, null);
 
   const [isSidePanelVisible, setIsSidePanelVisible] = useState(true);
   const [isExpandedOverlayOpen, setIsExpandedOverlayOpen] = useState(false);
@@ -95,6 +97,12 @@ export default function Session() {
     }
   }, [hasSessionStarted, setActiveWorkspaceTab]);
 
+  // While a saved session is still loading, the mode is briefly unknown —
+  // render the side panel empty rather than defaulting to workforce and
+  // flickering once the real mode resolves. Fresh sessions use the toggle.
+  const effectiveSessionMode: SessionModeType | null =
+    inferredSessionMode ?? (hasSessionStarted ? null : sessionMode);
+
   useEffect(() => {
     setIsExpandedOverlayOpen(false);
   }, [projectStore.activeProjectId]);
@@ -122,8 +130,8 @@ export default function Session() {
   }
 
   return (
-    <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-row overflow-hidden">
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+    <div className="min-h-0 min-w-0 flex h-full w-full flex-1 flex-row overflow-hidden">
+      <div className="min-h-0 min-w-0 flex flex-1 flex-col overflow-hidden">
         {chatStore.activeTaskId && hasAnyMessages && (
           <HeaderBox
             totalTokens={chatStore.tasks[chatStore.activeTaskId]?.tokens || 0}
@@ -135,22 +143,24 @@ export default function Session() {
       <div
         id="session-side-panel"
         className={cn(
-          'flex min-h-0 shrink-0 flex-col overflow-hidden transition-[width] duration-200 ease-out',
+          'min-h-0 ease-out flex shrink-0 flex-col overflow-hidden transition-[width] duration-200',
           isSidePanelVisible
             ? SESSION_SIDE_PANEL_EXPANDED_OUTER_CLASS
             : cn(SESSION_SIDE_PANEL_FOLDED_OUTER_CLASS, 'rounded-l-xl')
         )}
       >
-        <SessionSidePanel
-          mode={effectiveSessionMode}
-          workforcePanelKey={workforcePanelKey}
-          hasAnyMessages={hasAnyMessages}
-          isSidePanelVisible={isSidePanelVisible}
-          onToggleSidePanel={toggleSidePanel}
-          isExpandedOverlayOpen={isExpandedOverlayOpen}
-          onToggleExpandedOverlay={toggleExpandedOverlay}
-          onCloseExpandedOverlay={closeExpandedOverlay}
-        />
+        {effectiveSessionMode ? (
+          <SessionSidePanel
+            mode={effectiveSessionMode}
+            workforcePanelKey={workforcePanelKey}
+            hasAnyMessages={hasAnyMessages}
+            isSidePanelVisible={isSidePanelVisible}
+            onToggleSidePanel={toggleSidePanel}
+            isExpandedOverlayOpen={isExpandedOverlayOpen}
+            onToggleExpandedOverlay={toggleExpandedOverlay}
+            onCloseExpandedOverlay={closeExpandedOverlay}
+          />
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/WorkFlow/MarkDown.tsx
+++ b/src/components/WorkFlow/MarkDown.tsx
@@ -32,7 +32,12 @@ export const MarkDown = ({
   pTextSize?: string;
   olPadding?: string;
 }) => {
-  const [displayedContent, setDisplayedContent] = useState('');
+  // When the typewriter is off, seed with the full content so the very first
+  // paint already has it — otherwise the content arrives a tick later (via the
+  // effect below) and any height-animated container measures an empty body.
+  const [displayedContent, setDisplayedContent] = useState(
+    enableTypewriter ? '' : content
+  );
 
   useEffect(() => {
     if (!enableTypewriter) {

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -71,7 +71,7 @@ export default function Workspace() {
   }, [activeProject, customAgentFolderPath, isEmptyProject]);
   const setActiveWorkspaceTab = usePageTabStore((s) => s.setActiveWorkspaceTab);
   const sessionSidePanelMode = usePageTabStore(
-    (s) => s.sessionSidePanelMode ?? SessionMode.WORKFORCE
+    (s) => s.sessionSidePanelMode ?? SessionMode.SINGLE_AGENT
   );
   const setSessionSidePanelMode = usePageTabStore(
     (s) => s.setSessionSidePanelMode
@@ -81,10 +81,11 @@ export default function Workspace() {
   const activeTask = chatStore?.activeTaskId
     ? chatStore.tasks[chatStore.activeTaskId]
     : undefined;
-  const effectiveSessionMode = inferSessionModeFromTask(
-    activeTask,
-    sessionSidePanelMode
-  );
+  // Workspace is the pre-session landing — always resolve to a concrete mode
+  // so the interactive toggle and start-task call never see a null.
+  const effectiveSessionMode =
+    inferSessionModeFromTask(activeTask, sessionSidePanelMode) ??
+    sessionSidePanelMode;
 
   const [message, setMessage] = useState('');
   const { hasModel } = useModelConfigCheck();
@@ -283,8 +284,8 @@ export default function Workspace() {
       });
 
   return (
-    <div className="relative flex h-full min-h-0 w-full flex-col">
-      <div className="relative z-50 flex h-[44px] w-full shrink-0 flex-row items-center justify-start px-3">
+    <div className="min-h-0 relative flex h-full w-full flex-col">
+      <div className="px-3 relative z-50 flex h-[44px] w-full shrink-0 flex-row items-center justify-start">
         <TooltipSimple content={workWithPanelToggleLabel} delayDuration={300}>
           <Button
             type="button"
@@ -294,21 +295,21 @@ export default function Workspace() {
             onClick={() => setWorkspaceWorkWithPanelOpen((open) => !open)}
             aria-expanded={workspaceWorkWithPanelOpen}
             aria-controls="workspace-work-with-panel"
-            className="no-drag shrink-0 text-ds-text-neutral-muted-default hover:bg-ds-bg-neutral-strong-default"
+            className="no-drag text-ds-text-neutral-muted-default hover:bg-ds-bg-neutral-strong-default shrink-0"
             aria-label={workWithPanelToggleLabel}
           >
             <Cast className="h-4 w-4" aria-hidden />
           </Button>
         </TooltipSimple>
       </div>
-      <div className="relative z-0 flex min-h-0 w-full flex-1 flex-col items-stretch overflow-hidden">
-        <div className="flex min-h-0 w-full flex-1 flex-col px-3">
+      <div className="min-h-0 relative z-0 flex w-full flex-1 flex-col items-stretch overflow-hidden">
+        <div className="min-h-0 px-3 flex w-full flex-1 flex-col">
           <div className="mx-auto flex w-full max-w-[600px] shrink-0 flex-col">
-            <div className="flex min-h-[50vh] w-full min-w-0 flex-col justify-end">
+            <div className="min-w-0 flex min-h-[50vh] w-full flex-col justify-end">
               <div className="mb-8 flex w-full justify-center">
                 <WorkspaceProjectPicker />
               </div>
-              <span className="mb-8 w-full text-center text-heading-lg font-bold text-ds-text-neutral-default-default">
+              <span className="mb-8 text-heading-lg font-bold text-ds-text-neutral-default-default w-full text-center">
                 {effectiveSessionMode === SessionMode.SINGLE_AGENT
                   ? t('layout.workspace-cowork-single-agent', {
                       defaultValue: 'Cowork with Single Agent',
@@ -317,7 +318,7 @@ export default function Workspace() {
                       defaultValue: 'Cowork with Workforce',
                     })}
               </span>
-              <div className="mb-8 flex w-full justify-center px-5">
+              <div className="mb-8 px-5 flex w-full justify-center">
                 {effectiveSessionMode === SessionMode.SINGLE_AGENT ? (
                   <SingleAgentList />
                 ) : (
@@ -387,7 +388,7 @@ export default function Workspace() {
           </div>
 
           <div
-            className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto pt-6"
+            className="min-h-0 pt-6 flex w-full flex-1 flex-col overflow-y-auto"
             id="workspace-bottom-group"
           >
             {showWorkspaceExamplePrompts ? (
@@ -414,7 +415,7 @@ export default function Workspace() {
         <>
           <button
             type="button"
-            className="absolute inset-0 z-40 cursor-default bg-transparent backdrop-blur-[1px]"
+            className="inset-0 absolute z-40 cursor-default bg-transparent backdrop-blur-[1px]"
             aria-label={t('layout.workspace-work-with-dismiss-overlay', {
               defaultValue: 'Dismiss',
             })}
@@ -425,10 +426,10 @@ export default function Workspace() {
             role="dialog"
             aria-modal="true"
             aria-labelledby="workspace-work-with-heading"
-            className="absolute left-0 top-8 z-50 flex max-h-[calc(100%-2.75rem)] w-[300px] flex-col overflow-y-auto duration-200 ease-out animate-in fade-in-0 slide-in-from-left-2"
+            className="left-0 top-8 ease-out animate-in fade-in-0 slide-in-from-left-2 absolute z-50 flex max-h-[calc(100%-2.75rem)] w-[300px] flex-col overflow-y-auto duration-200"
           >
-            <div className="flex flex-col gap-3 p-3">
-              <div className="flex min-w-0 flex-col rounded-xl border border-solid border-ds-border-neutral-subtle-default bg-ds-bg-neutral-subtle-default p-3">
+            <div className="gap-3 p-3 flex flex-col">
+              <div className="min-w-0 rounded-xl border-ds-border-neutral-subtle-default bg-ds-bg-neutral-subtle-default p-3 flex flex-col border border-solid">
                 <span
                   id="workspace-work-with-heading"
                   className="text-body-sm font-semibold text-ds-text-neutral-default-default"
@@ -437,7 +438,7 @@ export default function Workspace() {
                     defaultValue: 'Work with',
                   })}
                 </span>
-                <div className="mt-3 flex flex-col gap-1">
+                <div className="mt-3 gap-1 flex flex-col">
                   <Button
                     type="button"
                     variant="ghost"
@@ -445,10 +446,10 @@ export default function Workspace() {
                     emphasis="default"
                     size="sm"
                     buttonContent="text"
-                    className="no-drag justify-start gap-2"
+                    className="no-drag gap-2 justify-start"
                   >
                     <MonitorSmartphone
-                      className="h-4 w-4 shrink-0 text-ds-text-neutral-muted-default"
+                      className="h-4 w-4 text-ds-text-neutral-muted-default shrink-0"
                       aria-hidden
                     />
                     {t('layout.workspace-work-with-remote-control', {
@@ -462,7 +463,7 @@ export default function Workspace() {
                     emphasis="default"
                     size="sm"
                     buttonContent="text"
-                    className="no-drag justify-start gap-2"
+                    className="no-drag gap-2 justify-start"
                     aria-label={t('layout.channels-telegram', {
                       defaultValue: 'Telegram',
                     })}
@@ -484,7 +485,7 @@ export default function Workspace() {
                     emphasis="default"
                     size="sm"
                     buttonContent="text"
-                    className="no-drag justify-start gap-2"
+                    className="no-drag gap-2 justify-start"
                     aria-label={t('layout.channels-lark', {
                       defaultValue: 'Lark',
                     })}
@@ -492,7 +493,7 @@ export default function Workspace() {
                     <img
                       src={larkIcon}
                       alt=""
-                      className="h-4 w-4 shrink-0 rounded-lg object-contain"
+                      className="h-4 w-4 rounded-lg shrink-0 object-contain"
                       aria-hidden
                     />
                     {t('layout.channels-lark', { defaultValue: 'Lark' })}
@@ -504,7 +505,7 @@ export default function Workspace() {
                     emphasis="default"
                     size="sm"
                     buttonContent="text"
-                    className="no-drag justify-start gap-2"
+                    className="no-drag gap-2 justify-start"
                     aria-label={t('layout.channels-whatsapp', {
                       defaultValue: 'WhatsApp',
                     })}

--- a/src/lib/sessionMode.ts
+++ b/src/lib/sessionMode.ts
@@ -45,10 +45,17 @@ function hasWorkforceAgent(agents: SessionModeAgent[] | undefined) {
   );
 }
 
+/**
+ * Resolve a task's session mode from its data.
+ *
+ * Pass `fallback: null` to detect the "not yet determined" case — useful
+ * while a project/session is still loading, so the UI can render a neutral
+ * state instead of flashing the wrong mode (workforce → single-agent).
+ */
 export function inferSessionModeFromTask(
   task: SessionModeTask | null | undefined,
-  fallback: SessionModeType = SessionMode.WORKFORCE
-): SessionModeType {
+  fallback: SessionModeType | null = SessionMode.WORKFORCE
+): SessionModeType | null {
   if (!task) return fallback;
   if (task.sessionMode) return task.sessionMode;
 

--- a/src/lib/sessionNavLead.ts
+++ b/src/lib/sessionNavLead.ts
@@ -30,6 +30,7 @@ import {
 import type { ChatStore } from '@/store/chatStore';
 import {
   ChatTaskStatus,
+  SessionMode,
   TaskStatus,
   type TaskStatusType,
 } from '@/types/constants';
@@ -129,11 +130,17 @@ export function getSessionNavLeadPresentation(
   const errorSignal =
     isTaskListRowHardFailure(task) || wf.some((s) => s === TaskStatus.FAILED);
   const warningSignal = Boolean(task.isContextExceeded) && !errorSignal;
+  // Single agent runs directly — no splitting/confirm step. Its sidebar icon
+  // tracks the task status only: chat bubble while preparing, running spinner
+  // while executing, check when finished — matching the chat container.
+  const isSingleAgent = task.sessionMode === SessionMode.SINGLE_AGENT;
   const bottom = getBottomBoxStateForTask(task);
+  // Human-in-the-loop = an unconfirmed plan or an explicit `ask` / `wait_confirm`.
+  // A workforce subtask in WAITING means "assigned, not yet started" — a normal
+  // running-phase state — so it must NOT surface the Hand icon while running.
+  // Single agent has no plan/confirm step, so it never shows the HITL icon.
   const hitlSignal =
-    bottom === 'confirm' ||
-    task.hasWaitComfirm ||
-    wf.some((s) => s === TaskStatus.WAITING);
+    !isSingleAgent && (bottom === 'confirm' || Boolean(task.hasWaitComfirm));
   const blockedSignal = wf.some((s) => s === TaskStatus.BLOCKED);
   const shelf = getTaskListShelfTone(task);
 

--- a/src/lib/taskLifecycleUi.ts
+++ b/src/lib/taskLifecycleUi.ts
@@ -17,6 +17,8 @@ import {
   AgentStep,
   ChatTaskStatus,
   type ChatTaskStatusType,
+  SessionMode,
+  type SessionModeType,
 } from '@/types/constants';
 
 /** Minimal task shape for bottom-box / sidebar lifecycle (matches chatStore Task fields used). */
@@ -28,6 +30,7 @@ export interface TaskLifecycleFields {
   isTakeControl?: boolean;
   taskInfo?: { id: string; content: string }[];
   isContextExceeded?: boolean;
+  sessionMode?: SessionModeType;
 }
 
 function getTaskMessages(task: TaskLifecycleFields): Message[] {
@@ -47,6 +50,8 @@ function getTaskInfoRows(
  * via {@link isTaskInPlanPhase}.
  */
 function isTaskInPlanPhase(task: TaskLifecycleFields): boolean {
+  // Single agent runs directly — it has no task-splitting / confirm phase.
+  if (task.sessionMode === SessionMode.SINGLE_AGENT) return false;
   const messages = getTaskMessages(task);
   const status = task.status ?? ChatTaskStatus.PENDING;
   const hasWaitComfirm = Boolean(task.hasWaitComfirm);

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -713,7 +713,7 @@ const ensureSingleAgentAssignment = (
   if (existingIndex !== -1) return existingIndex;
   taskAssigning.push({
     agent_id: agentId || `${taskId}-single-agent`,
-    name: 'Single Agent',
+    name: 'CAMEL Agent',
     type: 'single_agent',
     status: AgentStatusValue.RUNNING,
     tasks: [],
@@ -1130,9 +1130,15 @@ const chatStore = (initial?: Partial<ChatStore>) =>
           }
         }
       }
-      targetChatStore
-        .getState()
-        .setTaskSessionMode(newTaskId, sessionModeForRequest);
+      // For replay/share playback the real session mode is unknown until the
+      // playback re-emits `todo_state` / `to_sub_tasks`. Pre-setting it here
+      // would flash the wrong side panel when loading a saved session, so
+      // only seed it for live tasks; playback resolves it from the events.
+      if (!type || type === 'normal') {
+        targetChatStore
+          .getState()
+          .setTaskSessionMode(newTaskId, sessionModeForRequest);
+      }
 
       // Replay/share APIs live on the server side, not Brain.
       const serverBaseUrl = import.meta.env.DEV
@@ -1485,7 +1491,7 @@ const chatStore = (initial?: Partial<ChatStore>) =>
             document_agent: 'Document Agent',
             multi_modal_agent: 'Multi Modal Agent',
             social_media_agent: 'Social Media Agent',
-            single_agent: 'Single Agent',
+            single_agent: 'CAMEL Agent',
           };
 
           /**
@@ -2035,7 +2041,7 @@ const chatStore = (initial?: Partial<ChatStore>) =>
               existingIndex === -1
                 ? {
                     agent_id: agentId,
-                    name: 'Single Agent',
+                    name: 'CAMEL Agent',
                     type: 'single_agent',
                     tasks: todoTasks,
                     log: [],
@@ -2046,7 +2052,7 @@ const chatStore = (initial?: Partial<ChatStore>) =>
                 : {
                     ...existingAgents[existingIndex],
                     agent_id: existingAgents[existingIndex].agent_id || agentId,
-                    name: existingAgents[existingIndex].name || 'Single Agent',
+                    name: existingAgents[existingIndex].name || 'CAMEL Agent',
                     type: 'single_agent',
                     tasks: todoTasks,
                   };
@@ -2061,6 +2067,12 @@ const chatStore = (initial?: Partial<ChatStore>) =>
             setTaskRunning(currentTaskId, todoTasks);
             setTaskAssigning(currentTaskId, existingAgents);
             if (tasks[currentTaskId].status !== ChatTaskStatus.FINISHED) {
+              // Single-agent tasks have no confirm step, so `taskTime` is never
+              // seeded by `handleConfirmTask`. Start the work-log clock here on
+              // the first `todo_state`; the `=== 0` guard keeps it idempotent.
+              if (tasks[currentTaskId].taskTime === 0) {
+                setTaskTime(currentTaskId, Date.now());
+              }
               setStatus(currentTaskId, ChatTaskStatus.RUNNING);
             }
             return;

--- a/src/store/pageTabStore.ts
+++ b/src/store/pageTabStore.ts
@@ -216,11 +216,30 @@ export const usePageTabStore = create<PageTabState>()(
             triggerAddDialogRequestId: state.triggerAddDialogRequestId + 1,
           };
         }),
-      sessionSidePanelMode: SessionMode.WORKFORCE,
+      // Single agent is the default mode for a new project; once the user
+      // toggles it, the choice persists (see partialize below).
+      sessionSidePanelMode: SessionMode.SINGLE_AGENT,
       setSessionSidePanelMode: (mode) => set({ sessionSidePanelMode: mode }),
     }),
     {
       name: 'eigent-page-tab',
+      version: 1,
+      // v1: single agent becomes the default session mode. Drop the legacy
+      // persisted preference (from when workforce was the only/default mode)
+      // so existing installs adopt the new default once; later user switches
+      // persist normally.
+      migrate: (persistedState, version) => {
+        if (
+          version < 1 &&
+          persistedState &&
+          typeof persistedState === 'object'
+        ) {
+          const next = { ...(persistedState as Record<string, unknown>) };
+          delete next.sessionSidePanelMode;
+          return next as unknown as PageTabState;
+        }
+        return persistedState as PageTabState;
+      },
       partialize: (state) => ({
         projectSidebarFolded: state.projectSidebarFolded,
         customAgentFolderPathByProjectId:

--- a/src/types/chatbox.d.ts
+++ b/src/types/chatbox.d.ts
@@ -175,7 +175,7 @@ declare global {
     document_agent: 'Document Agent';
     multi_modal_agent: 'Multi Modal Agent';
     social_media_agent: 'Social Media Agent';
-    single_agent: 'Single Agent';
+    single_agent: 'CAMEL Agent';
   }
   type WorkspaceType =
     | 'workflow'

--- a/test/unit/components/TaskWorkLogAccordion.test.tsx
+++ b/test/unit/components/TaskWorkLogAccordion.test.tsx
@@ -374,6 +374,24 @@ describe('buildAgentBlocks — preparation phase', () => {
     expect(tools[1]?.status).toBe('running');
   });
 
+  it('uses the singular "Preparing agent" label in single-agent mode', () => {
+    const logs = [
+      tag(
+        'a-single',
+        'single_agent',
+        'CAMEL Agent',
+        mk(AgentStep.ACTIVATE_TOOLKIT, {
+          toolkit_name: 'Todo Toolkit',
+          method_name: 'register agent',
+          message: 'ChatAgent(CAMEL Agent)',
+        })
+      ),
+    ];
+    const [prep] = buildAgentBlocks(logs, true);
+    expect(prep?.kind).toBe('preparation');
+    expect(prep?.agentName).toBe('Preparing agent');
+  });
+
   it('ends the Preparing block when a non-register event arrives', () => {
     const logs = [
       tag(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

### Description

Adds **CAMEL-based single-agent mode** and fixes the **session/chat UX** so single-agent runs behave correctly end-to-end (no workforce-only planning UI, no mode flicker on load).

**Backend**
- Introduces `single_agent_service`, factory, toolkits (`observable_todo`, `depth_limited_agent`), agent memory, and chat routing so tasks can run as a single CAMEL agent instead of a workforce.

**Frontend — session mode**
- Adds `inferSessionModeFromTask()` with a `null` fallback while a saved session is still loading, so the UI does not flash workforce → single-agent.
- Defaults new projects to **Single Agent** (`pageTabStore` v1 migration clears legacy persisted workforce default).
- Hides the session side panel until mode is known on an existing session; workspace/chat input still resolve to a concrete mode for starting tasks.
- Skips pre-setting `sessionMode` on replay/share playback; mode is inferred from streamed events.

**Frontend — single-agent chat flow**
- Single-agent tasks skip planning/splitting/confirm phases (`UserQueryGroup`, `taskLifecycleUi`, `sessionNavLead`).
- Shows the work-log area and “Preparing to execute” during `PENDING` (before first `todo_state`), matching direct-run behavior.
- Starts the work-log timer on first `todo_state` (no confirm step).
- Renames display label **Single Agent → CAMEL Agent** across chat store and types.

**Frontend — work log & polish**
- `TaskWorkLogAccordion`: singular “Preparing agent” label, unified running header shimmer, capitalized narration.
- Sidebar icons for single-agent follow task status (no HITL/hand-from-waiting subtasks).
- Unit test for single-agent preparation block label.

### Testing Evidence (REQUIRED)
<img width="1392" height="1072" alt="Screenshot 2026-05-20 at 17 55 50" src="https://github.com/user-attachments/assets/bd393e07-c7bd-403e-ac61-bed979571df5" />

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->
<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->
<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

**Automated**
```bash
# Backend
cd backend && pytest tests/app/agent/toolkit/test_observable_todo_toolkit.py tests/app/agent/toolkit/test_depth_limited_agent_toolkit.py tests/app/utils/test_agent_memory.py -q

# Frontend
npm run test -- test/unit/components/TaskWorkLogAccordion.test.tsx
```

**Manual (attach screenshots/screen recording to this PR)**
- [x] **New task — Single Agent (default):** From Workspace, start a task in Single Agent mode → no plan/split card; “Preparing to execute” then work log appear while status is still pending; side panel shows Single Agent view.
- [x] **New task — Workforce:** Toggle to Workforce → plan/split/confirm flow unchanged.
- [x] **Reload saved single-agent session:** Open an existing single-agent chat → side panel does not flash workforce UI before settling on Single Agent.
- [x] **Reload saved workforce session:** Open workforce session → workforce side panel and splitting/HITL icons behave as before.
- [x] **Replay/share:** Play back a saved session → session mode and side panel match playback events (no wrong-mode flash at start).
- [x] **Work log:** Running step shows full header shimmer; prep block reads “Preparing agent” in single-agent mode.

- [x] I have included human-verified testing evidence in this PR.
- [x] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)