### PR TITLE
fix backend env live reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ yarn.lock
 .env.local
 .env.production
 .env.development
+client_secret_*.json
 
 .cursor
 

--- a/backend/app/component/environment.py
+++ b/backend/app/component/environment.py
@@ -21,13 +21,17 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, overload
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 from fastapi import APIRouter, FastAPI
 
 logger = logging.getLogger("env")
 
 # Thread-local storage for user-specific environment
 _thread_local = threading.local()
+
+# Keys present before dotenv files are loaded remain authoritative. Values
+# loaded from dotenv files can be refreshed from disk by env().
+_process_env_keys = set(os.environ.keys())
 
 # Safe base directory for user environment files
 env_base_dir = os.path.join(os.path.expanduser("~"), ".eigent")
@@ -58,6 +62,8 @@ def _load_initial_env_files(paths: Iterable[Path]) -> list[Path]:
     3. Earlier files in `paths`.
     """
     original_env = dict(os.environ)
+    global _process_env_keys
+    _process_env_keys = set(original_env.keys())
     loaded_paths: list[Path] = []
     seen: set[str] = set()
 
@@ -82,6 +88,26 @@ def _load_initial_env_files(paths: Iterable[Path]) -> list[Path]:
             ", ".join(str(path) for path in loaded_paths),
         )
     return loaded_paths
+
+
+def _load_live_env_values(paths: Iterable[Path]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    seen: set[str] = set()
+
+    for path in paths:
+        resolved = path.expanduser().resolve()
+        resolved_key = str(resolved)
+        if resolved_key in seen:
+            continue
+        seen.add(resolved_key)
+        if not resolved.exists():
+            continue
+
+        for key, value in dotenv_values(resolved).items():
+            if value is not None:
+                values[key] = value
+
+    return values
 
 
 _load_initial_env_files(_resolve_initial_env_paths())
@@ -258,8 +284,27 @@ def env(key: str, default=None):
             )
             delattr(_thread_local, "env_path")
 
-    # Fall back to global environment
-    value = os.getenv(key, default)
+    # Keep real process / service-manager env vars authoritative, but allow
+    # dotenv-backed values to be refreshed after Electron writes them.
+    if key in _process_env_keys and key in os.environ:
+        value = os.environ[key]
+        logger.debug(
+            f"Environment variable retrieved from process env: key={key}, "
+            f"has_value={value is not None}"
+        )
+        return value
+
+    live_env_values = _load_live_env_values(_resolve_initial_env_paths())
+    if key in live_env_values:
+        value = live_env_values[key]
+        logger.debug(
+            f"Environment variable retrieved from live dotenv config: "
+            f"key={key}, has_value={value is not None}"
+        )
+        return value
+
+    # Fall back to any value set programmatically after startup.
+    value = os.environ.get(key, default)
     logger.debug(
         f"Environment variable retrieved from global config: key={key}, "
         f"has_value={value is not None}, using_default={value == default}"

--- a/backend/tests/app/component/test_environment.py
+++ b/backend/tests/app/component/test_environment.py
@@ -18,8 +18,10 @@ from pathlib import Path
 
 import pytest
 
+import app.component.environment as environment
 from app.component.environment import (
     _load_initial_env_files,
+    env,
     env_base_dir,
     sanitize_env_path,
 )
@@ -226,3 +228,39 @@ def test_initial_env_files_precedence(monkeypatch, temp_dir: Path):
     assert os.environ["GLOBAL_ONLY"] == "from_global"
     assert os.environ["DEVELOPMENT_ONLY"] == "from_development"
     assert os.environ["PROCESS_KEY"] == "from_process"
+
+
+def test_env_reads_live_dotenv_updates(monkeypatch, temp_dir: Path):
+    """env() should see dotenv changes written after process startup."""
+    env_file = temp_dir / ".env"
+    env_file.write_text("DYNAMIC_ENV_KEY=first")
+
+    monkeypatch.delenv("DYNAMIC_ENV_KEY", raising=False)
+    monkeypatch.setattr(
+        environment, "_resolve_initial_env_paths", lambda: (env_file,)
+    )
+    monkeypatch.setattr(
+        environment, "_process_env_keys", set(os.environ.keys())
+    )
+
+    assert env("DYNAMIC_ENV_KEY") == "first"
+
+    env_file.write_text("DYNAMIC_ENV_KEY=second")
+
+    assert env("DYNAMIC_ENV_KEY") == "second"
+
+
+def test_env_process_value_overrides_live_dotenv(monkeypatch, temp_dir: Path):
+    """Real process env remains higher priority than dotenv files."""
+    env_file = temp_dir / ".env"
+    env_file.write_text("PROCESS_PRIORITY_KEY=from_file")
+
+    monkeypatch.setenv("PROCESS_PRIORITY_KEY", "from_process")
+    monkeypatch.setattr(
+        environment, "_resolve_initial_env_paths", lambda: (env_file,)
+    )
+    monkeypatch.setattr(
+        environment, "_process_env_keys", {"PROCESS_PRIORITY_KEY"}
+    )
+
+    assert env("PROCESS_PRIORITY_KEY") == "from_process"


### PR DESCRIPTION
## Summary

- Refresh backend dotenv-backed environment values at read time while keeping real process environment variables authoritative.
- Add tests for live dotenv updates and process-env precedence.
- Ignore Google OAuth client secret JSON files to avoid accidental commits.

## Root Cause

Electron writes connector settings such as Google Calendar credentials into `~/.eigent/.env` after the backend process is already running. The backend loaded dotenv files only during startup, so `env()` could still return missing values until the process restarted.

## Validation

- `uv run pytest tests/app/component/test_environment.py -q`
- `uv run ruff check app/component/environment.py tests/app/component/test_environment.py`