### PR TITLE
docs: Update docs provider and toolkit references

### DIFF
--- a/docs/core/models/byok.md
+++ b/docs/core/models/byok.md
@@ -68,20 +68,27 @@ When saving your configuration, Eigent validates your API key and model. Here ar
 
 Eigent supports the following BYOK providers:
 
-| Provider              | Default API Host                                           | Official Documentation                                                                        |
-| --------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **OpenAI**            | `https://api.openai.com/v1`                                | [OpenAI API Docs](https://platform.openai.com/docs/api-reference)                             |
-| **Anthropic**         | `https://api.anthropic.com/`                               | [Anthropic API Docs](https://docs.anthropic.com/en/api/getting-started)                       |
-| **Google Gemini**     | `https://generativelanguage.googleapis.com/v1beta/openai/` | [Gemini API Docs](https://ai.google.dev/gemini-api/docs)                                      |
-| **OpenRouter**        | `https://openrouter.ai/api/v1`                             | [OpenRouter Docs](https://openrouter.ai/docs)                                                 |
-| **OrcaRouter**        | `https://api.orcarouter.ai/v1`                             | [OrcaRouter Docs](https://docs.orcarouter.ai/)                                                |
-| **Qwen (Alibaba)**    | `https://dashscope.aliyuncs.com/compatible-mode/v1`        | [Qwen API Docs](https://help.aliyun.com/zh/dashscope/developer-reference/api-details)         |
-| **DeepSeek**          | `https://api.deepseek.com`                                 | [DeepSeek API Docs](https://platform.deepseek.com/api-docs)                                   |
-| **Minimax**           | `https://api.minimax.io/v1`                                | [Minimax API Docs](https://platform.minimaxi.com/document/Announcement)                       |
-| **Z.ai**              | `https://api.z.ai/api/coding/paas/v4/`                     | [Z.ai Platform](https://z.ai)                                                                 |
-| **Azure OpenAI**      | _(user-provided)_                                          | [Azure OpenAI Docs](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference)     |
-| **AWS Bedrock**       | _(user-provided)_                                          | [AWS Bedrock Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) |
-| **OpenAI Compatible** | _(user-provided)_                                          | For custom endpoints (e.g., xAI, local servers)                                               |
+| Provider                  | Default API Host                                           | Official Documentation                                                                        |
+| ------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Google Gemini**         | `https://generativelanguage.googleapis.com/v1beta/openai/` | [Gemini API Docs](https://ai.google.dev/gemini-api/docs)                                      |
+| **OpenAI**                | `https://api.openai.com/v1`                                | [OpenAI API Docs](https://platform.openai.com/docs/api-reference)                             |
+| **Anthropic**             | `https://api.anthropic.com`                                | [Anthropic API Docs](https://docs.anthropic.com/en/api/getting-started)                       |
+| **OrcaRouter**            | `https://api.orcarouter.ai/v1`                             | [OrcaRouter Docs](https://docs.orcarouter.ai/)                                                |
+| **OpenRouter**            | `https://openrouter.ai/api/v1`                             | [OpenRouter Docs](https://openrouter.ai/docs)                                                 |
+| **Qwen (Alibaba)**        | `https://dashscope.aliyuncs.com/compatible-mode/v1`        | [Qwen API Docs](https://help.aliyun.com/zh/dashscope/developer-reference/api-details)         |
+| **DeepSeek**              | `https://api.deepseek.com`                                 | [DeepSeek API Docs](https://platform.deepseek.com/api-docs)                                   |
+| **MiniMax**               | `https://api.minimax.io/v1`                                | [MiniMax API Docs](https://platform.minimax.io/docs/api-reference/api-overview)               |
+| **Z.ai**                  | `https://api.z.ai/api/coding/paas/v4/`                     | [Z.ai Developer Docs](https://zhipu-32152247.mintlify.app/api-reference/introduction)         |
+| **Moonshot**              | `https://api.moonshot.ai/v1`                               | [Moonshot AI Platform](https://platform.moonshot.ai/)                                         |
+| **ModelArk**              | `https://ark.ap-southeast.bytepluses.com/api/v3`           | [ModelArk Docs](https://docs.byteplus.com/en/docs/ModelArk/1298459)                           |
+| **SambaNova**             | `https://api.sambanova.ai/v1`                              | [SambaNova API Reference](https://docs.sambanova.ai/docs/en/api-reference/overview)           |
+| **Grok**                  | `https://api.x.ai/v1`                                      | [xAI Docs](https://docs.x.ai/docs/introduction)                                               |
+| **Mistral**               | `https://api.mistral.ai`                                   | [Mistral API Docs](https://docs.mistral.ai/api)                                               |
+| **AWS Bedrock**           | `https://bedrock-mantle.us-east-1.api.aws/v1`              | [AWS Bedrock Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) |
+| **AWS Bedrock Converse**  | `https://bedrock-runtime.us-east-1.amazonaws.com`          | [Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html) |
+| **Azure OpenAI**          | _(user-provided)_                                          | [Azure OpenAI Docs](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference)     |
+| **Baidu ERNIE**           | `https://qianfan.baidubce.com/v2`                          | [Baidu Qianfan Docs](https://intl.cloud.baidu.com/doc/qianfan/index.html)                     |
+| **OpenAI Compatible**     | _(user-provided)_                                          | For custom endpoints (e.g., xAI, local servers)                                               |
 
 ## Tips
 

--- a/docs/core/workforce.md
+++ b/docs/core/workforce.md
@@ -78,6 +78,7 @@ _A skilled coding assistant that can write and execute code, run terminal comman
 - TerminalToolkit
 - NoteTakingToolkit
 - WebDeployToolkit
+- SkillToolkit
 
 ### BrowserAgent
 
@@ -90,6 +91,7 @@ _Can search the web, extract webpage content, simulate browser actions, and prov
 - HumanToolkit
 - NoteTakingToolkit
 - TerminalToolkit
+- SkillToolkit
 
 ### DocumentAgent
 
@@ -106,6 +108,7 @@ _A document processing assistant for creating, modifying, and managing various d
 - TerminalToolkit
 - GoogleDriveMCPToolkit
 - SearchToolkit
+- SkillToolkit
 
 ### Multi-ModalAgent
 
@@ -115,12 +118,12 @@ _A multi-modal processing assistant for analyzing and generating media content l
 
 - VideoDownloaderToolkit
 - AudioAnalysisToolkit
-- ImageAnalysisToolkit
 - OpenAIImageToolkit
 - HumanToolkit
 - TerminalToolkit
 - NoteTakingToolkit
 - SearchToolkit
+- SkillToolkit
 
 ## Toolkit Reference
 
@@ -164,12 +167,6 @@ _Provides a powerful, stateful browser for web navigation and interaction._
 
 This toolkit gives an agent a fully-featured web browser that it can control programmatically. Unlike simple web scraping, this toolkit maintains a session, allowing the agent to click, type, hover, screenshot, and live _Take Control_ from the UI.
 
-### [ImageAnalysisToolkit](https://docs.camel-ai.org/reference/camel.toolkits.image_analysis_toolkit)
-
-_Provides tools for understanding the content of images._
-
-This toolkit enables an agent to "see" and interpret images. It can generate a detailed text description of an image or answer specific questions about what an image contains. This is crucial for tasks that involve visual data, such as describing products, analyzing charts, or identifying objects in a photo.
-
 ### [MarkItDownToolkit](https://docs.camel-ai.org/reference/camel.toolkits.markitdown_toolkit)
 
 _A specialized toolkit for converting content into clean Markdown._
@@ -200,6 +197,12 @@ _Provides access to various web search engines._
 
 This toolkit is the primary tool for web research. It allows an agent to search information on engines like Google, Wikipedia, Bing, and Baidu. The agent can submit a query and receive a list of relevant URLs and snippets, which it can then use as a starting point for deeper investigation with the `HybridBrowserToolkit`.
 
+### SkillToolkit
+
+_Loads custom Skills assigned to the current agent._
+
+This toolkit gives agents access to enabled Skills from the user's or project's Skill configuration. Skills can add reusable instructions, domain knowledge, or procedures, and can be scoped globally or to selected agents.
+
 ### [TerminalToolkit](https://docs.camel-ai.org/reference/camel.toolkits.terminal_toolkit)
 
 _A toolkit for terminal operations across multiple operating systems._
@@ -210,7 +213,7 @@ This toolkit gives an agent access to a command-line interface. It supports term
 
 _Allows an agent to download and process videos from popular platforms._
 
-This toolkit enables an agent to download video content from URLs (e.g., from YouTube) and optionally split them into chunks. The saved video can then be analyzed by other toolkits, such as the `AudioAnalysisToolkit` for transcription, or `ImageAnalysisToolkit` for object detection.
+This toolkit enables an agent to download video content from URLs (e.g., from YouTube) and optionally split them into chunks. The saved video can then be analyzed by other tools, such as the `AudioAnalysisToolkit` for transcription.
 
 ### [WebDeployToolkit](https://docs.camel-ai.org/reference/camel.toolkits.web_deploy_toolkit)
 

--- a/docs/core/workforce.md
+++ b/docs/core/workforce.md
@@ -197,7 +197,7 @@ _Provides access to various web search engines._
 
 This toolkit is the primary tool for web research. It allows an agent to search information on engines like Google, Wikipedia, Bing, and Baidu. The agent can submit a query and receive a list of relevant URLs and snippets, which it can then use as a starting point for deeper investigation with the `HybridBrowserToolkit`.
 
-### SkillToolkit
+### [SkillToolkit](https://docs.camel-ai.org/reference/camel.toolkits.skill_toolkit)
 
 _Loads custom Skills assigned to the current agent._
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,7 +2,6 @@
   "$schema": "https://mintlify.com/docs.json",
   "name": "Eigent Documentation",
   "theme": "aspen",
-  "defaultPage": "/get_started/welcome",
   "logo": {
     "light": "images/logo-light.png",
     "dark": "images/logo-dark.png",
@@ -49,67 +48,67 @@
             "group": "Get Started",
             "icon": "rocket",
             "pages": [
-              "/get_started/welcome",
-              "/get_started/installation",
-              "/get_started/quick_start",
-              "/get_started/self-hosting",
-              "/core/concepts"
+              "get_started/welcome",
+              "get_started/installation",
+              "get_started/quick_start",
+              "get_started/self-hosting",
+              "core/concepts"
             ]
           },
           {
             "group": "Dashboard",
             "icon": "grid-2",
             "pages": [
-              "/dashboard/overview",
-              "/dashboard/spaces",
-              "/dashboard/projects",
-              "/dashboard/tasks",
-              "/dashboard/views-and-search"
+              "dashboard/overview",
+              "dashboard/spaces",
+              "dashboard/projects",
+              "dashboard/tasks",
+              "dashboard/views-and-search"
             ]
           },
           {
             "group": "Projects",
             "icon": "folder-kanban",
             "pages": [
-              "/projects/overview",
-              "/projects/create-project",
-              "/projects/workspace",
-              "/projects/context-and-files",
-              "/projects/sessions",
-              "/core/project-runs",
-              "/projects/single-agent",
-              "/core/workforce"
+              "projects/overview",
+              "projects/create-project",
+              "projects/workspace",
+              "projects/context-and-files",
+              "projects/sessions",
+              "core/project-runs",
+              "projects/single-agent",
+              "core/workforce"
             ]
           },
           {
             "group": "Agents",
             "icon": "bot",
             "pages": [
-              "/agents/overview",
-              "/core/workers",
-              "/core/agent-skills",
-              "/agents/remote-sub-agents",
-              "/agents/memory"
+              "agents/overview",
+              "core/workers",
+              "core/agent-skills",
+              "agents/remote-sub-agents",
+              "agents/memory"
             ]
           },
           {
             "group": "Models",
             "icon": "brain",
             "pages": [
-              "/models/overview",
-              "/models/eigent-cloud",
-              "/core/models/byok",
-              "/core/models/local-model",
-              "/models/provider-reference",
+              "models/overview",
+              "models/eigent-cloud",
+              "core/models/byok",
+              "core/models/local-model",
+              "models/provider-reference",
               {
                 "group": "Provider Guides",
                 "expanded": false,
                 "pages": [
-                  "/core/models/gemini",
-                  "/core/models/ernie",
-                  "/core/models/minimax",
-                  "/core/models/kimi",
-                  "/core/models/sambanova"
+                  "core/models/gemini",
+                  "core/models/ernie",
+                  "core/models/minimax",
+                  "core/models/kimi",
+                  "core/models/sambanova"
                 ]
               }
             ]
@@ -118,50 +117,50 @@
             "group": "Connectors",
             "icon": "plug",
             "pages": [
-              "/connectors/overview",
-              "/connectors/mcp-marketplace",
-              "/connectors/custom-mcp",
-              "/connectors/google-search",
-              "/core/tools"
+              "connectors/overview",
+              "connectors/mcp-marketplace",
+              "connectors/custom-mcp",
+              "connectors/google-search",
+              "core/tools"
             ]
           },
           {
             "group": "Browser",
             "icon": "compass",
             "pages": [
-              "/browser/overview",
-              "/browser/connections",
-              "/browser/cookies"
+              "browser/overview",
+              "browser/connections",
+              "browser/cookies"
             ]
           },
           {
             "group": "Automation",
             "icon": "bolt",
             "pages": [
-              "/automation/overview",
-              "/automation/scheduled-triggers",
-              "/automation/webhook-triggers",
-              "/automation/dispatch"
+              "automation/overview",
+              "automation/scheduled-triggers",
+              "automation/webhook-triggers",
+              "automation/dispatch"
             ]
           },
           {
             "group": "Settings",
             "icon": "gear",
             "pages": [
-              "/settings/general",
-              "/settings/appearance",
-              "/settings/privacy"
+              "settings/general",
+              "settings/appearance",
+              "settings/privacy"
             ]
           },
           {
             "group": "Open Source",
             "icon": "code-branch",
-            "pages": ["/open-source/overview", "/core/brain-architecture"]
+            "pages": ["open-source/overview", "core/brain-architecture"]
           },
           {
             "group": "Troubleshooting",
             "icon": "question-circle",
-            "pages": ["/troubleshooting/support", "/troubleshooting/bug"]
+            "pages": ["troubleshooting/support", "troubleshooting/bug"]
           }
         ]
       }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,6 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "name": "Eigent Documentation",
   "theme": "aspen",
+  "defaultPage": "/get_started/welcome",
   "logo": {
     "light": "images/logo-light.png",
     "dark": "images/logo-dark.png",
@@ -48,67 +49,67 @@
             "group": "Get Started",
             "icon": "rocket",
             "pages": [
-              "get_started/welcome",
-              "get_started/installation",
-              "get_started/quick_start",
-              "get_started/self-hosting",
-              "core/concepts"
+              "/get_started/welcome",
+              "/get_started/installation",
+              "/get_started/quick_start",
+              "/get_started/self-hosting",
+              "/core/concepts"
             ]
           },
           {
             "group": "Dashboard",
             "icon": "grid-2",
             "pages": [
-              "dashboard/overview",
-              "dashboard/spaces",
-              "dashboard/projects",
-              "dashboard/tasks",
-              "dashboard/views-and-search"
+              "/dashboard/overview",
+              "/dashboard/spaces",
+              "/dashboard/projects",
+              "/dashboard/tasks",
+              "/dashboard/views-and-search"
             ]
           },
           {
             "group": "Projects",
             "icon": "folder-kanban",
             "pages": [
-              "projects/overview",
-              "projects/create-project",
-              "projects/workspace",
-              "projects/context-and-files",
-              "projects/sessions",
-              "core/project-runs",
-              "projects/single-agent",
-              "core/workforce"
+              "/projects/overview",
+              "/projects/create-project",
+              "/projects/workspace",
+              "/projects/context-and-files",
+              "/projects/sessions",
+              "/core/project-runs",
+              "/projects/single-agent",
+              "/core/workforce"
             ]
           },
           {
             "group": "Agents",
             "icon": "bot",
             "pages": [
-              "agents/overview",
-              "core/workers",
-              "core/agent-skills",
-              "agents/remote-sub-agents",
-              "agents/memory"
+              "/agents/overview",
+              "/core/workers",
+              "/core/agent-skills",
+              "/agents/remote-sub-agents",
+              "/agents/memory"
             ]
           },
           {
             "group": "Models",
             "icon": "brain",
             "pages": [
-              "models/overview",
-              "models/eigent-cloud",
-              "core/models/byok",
-              "core/models/local-model",
-              "models/provider-reference",
+              "/models/overview",
+              "/models/eigent-cloud",
+              "/core/models/byok",
+              "/core/models/local-model",
+              "/models/provider-reference",
               {
                 "group": "Provider Guides",
                 "expanded": false,
                 "pages": [
-                  "core/models/gemini",
-                  "core/models/ernie",
-                  "core/models/minimax",
-                  "core/models/kimi",
-                  "core/models/sambanova"
+                  "/core/models/gemini",
+                  "/core/models/ernie",
+                  "/core/models/minimax",
+                  "/core/models/kimi",
+                  "/core/models/sambanova"
                 ]
               }
             ]
@@ -117,50 +118,50 @@
             "group": "Connectors",
             "icon": "plug",
             "pages": [
-              "connectors/overview",
-              "connectors/mcp-marketplace",
-              "connectors/custom-mcp",
-              "connectors/google-search",
-              "core/tools"
+              "/connectors/overview",
+              "/connectors/mcp-marketplace",
+              "/connectors/custom-mcp",
+              "/connectors/google-search",
+              "/core/tools"
             ]
           },
           {
             "group": "Browser",
             "icon": "compass",
             "pages": [
-              "browser/overview",
-              "browser/connections",
-              "browser/cookies"
+              "/browser/overview",
+              "/browser/connections",
+              "/browser/cookies"
             ]
           },
           {
             "group": "Automation",
             "icon": "bolt",
             "pages": [
-              "automation/overview",
-              "automation/scheduled-triggers",
-              "automation/webhook-triggers",
-              "automation/dispatch"
+              "/automation/overview",
+              "/automation/scheduled-triggers",
+              "/automation/webhook-triggers",
+              "/automation/dispatch"
             ]
           },
           {
             "group": "Settings",
             "icon": "gear",
             "pages": [
-              "settings/general",
-              "settings/appearance",
-              "settings/privacy"
+              "/settings/general",
+              "/settings/appearance",
+              "/settings/privacy"
             ]
           },
           {
             "group": "Open Source",
             "icon": "code-branch",
-            "pages": ["open-source/overview", "core/brain-architecture"]
+            "pages": ["/open-source/overview", "/core/brain-architecture"]
           },
           {
             "group": "Troubleshooting",
             "icon": "question-circle",
-            "pages": ["troubleshooting/support", "troubleshooting/bug"]
+            "pages": ["/troubleshooting/support", "/troubleshooting/bug"]
           }
         ]
       }

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -10,12 +10,11 @@ icon: wrench
     - Download for macOS
     - Download for Windows
 
-```
 <Warning>
   **macOS Prerequisite**
+
   Please ensure you are running macOS 11 (Big Sur) or a newer version to install Eigent.
 </Warning>
-```
 
 </Step>
   <Step title="Install the Application">


### PR DESCRIPTION
## Summary

- Complete the BYOK Supported Providers table so it matches the current cloud provider list.
- Align the Workforce toolkit documentation by removing stale ImageAnalysisToolkit references and adding SkillToolkit with the CAMEL reference link.
- Fix the Installation page Warning block so Mintlify renders it as an admonition instead of a code block.

## Validation

- Checked `src/lib/llm.ts` against the BYOK provider table.
- Checked the current Multi-ModalAgent factory and toolkit files against the Workforce docs.
- Verified the PR net diff only includes `docs/core/models/byok.md`, `docs/core/workforce.md`, and `docs/get_started/installation.md`.
- Ran `git diff --cached --check` before committing.