### PR TITLE
feat: add opus 4.8 model

### DIFF
--- a/src/i18n/locales/ar/setting.json
+++ b/src/i18n/locales/ar/setting.json
@@ -200,6 +200,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
 

--- a/src/i18n/locales/de/setting.json
+++ b/src/i18n/locales/de/setting.json
@@ -260,6 +260,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "Netzwerk-Proxy",

--- a/src/i18n/locales/en-us/setting.json
+++ b/src/i18n/locales/en-us/setting.json
@@ -228,6 +228,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
 

--- a/src/i18n/locales/es/setting.json
+++ b/src/i18n/locales/es/setting.json
@@ -260,6 +260,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "Proxy de red",

--- a/src/i18n/locales/fr/setting.json
+++ b/src/i18n/locales/fr/setting.json
@@ -243,6 +243,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "Proxy réseau",

--- a/src/i18n/locales/it/setting.json
+++ b/src/i18n/locales/it/setting.json
@@ -260,6 +260,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "Proxy di rete",

--- a/src/i18n/locales/ja/setting.json
+++ b/src/i18n/locales/ja/setting.json
@@ -261,6 +261,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "ネットワークプロキシ",

--- a/src/i18n/locales/ko/setting.json
+++ b/src/i18n/locales/ko/setting.json
@@ -261,6 +261,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "네트워크 프록시",

--- a/src/i18n/locales/ru/setting.json
+++ b/src/i18n/locales/ru/setting.json
@@ -260,6 +260,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
   "network-proxy": "Сетевой прокси",

--- a/src/i18n/locales/zh-Hans/setting.json
+++ b/src/i18n/locales/zh-Hans/setting.json
@@ -218,6 +218,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
 

--- a/src/i18n/locales/zh-Hant/setting.json
+++ b/src/i18n/locales/zh-Hant/setting.json
@@ -189,6 +189,7 @@
   "claude-sonnet-4-6-name": "Claude Sonnet 4.6",
   "claude-opus-4-6-name": "Claude Opus 4.6",
   "claude-opus-4-7-name": "Claude Opus 4.7",
+  "claude-opus-4-8-name": "Claude Opus 4.8",
   "deepseek-v4-pro-name": "DeepSeek V4 Pro",
   "minimax-m2-7-name": "Minimax M2.7",
 

--- a/src/pages/Agents/Models.tsx
+++ b/src/pages/Agents/Models.tsx
@@ -589,6 +589,7 @@ export default function SettingModels() {
     { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6' },
     { id: 'claude-opus-4-6', name: 'Claude Opus 4.6' },
     { id: 'claude-opus-4-7', name: 'Claude Opus 4.7' },
+    { id: 'claude-opus-4-8', name: 'Claude Opus 4.8' },
     { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
     { id: 'minimax_m2_7', name: 'Minimax M2.7' },
   ];
@@ -1514,6 +1515,9 @@ export default function SettingModels() {
                   </SelectItem>
                   <SelectItem value="claude-opus-4-7">
                     {t('setting.claude-opus-4-7-name')}
+                  </SelectItem>
+                  <SelectItem value="claude-opus-4-8">
+                    {t('setting.claude-opus-4-8-name')}
                   </SelectItem>
                   <SelectItem value="deepseek-v4-pro">
                     {t('setting.deepseek-v4-pro-name')}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -29,6 +29,7 @@ export type CloudModelType =
   | 'claude-sonnet-4-6'
   | 'claude-opus-4-6'
   | 'claude-opus-4-7'
+  | 'claude-opus-4-8'
   | 'gpt-5.4'
   | 'gpt-5.5'
   | 'gpt-5-mini'

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -224,6 +224,7 @@ const CLOUD_MODEL_PLATFORM_MAP: Record<CloudModelType, CloudModelPlatform> = {
   'claude-sonnet-4-6': 'aws-bedrock-converse',
   'claude-opus-4-6': 'aws-bedrock-converse',
   'claude-opus-4-7': 'aws-bedrock-converse',
+  'claude-opus-4-8': 'aws-bedrock-converse',
   'gpt-5.4': 'azure',
   'gpt-5.5': 'azure',
   'gpt-5-mini': 'azure',

--- a/test/unit/store/chatStore.test.ts
+++ b/test/unit/store/chatStore.test.ts
@@ -235,6 +235,9 @@ describe('ChatStore - Core Functionality', () => {
       expect(getCloudModelPlatform('claude-opus-4-7')).toBe(
         'aws-bedrock-converse'
       );
+      expect(getCloudModelPlatform('claude-opus-4-8')).toBe(
+        'aws-bedrock-converse'
+      );
       expect(getCloudModelPlatform('deepseek-v4-pro')).toBe('deepseek');
       expect(getCloudModelPlatform('minimax_m2_7')).toBe('minimax');
     });


### PR DESCRIPTION
## Summary

- Adds `claude-opus-4-8` to the cloud model type union and the cloud model selector UI.
- Maps `claude-opus-4-8` to `aws-bedrock-converse` for backend task creation.
- Adds localized display-name entries for all existing settings locales and extends the platform mapping test.

## Validation

- `npm run type-check`
- `npx prettier --check src/store/authStore.ts src/store/chatStore.ts src/pages/Agents/Models.tsx test/unit/store/chatStore.test.ts src/i18n/locales/*/setting.json`
- `npx vitest run test/unit/store/chatStore.test.ts -t "Cloud Model Platform Mapping"`

## Notes

- `npm test -- test/unit/store/chatStore.test.ts` currently fails 4 existing replay/SSE tests because the cloud model key mock returns an empty value before those tests reach SSE behavior; the new platform mapping test passes.
