### PR TITLE
fix: align cloud model lists across UI

### DIFF
--- a/src/components/AddWorker/index.tsx
+++ b/src/components/AddWorker/index.tsx
@@ -79,6 +79,12 @@ interface WorkerModelOption {
 
 const EIGENT_MODEL_OPTIONS: ReadonlyArray<WorkerModelOption> = [
   {
+    value: 'gemini-3.5-flash',
+    label: 'Gemini 3.5 Flash',
+    model_platform: 'gemini',
+    model_type: 'gemini-3.5-flash',
+  },
+  {
     value: 'gemini-3.1-pro-preview',
     label: 'Gemini 3.1 Pro Preview',
     model_platform: 'gemini',
@@ -97,46 +103,16 @@ const EIGENT_MODEL_OPTIONS: ReadonlyArray<WorkerModelOption> = [
     model_type: 'gemini-3-flash-preview',
   },
   {
-    value: 'gpt-4.1-mini',
-    label: 'GPT-4.1 Mini',
-    model_platform: 'openai',
-    model_type: 'gpt-4.1-mini',
-  },
-  {
-    value: 'gpt-4.1',
-    label: 'GPT-4.1',
-    model_platform: 'openai',
-    model_type: 'gpt-4.1',
-  },
-  {
-    value: 'gpt-5',
-    label: 'GPT-5',
-    model_platform: 'openai',
-    model_type: 'gpt-5',
-  },
-  {
-    value: 'gpt-5.1',
-    label: 'GPT-5.1',
-    model_platform: 'openai',
-    model_type: 'gpt-5.1',
-  },
-  {
-    value: 'gpt-5.2',
-    label: 'GPT-5.2',
-    model_platform: 'openai',
-    model_type: 'gpt-5.2',
-  },
-  {
     value: 'gpt-5.4',
     label: 'GPT-5.4',
-    model_platform: 'openai',
+    model_platform: 'azure',
     model_type: 'gpt-5.4',
   },
   {
-    value: 'gpt-5-mini',
-    label: 'GPT-5 Mini',
-    model_platform: 'openai',
-    model_type: 'gpt-5-mini',
+    value: 'gpt-5.5',
+    label: 'GPT-5.5',
+    model_platform: 'azure',
+    model_type: 'gpt-5.5',
   },
   {
     value: 'claude-haiku-4-5',
@@ -163,10 +139,22 @@ const EIGENT_MODEL_OPTIONS: ReadonlyArray<WorkerModelOption> = [
     model_type: 'claude-opus-4-6',
   },
   {
-    value: 'minimax_m2_5',
-    label: 'Minimax M2.5',
-    model_platform: 'openai-compatible-model',
-    model_type: 'minimax_m2_5',
+    value: 'claude-opus-4-7',
+    label: 'Claude Opus 4.7',
+    model_platform: 'aws-bedrock-converse',
+    model_type: 'claude-opus-4-7',
+  },
+  {
+    value: 'deepseek-v4-pro',
+    label: 'DeepSeek V4 Pro',
+    model_platform: 'deepseek',
+    model_type: 'deepseek-v4-pro',
+  },
+  {
+    value: 'minimax_m2_7',
+    label: 'Minimax M2.7',
+    model_platform: 'minimax',
+    model_type: 'minimax_m2_7',
   },
 ];
 
@@ -652,7 +640,7 @@ export function AddWorker({
         </DialogTrigger>
         <DialogContent
           size="md"
-          className="gap-0 p-0 min-h-[60vh]"
+          className="min-h-[60vh] gap-0 p-0"
           onInteractOutside={(e: any) => {
             if (isValidating) e.preventDefault();
           }}
@@ -678,8 +666,8 @@ export function AddWorker({
           {showEnvConfig ? (
             // environment configuration interface
             <>
-              <DialogContentSection className="scrollbar-always-visible gap-3 p-md flex flex-col overflow-y-auto">
-                <div className="gap-md flex items-center">
+              <DialogContentSection className="scrollbar-always-visible flex flex-col gap-3 overflow-y-auto p-md">
+                <div className="flex items-center gap-md">
                   {getCategoryIcon(activeMcp?.category?.name)}
                   <div>
                     <div className="text-base font-bold leading-9 text-ds-text-neutral-default-default">
@@ -699,7 +687,7 @@ export function AddWorker({
                               verticalAlign: 'middle',
                             }}
                           />
-                          <span className="text-xs font-medium leading-normal line-clamp-1 items-center justify-center self-stretch overflow-hidden break-words text-ellipsis">
+                          <span className="line-clamp-1 items-center justify-center self-stretch overflow-hidden text-ellipsis break-words text-xs font-medium leading-normal">
                             {getGithubRepoName(activeMcp?.home_page)}
                           </span>
                         </div>
@@ -707,7 +695,7 @@ export function AddWorker({
                     </div>
                   </div>
                 </div>
-                <div className="gap-sm flex flex-col">
+                <div className="flex flex-col gap-sm">
                   {Object.keys(activeMcp?.install_command?.env || {}).map(
                     (key) => (
                       <div key={key}>
@@ -777,10 +765,10 @@ export function AddWorker({
           ) : (
             // default add interface
             <>
-              <DialogContentSection className="scrollbar-always-visible gap-3 p-md flex flex-col overflow-y-auto">
-                <div className="gap-4 flex flex-col">
-                  <div className="gap-sm flex items-center">
-                    <div className="h-16 w-16 flex items-center justify-center">
+              <DialogContentSection className="scrollbar-always-visible flex flex-col gap-3 overflow-y-auto p-md">
+                <div className="flex flex-col gap-4">
+                  <div className="flex items-center gap-sm">
+                    <div className="flex h-16 w-16 items-center justify-center">
                       <Bot
                         size={32}
                         className="text-ds-icon-neutral-default-default"
@@ -820,8 +808,8 @@ export function AddWorker({
                 />
 
                 {/* Model Configuration Section */}
-                <div className="mt-2 gap-2 flex flex-col">
-                  <div className="gap-3 flex items-center justify-start">
+                <div className="mt-2 flex flex-col gap-2">
+                  <div className="flex items-center justify-start gap-3">
                     <span className="text-body-sm font-bold text-ds-text-neutral-default-default">
                       {t('workforce.use-custom-model')}
                     </span>
@@ -834,13 +822,13 @@ export function AddWorker({
                         }
                       }}
                       aria-label={t('workforce.use-custom-model')}
-                      className="border-ds-border-neutral-default-default border-[0.5px] border-solid"
+                      className="border-[0.5px] border-solid border-ds-border-neutral-default-default"
                     />
                   </div>
 
                   {showModelConfig && (
-                    <div className="gap-3 rounded-lg bg-ds-bg-neutral-muted-default px-3 py-2 flex flex-row">
-                      <div className="gap-1 flex w-full flex-1 flex-col">
+                    <div className="flex flex-row gap-3 rounded-lg bg-ds-bg-neutral-muted-default px-3 py-2">
+                      <div className="flex w-full flex-1 flex-col gap-1">
                         <label className="text-body-sm font-bold text-ds-text-neutral-default-default">
                           {t('workforce.model-platform')}
                         </label>
@@ -872,7 +860,7 @@ export function AddWorker({
                         </Select>
                       </div>
 
-                      <div className="gap-1 flex w-full flex-1 flex-col">
+                      <div className="flex w-full flex-1 flex-col gap-1">
                         <label className="text-body-sm font-bold text-ds-text-neutral-default-default">
                           {t('workforce.model-type')}
                         </label>

--- a/src/components/ChatBox/BottomBox/ChatInputModelDropdown.tsx
+++ b/src/components/ChatBox/BottomBox/ChatInputModelDropdown.tsx
@@ -69,6 +69,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 const cloudModelOptions = [
+  { id: 'gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
   { id: 'gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro Preview' },
   { id: 'gemini-3-pro-preview', name: 'Gemini 3 Pro Preview' },
   { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash Preview' },
@@ -378,9 +379,9 @@ export function ChatInputModelDropdown({
           }
         )}
       >
-        <span className="min-w-0 gap-1.5 inline-flex min-h-[1.25rem] items-center overflow-hidden">
+        <span className="inline-flex min-h-[1.25rem] min-w-0 items-center gap-1.5 overflow-hidden">
           <Sparkles className="size-3.5 shrink-0" strokeWidth={2} aria-hidden />
-          <span className="min-w-0 !text-label-xs font-semibold truncate">
+          <span className="min-w-0 truncate !text-label-xs font-semibold">
             {triggerModelName}
           </span>
         </span>
@@ -404,19 +405,19 @@ export function ChatInputModelDropdown({
           className={cn(
             modelTriggerShellClass,
             'min-w-0 cursor-pointer border-0 text-left',
-            'font-semibold justify-between transition-colors',
+            'justify-between font-semibold transition-colors',
             'hover:bg-ds-bg-neutral-subtle-hover active:bg-ds-bg-neutral-subtle-default',
-            'focus-visible:ring-ds-border-neutral-strong-default focus-visible:ring-offset-ds-bg-neutral-default-default focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ds-border-neutral-strong-default focus-visible:ring-offset-2 focus-visible:ring-offset-ds-bg-neutral-default-default',
             'disabled:pointer-events-none disabled:opacity-50'
           )}
         >
-          <span className="min-w-0 gap-1.5 flex flex-1 items-center overflow-hidden">
+          <span className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
             <Sparkles
               className="size-3.5 shrink-0"
               strokeWidth={2}
               aria-hidden
             />
-            <span className="min-w-0 !text-label-xs text-ds-text-neutral-default-default flex-1 truncate text-left">
+            <span className="min-w-0 flex-1 truncate text-left !text-label-xs text-ds-text-neutral-default-default">
               {triggerModelName}
             </span>
           </span>
@@ -443,7 +444,7 @@ export function ChatInputModelDropdown({
             }}
           >
             <DropdownMenuSubTrigger
-              className="min-w-0 gap-2 [&>svg:first-child]:!h-4 [&>svg:first-child]:!min-h-4 [&>svg:first-child]:!w-4 [&>svg:first-child]:!min-w-4 flex w-full items-center justify-start"
+              className="flex w-full min-w-0 items-center justify-start gap-2 [&>svg:first-child]:!h-4 [&>svg:first-child]:!min-h-4 [&>svg:first-child]:!w-4 [&>svg:first-child]:!min-w-4"
               onPointerEnter={(e) => {
                 activeSubTriggerRef.current = e.currentTarget;
               }}
@@ -454,7 +455,7 @@ export function ChatInputModelDropdown({
                 className="mt-0.5 h-4 w-4 shrink-0"
                 aria-hidden
               />
-              <span className="min-w-0 text-body-sm flex-1 text-left">
+              <span className="min-w-0 flex-1 text-left text-body-sm">
                 {t('setting.eigent-cloud')}
               </span>
             </DropdownMenuSubTrigger>
@@ -489,16 +490,16 @@ export function ChatInputModelDropdown({
           }}
         >
           <DropdownMenuSubTrigger
-            className="min-w-0 gap-2 [&>svg:first-child]:!h-5 [&>svg:first-child]:!min-h-4 [&>svg:first-child]:!w-4 [&>svg:first-child]:!min-w-4 flex w-full items-center justify-start"
+            className="flex w-full min-w-0 items-center justify-start gap-2 [&>svg:first-child]:!h-5 [&>svg:first-child]:!min-h-4 [&>svg:first-child]:!w-4 [&>svg:first-child]:!min-w-4"
             onPointerEnter={(e) => {
               activeSubTriggerRef.current = e.currentTarget;
             }}
           >
             <Layers
-              className="text-ds-icon-neutral-default-default shrink-0"
+              className="shrink-0 text-ds-icon-neutral-default-default"
               aria-hidden
             />
-            <span className="min-w-0 text-body-sm flex-1 text-left">
+            <span className="min-w-0 flex-1 text-left text-body-sm">
               {t('setting.custom-model')}
             </span>
           </DropdownMenuSubTrigger>
@@ -522,7 +523,7 @@ export function ChatInputModelDropdown({
                   }}
                   className="flex items-center justify-between"
                 >
-                  <div className="gap-2 flex items-center">
+                  <div className="flex items-center gap-2">
                     {modelImage ? (
                       <img
                         src={modelImage}
@@ -543,15 +544,15 @@ export function ChatInputModelDropdown({
                       {item.name}
                     </span>
                   </div>
-                  <div className="gap-1 flex items-center">
+                  <div className="flex items-center gap-1">
                     {!isConfigured && (
-                      <div className="h-2 w-2 bg-ds-text-neutral-subtle-default rounded-full opacity-10" />
+                      <div className="h-2 w-2 rounded-full bg-ds-text-neutral-subtle-default opacity-10" />
                     )}
                     {isPreferred && (
                       <Check className="h-4 w-4 text-ds-text-success-default-default" />
                     )}
                     {isConfigured && !isPreferred && (
-                      <div className="h-2 w-2 bg-ds-text-success-default-default rounded-full" />
+                      <div className="h-2 w-2 rounded-full bg-ds-text-success-default-default" />
                     )}
                   </div>
                 </DropdownMenuItem>
@@ -566,16 +567,16 @@ export function ChatInputModelDropdown({
           }}
         >
           <DropdownMenuSubTrigger
-            className="min-w-0 gap-2 [&>svg:first-child]:!h-4 [&>svg:first-child]:!min-h-4 [&>svg:first-child]:!w-4 [&>svg:first-child]:!min-w-4 flex w-full items-center justify-start"
+            className="flex w-full min-w-0 items-center justify-start gap-2 [&>svg:first-child]:!h-4 [&>svg:first-child]:!min-h-4 [&>svg:first-child]:!w-4 [&>svg:first-child]:!min-w-4"
             onPointerEnter={(e) => {
               activeSubTriggerRef.current = e.currentTarget;
             }}
           >
             <HardDrive
-              className="text-ds-icon-neutral-default-default shrink-0"
+              className="shrink-0 text-ds-icon-neutral-default-default"
               aria-hidden
             />
-            <span className="min-w-0 text-body-sm flex-1 text-left">
+            <span className="min-w-0 flex-1 text-left text-body-sm">
               {t('setting.local-model')}
             </span>
           </DropdownMenuSubTrigger>
@@ -599,7 +600,7 @@ export function ChatInputModelDropdown({
                   }}
                   className="flex items-center justify-between"
                 >
-                  <div className="gap-2 flex items-center">
+                  <div className="flex items-center gap-2">
                     {modelImage ? (
                       <img
                         src={modelImage}
@@ -620,15 +621,15 @@ export function ChatInputModelDropdown({
                       {model.name}
                     </span>
                   </div>
-                  <div className="gap-1 flex items-center">
+                  <div className="flex items-center gap-1">
                     {!isConfigured && (
-                      <div className="h-2 w-2 bg-ds-text-neutral-subtle-default rounded-full opacity-10" />
+                      <div className="h-2 w-2 rounded-full bg-ds-text-neutral-subtle-default opacity-10" />
                     )}
                     {isPreferred && (
                       <Check className="h-4 w-4 text-ds-text-success-default-default" />
                     )}
                     {isConfigured && !isPreferred && (
-                      <div className="h-2 w-2 bg-ds-text-success-default-default rounded-full" />
+                      <div className="h-2 w-2 rounded-full bg-ds-text-success-default-default" />
                     )}
                   </div>
                 </DropdownMenuItem>

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -142,6 +142,7 @@ const getRandomDefaultModel = (): CloudModelType => {
 
 const SUPPORTED_CLOUD_MODEL_TYPES: ReadonlySet<CloudModelType> =
   new Set<CloudModelType>([
+    'gemini-3.5-flash',
     'gemini-3.1-pro-preview',
     'gemini-3-pro-preview',
     'gemini-3-flash-preview',


### PR DESCRIPTION
## Summary

- Align ChatBox dropdown and AddWorker model lists with Settings (Models.tsx) as source of truth
- Add missing `gemini-3.5-flash` to ChatBox dropdown and `SUPPORTED_CLOUD_MODEL_TYPES`
- Replace outdated AddWorker models (gpt-4.1-mini, gpt-4.1, gpt-5, gpt-5.1, gpt-5.2, minimax_m2_5) with current Settings list
- Fix AddWorker GPT model platform from `openai` to `azure`
- Add missing models to AddWorker: gpt-5.5, claude-opus-4.7, deepseek-v4-pro, minimax_m2_7

## Test plan

- [ ] Verify ChatBox model dropdown matches Settings model list
- [ ] Verify AddWorker eigent model dropdown matches Settings model list
- [ ] Confirm `gemini-3.5-flash` persists after app reload (SUPPORTED validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)