### PR TITLE
Use text input for provider model types

### DIFF
--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -215,7 +215,6 @@ export const INIT_PROVODERS: Provider[] = [
     description: 'OrcaRouter model configuration.',
     is_valid: false,
     model_type: '',
-    modelsEndpoint: '/models',
     websiteUrl: 'https://www.orcarouter.ai',
   },
   {
@@ -226,7 +225,6 @@ export const INIT_PROVODERS: Provider[] = [
     description: 'Nebius Token Factory model configuration.',
     is_valid: false,
     model_type: '',
-    modelsEndpoint: '/models',
     websiteUrl: 'https://docs.tokenfactory.nebius.com/quickstart',
   },
   {


### PR DESCRIPTION
## Why

OrcaRouter and Nebius Token Factory rendered the model type field as a model-list combobox because they declared a models endpoint. That made their configuration UI look and behave differently from the other provider cards.

## What Changed

- Removed the model-list endpoint metadata from OrcaRouter and Nebius Token Factory.
- Both providers now use the same freeform Model Type input as the other provider configurations.

Validated with `npx eslint src/lib/llm.ts --no-warn-ignored` and `npm run type-check`.
