### PR TITLE
fix(chat): prevent follow-up prompts from reusing first task question

### DIFF
--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -57,6 +57,35 @@ const API_CODE_TRIAL_LIMIT = '22';
 const PROJECT_CONTEXT_MAX_CHARS = 24_000;
 const PROJECT_CONTEXT_MAX_RUNS = 8;
 
+type ConfirmedUserPromptSources = {
+  lastMessageContent?: unknown;
+  messageContent?: unknown;
+  question?: unknown;
+  isFollowUpConfirm: boolean;
+};
+
+const nonEmptyString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+export function resolveConfirmedUserMessageContent({
+  lastMessageContent,
+  messageContent,
+  question,
+  isFollowUpConfirm,
+}: ConfirmedUserPromptSources): string {
+  const optimisticMessage = nonEmptyString(lastMessageContent);
+  if (optimisticMessage) return optimisticMessage;
+
+  const capturedStartMessage = nonEmptyString(messageContent);
+  const eventQuestion = nonEmptyString(question);
+
+  if (isFollowUpConfirm) {
+    return eventQuestion || capturedStartMessage || '';
+  }
+
+  return capturedStartMessage || eventQuestion || '';
+}
+
 const hasApiCode = (value: unknown, code: string) =>
   typeof value === 'object' &&
   value !== null &&
@@ -1771,6 +1800,7 @@ const chatStore = (initial?: Partial<ChatStore>) =>
                   newChatStore.getState().setType(newTaskId, 'replay');
                 }
 
+                const isFollowUpConfirm = Boolean(previousChatStore.nextTaskId);
                 const lastMessage =
                   previousChatStore.tasks[currentTaskId]?.messages.at(-1);
                 if (lastMessage?.role === 'user' && lastMessage?.id) {
@@ -1789,29 +1819,30 @@ const chatStore = (initial?: Partial<ChatStore>) =>
                         ...(messageAttaches || []),
                       ];
 
-                // Three candidate sources for the user prompt body, in
-                // descending order of trustworthiness:
+                // Three candidate sources for the user prompt body.
                 //   1. lastMessage.content -- the prompt ChatBox.handleSend
                 //      just added to the previous chatStore. This is what
                 //      the user actually typed *this turn* and is therefore
                 //      authoritative for both startTask and improve flows.
-                //   2. messageContent -- the closure-captured arg passed to
-                //      startTask. Stale for improve turns (the SSE consumer
-                //      keeps the first prompt forever) but accurate for the
-                //      startTask path that drove this handler.
-                //   3. question -- the SSE CONFIRMED event's question field.
-                //      Drifts in Workforce when backend reuses task_lock
-                //      across turns; correct in Single Agent improve.
-                // Falling back from (1) → (2) → (3) covers replay (no
-                // optimistic message exists) and any unexpected paths
-                // without ever silently injecting the first-turn prompt.
-                const userMessageContent =
-                  (lastMessage?.role === 'user' &&
-                    typeof lastMessage.content === 'string' &&
-                    lastMessage.content) ||
-                  (messageContent as string) ||
-                  question ||
-                  '';
+                //   2. question -- the SSE CONFIRMED event's question field.
+                //      This is the current improve/follow-up prompt.
+                //   3. messageContent -- the closure-captured arg passed to
+                //      the original startTask call. It is accurate for the
+                //      first run but stale for improve turns because the SSE
+                //      consumer remains alive across the whole Project.
+                //
+                // So the fallback order depends on the lifecycle:
+                // - first startTask confirmed: messageContent before question
+                // - follow-up confirmed: question before stale messageContent
+                const userMessageContent = resolveConfirmedUserMessageContent({
+                  lastMessageContent:
+                    lastMessage?.role === 'user'
+                      ? lastMessage.content
+                      : undefined,
+                  messageContent,
+                  question,
+                  isFollowUpConfirm,
+                });
                 newChatStore.getState().addMessages(newTaskId, {
                   id: generateUniqueId(),
                   role: 'user',

--- a/test/unit/store/chatStore.test.ts
+++ b/test/unit/store/chatStore.test.ts
@@ -127,6 +127,7 @@ import { generateUniqueId } from '../../../src/lib';
 import {
   collectTaskUploadFiles,
   getCloudModelPlatform,
+  resolveConfirmedUserMessageContent,
   useChatStore,
 } from '../../../src/store/chatStore';
 import { useProjectStore } from '../../../src/store/projectStore';
@@ -146,6 +147,39 @@ import { ChatTaskStatus } from '../../../src/types/constants';
 describe('ChatStore - Core Functionality', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('Confirmed user prompt resolution', () => {
+    it('uses the optimistic user message when it exists', () => {
+      expect(
+        resolveConfirmedUserMessageContent({
+          lastMessageContent: 'current typed prompt',
+          messageContent: 'first prompt',
+          question: 'backend current prompt',
+          isFollowUpConfirm: true,
+        })
+      ).toBe('current typed prompt');
+    });
+
+    it('uses the SSE question for follow-up confirms before stale startTask content', () => {
+      expect(
+        resolveConfirmedUserMessageContent({
+          messageContent: 'first prompt',
+          question: 'follow-up prompt',
+          isFollowUpConfirm: true,
+        })
+      ).toBe('follow-up prompt');
+    });
+
+    it('keeps first-run confirms on the captured startTask content before question', () => {
+      expect(
+        resolveConfirmedUserMessageContent({
+          messageContent: 'first prompt',
+          question: 'backend confirmed prompt',
+          isFollowUpConfirm: false,
+        })
+      ).toBe('first prompt');
+    });
   });
 
   describe('Task Upload Files', () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

Closes #

### Description

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

### Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->
<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->
<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- [x] I have included human-verified testing evidence in this PR.
- [x] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
