### PR TITLE
fix: use per-task question when loading from history (#1366)

### DIFF
--- a/src/components/HistorySidebar/index.tsx
+++ b/src/components/HistorySidebar/index.tsx
@@ -146,6 +146,9 @@ export default function HistorySidebar() {
     const taskIdsList = project?.tasks.map(
       (task: HistoryTask) => task.task_id
     ) || [projectId];
+    const taskQuestionsList = project?.tasks.map(
+      (task: HistoryTask) => task.question
+    );
 
     // If no tasks to replay, create an empty project
     if (!taskIdsList || taskIdsList.length === 0) {
@@ -165,7 +168,8 @@ export default function HistorySidebar() {
       question,
       historyId,
       taskIdsList,
-      project?.project_name
+      project?.project_name,
+      taskQuestionsList
     );
   };
 

--- a/src/lib/replay.ts
+++ b/src/lib/replay.ts
@@ -36,7 +36,8 @@ export const loadProjectFromHistory = async (
   question: string,
   historyId: string,
   taskIdsList?: string[],
-  projectName?: string
+  projectName?: string,
+  taskQuestions?: string[]
 ) => {
   const taskIds = taskIdsList || [projectId];
   await projectStore.loadProjectFromHistory(
@@ -44,7 +45,8 @@ export const loadProjectFromHistory = async (
     question,
     projectId,
     historyId,
-    projectName
+    projectName,
+    taskQuestions
   );
   navigate({ pathname: '/' });
 };

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -96,7 +96,8 @@ interface ProjectStore {
     question: string,
     projectId: string,
     historyId?: string,
-    projectName?: string
+    projectName?: string,
+    taskQuestions?: string[]
   ) => Promise<string>;
 
   // Project-level queued messages management
@@ -635,7 +636,8 @@ const projectStore = create<ProjectStore>()((set, get) => ({
     question: string,
     projectId: string,
     historyId?: string,
-    projectName?: string
+    projectName?: string,
+    taskQuestions?: string[]
   ) => {
     const { projects, removeProject, createProject, createChatStore } = get();
 
@@ -679,7 +681,8 @@ const projectStore = create<ProjectStore>()((set, get) => ({
         const chatStore = project.chatStores[chatId];
         if (chatStore) {
           try {
-            await chatStore.getState().replay(taskId, question, 0);
+            const taskQuestion = taskQuestions?.[index] || question;
+            await chatStore.getState().replay(taskId, taskQuestion, 0);
             console.log(`[ProjectStore] Loaded task ${taskId}`);
           } catch (error) {
             console.error(


### PR DESCRIPTION
## Summary

When loading a project from history, every task was replayed with the same question
(`project.last_prompt`), regardless of what question each individual task had been
created with. This caused tasks to show incorrect questions when replayed.

## Changes

- `src/store/projectStore.ts`: Added `taskQuestions?` parameter to `loadProjectFromHistory`;
  each task now uses `taskQuestions[index] || question` instead of always using `question`
- `src/lib/replay.ts`: Pass `taskQuestions?` through to `projectStore.loadProjectFromHistory`
- `src/components/HistorySidebar/index.tsx`: Extract `taskQuestionsList` from `project.tasks`
  (each task has its own `question` field) and pass it to `loadProjectFromHistory`

## Why

Each `HistoryTask` already stores its own `question` field. This fix ensures that field
is actually used during history replay, falling back to the project-level question only
when a task's question is missing.

Closes #1366