### PR TITLE
feat: add TokenMix as a built-in OpenAI-compatible provider

### DIFF
--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -74,6 +74,17 @@ export const INIT_PROVODERS: Provider[] = [
     model_type: '',
   },
   {
+    id: 'tokenmix',
+    name: 'TokenMix',
+    apiKey: '',
+    apiHost: 'https://api.tokenmix.ai/v1',
+    description: 'TokenMix — 171 AI models from 14 providers via a single OpenAI-compatible API.',
+    is_valid: false,
+    model_type: '',
+    modelsEndpoint: '/models',
+    websiteUrl: 'https://tokenmix.ai',
+  },
+  {
     id: 'tongyi-qianwen',
     name: 'Qwen',
     apiKey: '',


### PR DESCRIPTION
## Summary

This PR adds **TokenMix** to the built-in provider list in src/lib/llm.ts.

TokenMix is an OpenAI-compatible API aggregator that gives users access to **171 AI models from 14 providers** (Claude, GPT, Gemini, DeepSeek, Qwen, Mistral, and more) through a single endpoint — functionally similar to OpenRouter, which is already listed.

### Change

One new entry added to INIT_PROVODERS in src/lib/llm.ts, placed after OpenRouter:

`	ypescript
{
  id: 'tokenmix',
  name: 'TokenMix',
  apiKey: '',
  apiHost: 'https://api.tokenmix.ai/v1',
  description: 'TokenMix — 171 AI models from 14 providers via a single OpenAI-compatible API.',
  is_valid: false,
  model_type: '',
  modelsEndpoint: '/models',
  websiteUrl: 'https://tokenmix.ai',
},
`

### Why TokenMix?

| | TokenMix | OpenRouter |
|--|---------|-----------|
| Models | 171 | 300+ |
| Protocol | OpenAI-compatible | OpenAI-compatible |
| Pricing | Pay-as-you-go | Pay-as-you-go |
| Endpoint | pi.tokenmix.ai/v1 | openrouter.ai/api/v1 |

Single-file change, no type system modifications required.