### PR TITLE
[codex] Complete BYOK supported providers

### DIFF
--- a/docs/core/models/byok.md
+++ b/docs/core/models/byok.md
@@ -68,20 +68,27 @@ When saving your configuration, Eigent validates your API key and model. Here ar
 
 Eigent supports the following BYOK providers:
 
-| Provider              | Default API Host                                           | Official Documentation                                                                        |
-| --------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **OpenAI**            | `https://api.openai.com/v1`                                | [OpenAI API Docs](https://platform.openai.com/docs/api-reference)                             |
-| **Anthropic**         | `https://api.anthropic.com/`                               | [Anthropic API Docs](https://docs.anthropic.com/en/api/getting-started)                       |
-| **Google Gemini**     | `https://generativelanguage.googleapis.com/v1beta/openai/` | [Gemini API Docs](https://ai.google.dev/gemini-api/docs)                                      |
-| **OpenRouter**        | `https://openrouter.ai/api/v1`                             | [OpenRouter Docs](https://openrouter.ai/docs)                                                 |
-| **OrcaRouter**        | `https://api.orcarouter.ai/v1`                             | [OrcaRouter Docs](https://docs.orcarouter.ai/)                                                |
-| **Qwen (Alibaba)**    | `https://dashscope.aliyuncs.com/compatible-mode/v1`        | [Qwen API Docs](https://help.aliyun.com/zh/dashscope/developer-reference/api-details)         |
-| **DeepSeek**          | `https://api.deepseek.com`                                 | [DeepSeek API Docs](https://platform.deepseek.com/api-docs)                                   |
-| **Minimax**           | `https://api.minimax.io/v1`                                | [Minimax API Docs](https://platform.minimaxi.com/document/Announcement)                       |
-| **Z.ai**              | `https://api.z.ai/api/coding/paas/v4/`                     | [Z.ai Platform](https://z.ai)                                                                 |
-| **Azure OpenAI**      | _(user-provided)_                                          | [Azure OpenAI Docs](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference)     |
-| **AWS Bedrock**       | _(user-provided)_                                          | [AWS Bedrock Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) |
-| **OpenAI Compatible** | _(user-provided)_                                          | For custom endpoints (e.g., xAI, local servers)                                               |
+| Provider                  | Default API Host                                           | Official Documentation                                                                        |
+| ------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Google Gemini**         | `https://generativelanguage.googleapis.com/v1beta/openai/` | [Gemini API Docs](https://ai.google.dev/gemini-api/docs)                                      |
+| **OpenAI**                | `https://api.openai.com/v1`                                | [OpenAI API Docs](https://platform.openai.com/docs/api-reference)                             |
+| **Anthropic**             | `https://api.anthropic.com`                                | [Anthropic API Docs](https://docs.anthropic.com/en/api/getting-started)                       |
+| **OrcaRouter**            | `https://api.orcarouter.ai/v1`                             | [OrcaRouter Docs](https://docs.orcarouter.ai/)                                                |
+| **OpenRouter**            | `https://openrouter.ai/api/v1`                             | [OpenRouter Docs](https://openrouter.ai/docs)                                                 |
+| **Qwen (Alibaba)**        | `https://dashscope.aliyuncs.com/compatible-mode/v1`        | [Qwen API Docs](https://help.aliyun.com/zh/dashscope/developer-reference/api-details)         |
+| **DeepSeek**              | `https://api.deepseek.com`                                 | [DeepSeek API Docs](https://platform.deepseek.com/api-docs)                                   |
+| **MiniMax**               | `https://api.minimax.io/v1`                                | [MiniMax API Docs](https://platform.minimax.io/docs/api-reference/api-overview)               |
+| **Z.ai**                  | `https://api.z.ai/api/coding/paas/v4/`                     | [Z.ai Developer Docs](https://zhipu-32152247.mintlify.app/api-reference/introduction)         |
+| **Moonshot**              | `https://api.moonshot.ai/v1`                               | [Moonshot AI Platform](https://platform.moonshot.ai/)                                         |
+| **ModelArk**              | `https://ark.ap-southeast.bytepluses.com/api/v3`           | [ModelArk Docs](https://docs.byteplus.com/en/docs/ModelArk/1298459)                           |
+| **SambaNova**             | `https://api.sambanova.ai/v1`                              | [SambaNova API Reference](https://docs.sambanova.ai/docs/en/api-reference/overview)           |
+| **Grok**                  | `https://api.x.ai/v1`                                      | [xAI Docs](https://docs.x.ai/docs/introduction)                                               |
+| **Mistral**               | `https://api.mistral.ai`                                   | [Mistral API Docs](https://docs.mistral.ai/api)                                               |
+| **AWS Bedrock**           | `https://bedrock-mantle.us-east-1.api.aws/v1`              | [AWS Bedrock Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) |
+| **AWS Bedrock Converse**  | `https://bedrock-runtime.us-east-1.amazonaws.com`          | [Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html) |
+| **Azure OpenAI**          | _(user-provided)_                                          | [Azure OpenAI Docs](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference)     |
+| **Baidu ERNIE**           | `https://qianfan.baidubce.com/v2`                          | [Baidu Qianfan Docs](https://intl.cloud.baidu.com/doc/qianfan/index.html)                     |
+| **OpenAI Compatible**     | _(user-provided)_                                          | For custom endpoints (e.g., xAI, local servers)                                               |
 
 ## Tips
 


### PR DESCRIPTION
## Summary

- Complete the BYOK Supported Providers table so it matches the current cloud provider initialization list.
- Add missing provider rows for Moonshot, ModelArk, SambaNova, Grok, Mistral, AWS Bedrock Converse, and Baidu ERNIE.
- Align existing provider names and default API hosts with the current application configuration.

## Validation

- Checked `src/lib/llm.ts` `INIT_PROVODERS` against the BYOK documentation.
- Verified the local Mintlify page responds successfully: `http://localhost:3000/core/models/byok` returned HTTP 200.
- Ran `git diff --cached --check` before committing.