### PR TITLE
[codex] fix zai platform alias

### DIFF
--- a/backend/app/model/model_platform.py
+++ b/backend/app/model/model_platform.py
@@ -17,7 +17,7 @@ from typing import Annotated, Final
 from pydantic import BeforeValidator
 
 PLATFORM_ALIAS_MAPPING: Final[dict[str, str]] = {
-    "z.ai": "zhipu",
+    "z.ai": "zhipuai",
     "ModelArk": "openai-compatible-model",
     "grok": "openai-compatible-model",
     "ernie": "qianfan",

--- a/backend/tests/app/model/test_model_platform.py
+++ b/backend/tests/app/model/test_model_platform.py
@@ -24,7 +24,7 @@ from app.model.model_platform import (
 
 def test_normalize_model_platform_maps_known_aliases():
     assert normalize_model_platform("grok") == "openai-compatible-model"
-    assert normalize_model_platform("z.ai") == "zhipu"
+    assert normalize_model_platform("z.ai") == "zhipuai"
     assert normalize_model_platform("ModelArk") == "openai-compatible-model"
     assert normalize_model_platform("ernie") == "qianfan"
     assert normalize_model_platform("llama.cpp") == "openai-compatible-model"


### PR DESCRIPTION
## Summary
- Map the `z.ai` provider alias to CAMEL's supported `zhipuai` platform name.
- Update the model platform alias test expectation.

## Root Cause
The backend normalized `z.ai` to `zhipu`, but the current CAMEL `ModelPlatformType` enum recognizes `zhipuai`. Model validation therefore failed during `ModelFactory.create()` with `Unknown model platform: zhipu`.

## Validation
- `uv run pytest tests/app/model/test_model_platform.py -q`
- `uv run ruff check app/model/model_platform.py tests/app/model/test_model_platform.py`
- `uv run ruff format --check app/model/model_platform.py tests/app/model/test_model_platform.py`
