### PR TITLE
fix: add DeepSeek, Z.ai, MiniMax, Moonshot, SambaNova to PLATFORM_ALIAS_MAPPING (fixes #1578, #1556)

### DIFF
--- a/backend/app/model/model_platform.py
+++ b/backend/app/model/model_platform.py
@@ -17,7 +17,11 @@ from typing import Annotated, Final
 from pydantic import BeforeValidator
 
 PLATFORM_ALIAS_MAPPING: Final[dict[str, str]] = {
-    "z.ai": "zhipuai",
+    "z.ai": "openai-compatible-model",
+    "deepseek": "openai-compatible-model",
+    "minimax": "openai-compatible-model",
+    "moonshot": "openai-compatible-model",
+    "samba-nova": "openai-compatible-model",
     "ModelArk": "openai-compatible-model",
     "grok": "openai-compatible-model",
     "ernie": "qianfan",

--- a/backend/tests/app/model/test_model_platform.py
+++ b/backend/tests/app/model/test_model_platform.py
@@ -24,11 +24,16 @@ from app.model.model_platform import (
 
 def test_normalize_model_platform_maps_known_aliases():
     assert normalize_model_platform("grok") == "openai-compatible-model"
-    assert normalize_model_platform("z.ai") == "zhipuai"
+    assert normalize_model_platform("z.ai") == "openai-compatible-model"
+    assert normalize_model_platform("deepseek") == "openai-compatible-model"
+    assert normalize_model_platform("minimax") == "openai-compatible-model"
+    assert normalize_model_platform("moonshot") == "openai-compatible-model"
+    assert normalize_model_platform("samba-nova") == "openai-compatible-model"
     assert normalize_model_platform("ModelArk") == "openai-compatible-model"
     assert normalize_model_platform("ernie") == "qianfan"
     assert normalize_model_platform("llama.cpp") == "openai-compatible-model"
     assert normalize_model_platform("nebius") == "openai-compatible-model"
+    assert normalize_model_platform("orcarouter") == "openai-compatible-model"
 
 
 def test_normalize_model_platform_keeps_non_alias_unchanged():


### PR DESCRIPTION
## Problem

Users configuring DeepSeek, Z.ai, MiniMax, Moonshot, or SambaNova as custom API keys through the BYOK UI would encounter validation failures. The backend's `PLATFORM_ALIAS_MAPPING` was missing these providers.

Related issues: #1578 (DeepSeek), #1556 (Z.ai)

## Root Cause

The frontend (`src/lib/llm.ts`) lists these providers as BYOK options, but the backend alias mapping didn't include entries for them, so they were passed directly to CAMEL which couldn't recognize them.

Additionally, `z.ai` was incorrectly mapped to `"zhipu"` instead of `"openai-compatible-model"`.

## Fix

Updated `backend/app/model/model_platform.py`:

- `deepseek` → `openai-compatible-model` (new)
- `z.ai` → `openai-compatible-model` (was incorrectly `zhipu`)
- `minimax` → `openai-compatible-model` (new)
- `moonshot` → `openai-compatible-model` (new)
- `samba-nova` → `openai-compatible-model` (new)

All these providers expose OpenAI-compatible API endpoints.

Also updated the test file to cover the new mappings.

## Files Changed

- `backend/app/model/model_platform.py` - Added missing provider aliases
- `backend/tests/app/model/test_model_platform.py` - Updated tests
