### PR TITLE
fix task splitting plan display

### DIFF
--- a/backend/app/service/chat_service.py
+++ b/backend/app/service/chat_service.py
@@ -115,6 +115,43 @@ def normalize_summary_task(
     return f"{name or 'Task'}|{summary or name or 'Task'}"
 
 
+def _extract_stream_chunk_content(chunk: Any) -> str:
+    """Return user-visible text from a streaming chunk.
+
+    Some CAMEL streaming chunks carry planning text in ``reasoning_content``.
+    Falling back to ``str(chunk)`` leaks internal ``BaseMessage(...)``
+    representations to the UI, so only explicit text fields are displayable.
+    """
+    if chunk is None:
+        return ""
+    if isinstance(chunk, str):
+        return chunk
+
+    def message_text(message: Any) -> str:
+        for attr in ("content", "reasoning_content"):
+            value = getattr(message, attr, None)
+            if isinstance(value, str) and value:
+                return value
+        return ""
+
+    msg = getattr(chunk, "msg", None)
+    content = message_text(msg)
+    if content:
+        return content
+
+    msgs = getattr(chunk, "msgs", None)
+    if msgs:
+        contents = [
+            item_content
+            for item in msgs
+            if (item_content := message_text(item))
+        ]
+        if contents:
+            return "".join(contents)
+
+    return ""
+
+
 def format_task_context(
     task_data: dict, seen_files: set | None = None, skip_files: bool = False
 ) -> str:
@@ -838,10 +875,10 @@ async def step_solve(options: Chat, request: Request, task_lock: TaskLock):
                     def on_stream_text(chunk):
                         try:
                             accumulated_content = (
-                                chunk.msg.content
-                                if hasattr(chunk, "msg") and chunk.msg
-                                else str(chunk)
+                                _extract_stream_chunk_content(chunk)
                             )
+                            if not accumulated_content:
+                                return
                             last_content = stream_state["last_content"]
 
                             # Calculate delta: new content
@@ -1516,12 +1553,11 @@ async def step_solve(options: Chat, request: Request, task_lock: TaskLock):
 
                         def on_stream_text(chunk):
                             try:
-                                has_msg = hasattr(chunk, "msg") and chunk.msg
                                 accumulated_content = (
-                                    chunk.msg.content
-                                    if has_msg
-                                    else str(chunk)
+                                    _extract_stream_chunk_content(chunk)
                                 )
+                                if not accumulated_content:
+                                    return
                                 last_content = stream_state["last_content"]
 
                                 if accumulated_content.startswith(

--- a/backend/tests/app/service/test_chat_service.py
+++ b/backend/tests/app/service/test_chat_service.py
@@ -20,6 +20,7 @@ from camel.tasks.task import TaskState
 
 from app.model.chat import Chat, NewAgent
 from app.service.chat_service import (
+    _extract_stream_chunk_content,
     _render_subtask_report,
     _trim_in_process_history,
     add_sub_tasks,
@@ -47,6 +48,60 @@ from app.service.task import (
     ImprovePayload,
     TaskLock,
 )
+
+
+class _StreamMsg:
+    def __init__(self, content="", reasoning_content=""):
+        self.content = content
+        self.reasoning_content = reasoning_content
+
+
+class _StreamChunk:
+    def __init__(self, msg=None, msgs=None):
+        self.msg = msg
+        self.msgs = msgs
+
+    def __str__(self):
+        return "msgs=[BaseMessage(role_name='System', reasoning_content='We')]"
+
+
+@pytest.mark.unit
+class TestExtractStreamChunkContent:
+    def test_extracts_single_message_content(self):
+        chunk = _StreamChunk(msg=_StreamMsg("<task>Clean desktop</task>"))
+
+        assert _extract_stream_chunk_content(chunk) == (
+            "<task>Clean desktop</task>"
+        )
+
+    def test_extracts_single_message_reasoning_content(self):
+        chunk = _StreamChunk(
+            msg=_StreamMsg(
+                reasoning_content="We need to organize the desktop."
+            )
+        )
+
+        assert (
+            _extract_stream_chunk_content(chunk)
+            == "We need to organize the desktop."
+        )
+
+    def test_extracts_message_list_content(self):
+        chunk = _StreamChunk(
+            msgs=[
+                _StreamMsg(reasoning_content="We need "),
+                _StreamMsg("<task>Group files</task>"),
+            ]
+        )
+
+        assert _extract_stream_chunk_content(chunk) == (
+            "We need <task>Group files</task>"
+        )
+
+    def test_ignores_metadata_only_chunk(self):
+        chunk = _StreamChunk()
+
+        assert _extract_stream_chunk_content(chunk) == ""
 
 
 @pytest.mark.unit

--- a/src/components/ChatBox/TaskBox/PlanTaskBox/utils.ts
+++ b/src/components/ChatBox/TaskBox/PlanTaskBox/utils.ts
@@ -39,6 +39,13 @@ export function parseStreamingTasks(text: string): {
       isStreaming = true;
     }
   }
+  if (tasks.length === 0) {
+    const fallback = text.trim();
+    if (fallback) {
+      tasks.push(fallback);
+      isStreaming = true;
+    }
+  }
   return { tasks, isStreaming };
 }
 

--- a/src/components/ChatBox/TaskBox/PlanTaskBox/utils.ts
+++ b/src/components/ChatBox/TaskBox/PlanTaskBox/utils.ts
@@ -17,6 +17,20 @@ import { AgentStep, ChatTaskStatus } from '@/types/constants';
 import { useEffect, useMemo, useState } from 'react';
 
 /** Parse `<task>...</task>` tokens out of a streaming decompose blob. */
+function isDisplayableRawStreamingText(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+
+  return ![
+    /^msgs=\[/,
+    /BaseMessage\(/,
+    /\brole_name=/,
+    /\bmeta_dict=/,
+    /\breasoning_content=/,
+    /\bstream_accumulate_mode=/,
+  ].some((pattern) => pattern.test(trimmed));
+}
+
 export function parseStreamingTasks(text: string): {
   tasks: string[];
   isStreaming: boolean;
@@ -41,7 +55,7 @@ export function parseStreamingTasks(text: string): {
   }
   if (tasks.length === 0) {
     const fallback = text.trim();
-    if (fallback) {
+    if (isDisplayableRawStreamingText(fallback)) {
       tasks.push(fallback);
       isStreaming = true;
     }

--- a/src/components/ChatBox/UserQueryGroup.tsx
+++ b/src/components/ChatBox/UserQueryGroup.tsx
@@ -47,26 +47,26 @@ const AgentResultCard: React.FC<{
   const label = agentName || 'Agent';
 
   return (
-    <div className="px-2 overflow-hidden">
+    <div className="overflow-hidden px-2">
       {/* Header (always visible) */}
       <button
         type="button"
-        className="focus-visible:ring-ds-border-brand-default-focus/40 gap-2 rounded-xl px-3 py-2 text-sm font-semibold text-ds-text-neutral-default-default hover:bg-ds-bg-neutral-default-hover active:bg-ds-bg-neutral-default-active flex w-full items-center text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
+        className="focus-visible:ring-ds-border-brand-default-focus/40 flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-semibold text-ds-text-neutral-default-default transition-colors hover:bg-ds-bg-neutral-default-hover focus-visible:outline-none focus-visible:ring-2 active:bg-ds-bg-neutral-default-active"
         onClick={() => setIsOpen((v) => !v)}
       >
         <span className="min-w-0 flex-1 truncate">{label}</span>
         <ChevronDown
           size={14}
           aria-hidden
-          className={`text-ds-icon-neutral-default-default shrink-0 transition-transform duration-200 ${isOpen ? 'rotate-180' : 'rotate-0'}`}
+          className={`shrink-0 text-ds-icon-neutral-default-default transition-transform duration-200 ${isOpen ? 'rotate-180' : 'rotate-0'}`}
         />
       </button>
 
       {/* Collapsible body */}
       <div
-        className={`ease-in-out overflow-hidden transition-all duration-200 ${isOpen ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}`}
+        className={`overflow-hidden transition-all duration-200 ease-in-out ${isOpen ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}`}
       >
-        <div className="border-ds-border-neutral-default-default px-1 py-1 border-t">
+        <div className="border-t border-ds-border-neutral-default-default px-1 py-1">
           <AgentMessageCard
             id={id}
             content={content}
@@ -164,7 +164,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
     (callback) => chatStore.subscribe(callback),
     () => {
       const state = chatStore.getState();
-      const taskId = state.activeTaskId;
+      const taskId = activeTaskId;
       if (!taskId || !state.tasks[taskId]) return '';
       return state.tasks[taskId].streamingDecomposeText || '';
     }
@@ -320,6 +320,9 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
       (showTaskPlanCard && hasConfirmedSubTasks) ||
       // Single agent: from submit until the first `todo_state` arrives.
       shouldShowSingleAgentWorkLog);
+  const shouldShowPlanTaskBox = Boolean(
+    !hasConfirmedSubTasks && (isLastUserQuery || queryGroup.taskMessage)
+  );
 
   return (
     <motion.div
@@ -394,8 +397,9 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                   }}
                   clickable={true}
                 />
-              ) : isLastUserQuery ? (
-                // Live planning UI: only on the most recent turn.
+              ) : shouldShowPlanTaskBox ? (
+                // Live planning UI: latest splitting turn or the group that
+                // owns an unconfirmed to_sub_tasks message.
                 <PlanTaskBox
                   chatStore={chatStore}
                   taskId={activeTaskId}
@@ -429,7 +433,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
-                className="gap-4 flex flex-col"
+                className="flex flex-col gap-4"
               >
                 <AgentMessageCard
                   typewriter={shouldUseLiveAgentTypewriter(task, message.id)}
@@ -438,7 +442,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                   onTyping={() => {}}
                   deferredFooter={
                     message.fileList?.length ? (
-                      <div className="my-2 gap-2 flex flex-wrap">
+                      <div className="my-2 flex flex-wrap gap-2">
                         {message.fileList.map(
                           (file: any, fileIndex: number) => (
                             <motion.div
@@ -449,14 +453,14 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                               onClick={() => {
                                 openFilePreview(file);
                               }}
-                              className="gap-2 rounded-lg bg-ds-bg-neutral-default-default px-3 py-2 hover:bg-ds-bg-neutral-default-hover flex w-[140px] cursor-pointer items-center transition-colors"
+                              className="flex w-[140px] cursor-pointer items-center gap-2 rounded-lg bg-ds-bg-neutral-default-default px-3 py-2 transition-colors hover:bg-ds-bg-neutral-default-hover"
                             >
                               <FileText
                                 size={16}
-                                className="text-ds-icon-neutral-default-default flex-shrink-0"
+                                className="flex-shrink-0 text-ds-icon-neutral-default-default"
                               />
                               <div className="flex flex-col">
-                                <div className="text-body-sm font-bold text-ds-text-neutral-default-default max-w-[100px] overflow-hidden text-ellipsis whitespace-nowrap">
+                                <div className="max-w-[100px] overflow-hidden text-ellipsis whitespace-nowrap text-body-sm font-bold text-ds-text-neutral-default-default">
                                   {file.name.split('.')[0]}
                                 </div>
                                 <div className="text-label-xs font-medium text-ds-text-neutral-muted-default">
@@ -479,7 +483,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
-                className="gap-4 flex flex-col"
+                className="flex flex-col gap-4"
               >
                 <AgentMessageCard
                   key={message.id}
@@ -514,7 +518,7 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
-                className="gap-4 flex flex-col"
+                className="flex flex-col gap-4"
               >
                 <AgentMessageCard
                   key={message.id}
@@ -534,10 +538,10 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ delay: 0.2 }}
-              className="gap-4 flex flex-col"
+              className="flex flex-col gap-4"
             >
               {message.fileList && (
-                <div className="gap-2 flex flex-wrap">
+                <div className="flex flex-wrap gap-2">
                   {message.fileList.map((file: any, fileIndex: number) => (
                     <motion.div
                       key={`file-${message.id}-${file.name}-${fileIndex}`}
@@ -547,14 +551,14 @@ export const UserQueryGroup: React.FC<UserQueryGroupProps> = ({
                       onClick={() => {
                         openFilePreview(file);
                       }}
-                      className="gap-2 rounded-2xl bg-ds-bg-neutral-default-default px-2 py-1 hover:bg-ds-bg-neutral-default-hover flex w-[120px] cursor-pointer items-center transition-colors"
+                      className="flex w-[120px] cursor-pointer items-center gap-2 rounded-2xl bg-ds-bg-neutral-default-default px-2 py-1 transition-colors hover:bg-ds-bg-neutral-default-hover"
                     >
                       <FileText
                         size={16}
-                        className="text-ds-icon-neutral-default-default flex-shrink-0"
+                        className="flex-shrink-0 text-ds-icon-neutral-default-default"
                       />
                       <div className="flex flex-col">
-                        <div className="text-body max-w-48 text-sm font-bold text-ds-text-neutral-default-default overflow-hidden text-ellipsis whitespace-nowrap">
+                        <div className="text-body max-w-48 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-bold text-ds-text-neutral-default-default">
                           {file.name.split('.')[0]}
                         </div>
                         <div className="text-xs font-medium leading-29 text-ds-text-neutral-default-default">

--- a/test/integration/components/ChatBox.integration.test.tsx
+++ b/test/integration/components/ChatBox.integration.test.tsx
@@ -141,6 +141,18 @@ describe('ChatBox Integration Tests - Different ChatStore Configurations', () =>
             ],
           },
         });
+        chatStore.setSummaryTask(
+          taskId,
+          'Calculator App|Build a simple calculator app'
+        );
+        chatStore.setTaskInfo(taskId, [
+          { id: 'task-1', content: 'Create UI components', status: '' },
+          {
+            id: 'task-2',
+            content: 'Implement calculator logic',
+            status: '',
+          },
+        ]);
         rerender();
       });
 
@@ -158,6 +170,10 @@ describe('ChatBox Integration Tests - Different ChatStore Configurations', () =>
         );
         expect(calculatorElements.length).toBeGreaterThanOrEqual(1);
         // The component should show task breakdown
+        expect(screen.getByText('Create UI components')).toBeInTheDocument();
+        expect(
+          screen.getByText('Implement calculator logic')
+        ).toBeInTheDocument();
         expect(
           screen.queryByText(/layout.welcome-to-eigent/i)
         ).not.toBeInTheDocument();

--- a/test/unit/components/PlanTaskBoxUtils.test.ts
+++ b/test/unit/components/PlanTaskBoxUtils.test.ts
@@ -30,4 +30,15 @@ describe('parseStreamingTasks', () => {
       isStreaming: true,
     });
   });
+
+  it('does not display internal streaming chunk objects as raw text', () => {
+    expect(
+      parseStreamingTasks(
+        "msgs=[BaseMessage(role_name='System', meta_dict={}, reasoning_content='We')] stream_accumulate_mode='accumulate'"
+      )
+    ).toEqual({
+      tasks: [],
+      isStreaming: false,
+    });
+  });
 });

--- a/test/unit/components/PlanTaskBoxUtils.test.ts
+++ b/test/unit/components/PlanTaskBoxUtils.test.ts
@@ -1,0 +1,33 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest';
+
+import { parseStreamingTasks } from '@/components/ChatBox/TaskBox/PlanTaskBox/utils';
+
+describe('parseStreamingTasks', () => {
+  it('parses completed and streaming task tags', () => {
+    expect(parseStreamingTasks('<task>First task</task><task>Second')).toEqual({
+      tasks: ['First task', 'Second'],
+      isStreaming: true,
+    });
+  });
+
+  it('falls back to raw streaming text before task tags arrive', () => {
+    expect(parseStreamingTasks('Thinking through the subtasks')).toEqual({
+      tasks: ['Thinking through the subtasks'],
+      isStreaming: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Keep the planning card visible for the query group that owns an unconfirmed `to_sub_tasks` message.
- Scope decomposition streaming text lookup to the rendered task id instead of the global active task id.
- Extract displayable decomposition stream text from backend chunks using `content` first and `reasoning_content` as a fallback, instead of leaking stringified `BaseMessage(...)` objects.
- Show raw streaming decomposition text before `<task>` tags arrive, while filtering obvious internal chunk-object strings on the frontend.
- Strengthen tests for streaming task parsing, backend chunk extraction, and visible subtask rendering.

## Root Cause
The chat group stopped qualifying as the current/latest user query once the `to_sub_tasks` message was attached as `taskMessage`, so the main chat branch rendered `null` instead of `PlanTaskBox`.

A separate streaming issue came from the backend falling back to `str(chunk)` when a CAMEL stream chunk did not expose `msg.content`. For reasoning chunks, that exposed internal `BaseMessage(...)` representations in the UI instead of sending just the planning text from `reasoning_content`.

## Validation
- `npx vitest run test/unit/components/PlanTaskBoxUtils.test.ts --reporter=dot`
- `npx vitest run test/integration/components/ChatBox.integration.test.tsx -t "should render task splitting UI when task is in to_sub_tasks state" --reporter=dot`
- `npx prettier --check src/components/ChatBox/UserQueryGroup.tsx src/components/ChatBox/TaskBox/PlanTaskBox/utils.ts test/unit/components/PlanTaskBoxUtils.test.ts test/integration/components/ChatBox.integration.test.tsx`
- `npx eslint src/components/ChatBox/UserQueryGroup.tsx src/components/ChatBox/TaskBox/PlanTaskBox/utils.ts test/unit/components/PlanTaskBoxUtils.test.ts test/integration/components/ChatBox.integration.test.tsx`
- `uv run pytest tests/app/service/test_chat_service.py -q -k "ExtractStreamChunkContent"`
- `uv run ruff check app/service/chat_service.py tests/app/service/test_chat_service.py`
- `uv run ruff format --check app/service/chat_service.py tests/app/service/test_chat_service.py`
