### PR TITLE
fix(skills): stably expose Single Agent in skill scope picker

### DIFF
--- a/backend/app/agent/toolkit/skill_toolkit.py
+++ b/backend/app/agent/toolkit/skill_toolkit.py
@@ -129,11 +129,7 @@ def _normalize_agent_name(agent_name: str | None) -> str | None:
     if not cleaned:
         return None
     lowered = cleaned.lower()
-    if (
-        lowered == "single_agent"
-        or lowered == "agents.single_agent"
-        or lowered.endswith(".single_agent")
-    ):
+    if lowered == "single_agent" or lowered == "agents.single_agent":
         return "single_agent"
     return cleaned
 

--- a/backend/app/agent/toolkit/skill_toolkit.py
+++ b/backend/app/agent/toolkit/skill_toolkit.py
@@ -117,6 +117,39 @@ def _get_merged_skill_config(
     return config
 
 
+def _normalize_agent_name(agent_name: str | None) -> str | None:
+    """Canonicalize agent names for skill scope matching.
+
+    Backend Single Agent uses Agents.single_agent == "single_agent". Accept
+    legacy aliases so Skills UI bindings stay effective.
+    """
+    if agent_name is None:
+        return None
+    cleaned = str(agent_name).strip()
+    if not cleaned:
+        return None
+    lowered = cleaned.lower()
+    if (
+        lowered == "single_agent"
+        or lowered == "agents.single_agent"
+        or lowered.endswith(".single_agent")
+    ):
+        return "single_agent"
+    return cleaned
+
+
+def _agent_in_list(agent_name: str | None, agents: list) -> bool:
+    normalized = _normalize_agent_name(agent_name)
+    if not normalized:
+        return False
+    selected = {
+        _normalize_agent_name(str(item))
+        for item in agents
+        if _normalize_agent_name(str(item))
+    }
+    return normalized in selected
+
+
 def _is_skill_enabled(
     skill_name: str, config: dict[str, SkillEntryConfig]
 ) -> bool:
@@ -167,7 +200,7 @@ def _is_agent_allowed(
             )
             return False
 
-        return agent_name in selected_agents
+        return _agent_in_list(agent_name, selected_agents)
 
     allowed_agents = skill_config.get("agents", [])
 
@@ -182,7 +215,7 @@ def _is_agent_allowed(
         )
         return False
 
-    return agent_name in allowed_agents
+    return _agent_in_list(agent_name, allowed_agents)
 
 
 def _build_allowed_skills(

--- a/backend/tests/app/service/test_skill_initialization.py
+++ b/backend/tests/app/service/test_skill_initialization.py
@@ -217,11 +217,14 @@ def test_skill_toolkit_allows_single_agent_aliases():
         "demo", "Agents.single_agent", config
     )
     assert not agent_skill_toolkit._is_agent_allowed(
+        "demo", "foo.single_agent", config
+    )
+    assert not agent_skill_toolkit._is_agent_allowed(
         "demo", "developer_agent", config
     )
 
 
-def test_skill_toolkit_normalizes_selected_agent_aliases():
+def test_skill_toolkit_normalizes_selected_single_agent_aliases():
     config = {
         "demo": {
             "enabled": True,

--- a/backend/tests/app/service/test_skill_initialization.py
+++ b/backend/tests/app/service/test_skill_initialization.py
@@ -198,3 +198,35 @@ def test_agent_skill_toolkit_reads_canonical_user_config_path(
     assert agent_skill_toolkit._get_user_config_path("user_42") == (
         tmp_path / ".eigent" / "user_42" / "skills-config.json"
     )
+
+
+def test_skill_toolkit_allows_single_agent_aliases():
+    config = {
+        "demo": {
+            "enabled": True,
+            "scope": {
+                "isGlobal": False,
+                "selectedAgents": ["single_agent"],
+            },
+        }
+    }
+    assert agent_skill_toolkit._is_agent_allowed("demo", "single_agent", config)
+    assert agent_skill_toolkit._is_agent_allowed(
+        "demo", "Agents.single_agent", config
+    )
+    assert not agent_skill_toolkit._is_agent_allowed(
+        "demo", "developer_agent", config
+    )
+
+
+def test_skill_toolkit_normalizes_selected_agent_aliases():
+    config = {
+        "demo": {
+            "enabled": True,
+            "scope": {
+                "isGlobal": False,
+                "selectedAgents": ["Agents.single_agent"],
+            },
+        }
+    }
+    assert agent_skill_toolkit._is_agent_allowed("demo", "single_agent", config)

--- a/backend/tests/app/service/test_skill_initialization.py
+++ b/backend/tests/app/service/test_skill_initialization.py
@@ -210,7 +210,9 @@ def test_skill_toolkit_allows_single_agent_aliases():
             },
         }
     }
-    assert agent_skill_toolkit._is_agent_allowed("demo", "single_agent", config)
+    assert agent_skill_toolkit._is_agent_allowed(
+        "demo", "single_agent", config
+    )
     assert agent_skill_toolkit._is_agent_allowed(
         "demo", "Agents.single_agent", config
     )
@@ -229,4 +231,6 @@ def test_skill_toolkit_normalizes_selected_agent_aliases():
             },
         }
     }
-    assert agent_skill_toolkit._is_agent_allowed("demo", "single_agent", config)
+    assert agent_skill_toolkit._is_agent_allowed(
+        "demo", "single_agent", config
+    )

--- a/src/components/WorkFlow/agents.tsx
+++ b/src/components/WorkFlow/agents.tsx
@@ -151,9 +151,7 @@ export const SKILL_SCOPE_AGENT_LIST: {
     id: SINGLE_AGENT_ID,
     // Product label (layout.workspace-session-single-agent). Value stays `single_agent`.
     name: 'Single Agent',
-    icon: (
-      <Bot size={16} className="text-ds-text-neutral-default-default" />
-    ),
+    icon: <Bot size={16} className="text-ds-text-neutral-default-default" />,
   },
   ...WORKFLOW_AGENT_LIST,
 ];
@@ -171,11 +169,7 @@ export function normalizeSkillScopeAgentId(agentName?: string | null): string {
   const raw = String(agentName ?? '').trim();
   if (!raw) return '';
   const lowered = raw.toLowerCase();
-  if (
-    lowered === SINGLE_AGENT_ID ||
-    lowered === 'agents.single_agent' ||
-    lowered.endsWith('.single_agent')
-  ) {
+  if (lowered === SINGLE_AGENT_ID || lowered === 'agents.single_agent') {
     return SINGLE_AGENT_ID;
   }
   return raw;

--- a/src/components/WorkFlow/agents.tsx
+++ b/src/components/WorkFlow/agents.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-import { Bird, CodeXml, FileText, Globe, Image } from 'lucide-react';
+import { Bird, Bot, CodeXml, FileText, Globe, Image } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 export type WorkflowAgentType =
@@ -21,6 +21,11 @@ export type WorkflowAgentType =
   | 'document_agent'
   | 'multi_modal_agent'
   | 'social_media_agent';
+
+/** Backend agent name used by Single Agent SkillToolkit (`Agents.single_agent`). */
+export const SINGLE_AGENT_ID = 'single_agent' as const;
+
+export type SkillScopeAgentType = WorkflowAgentType | typeof SINGLE_AGENT_ID;
 
 export interface AgentDisplayInfo {
   name: string;
@@ -132,12 +137,101 @@ export const WORKFLOW_AGENT_LIST: {
   },
 ];
 
-/** Get display info (name + icon) by agent name; returns undefined if not a workflow agent. */
+/**
+ * Agents shown in Skills "Select agent access".
+ * Always includes Single Agent first so skill scope can target `single_agent`
+ * the same way backend SkillToolkit / Agents.single_agent does.
+ */
+export const SKILL_SCOPE_AGENT_LIST: {
+  id: SkillScopeAgentType;
+  name: string;
+  icon: ReactNode;
+}[] = [
+  {
+    id: SINGLE_AGENT_ID,
+    // Product label (layout.workspace-session-single-agent). Value stays `single_agent`.
+    name: 'Single Agent',
+    icon: (
+      <Bot size={16} className="text-ds-text-neutral-default-default" />
+    ),
+  },
+  ...WORKFLOW_AGENT_LIST,
+];
+
+export type SkillScopeAgentOption = {
+  value: string;
+  label: string;
+};
+
+/**
+ * Canonicalize skill-scope agent ids so UI + backend agree.
+ * Accepts legacy aliases such as `Agents.single_agent`.
+ */
+export function normalizeSkillScopeAgentId(agentName?: string | null): string {
+  const raw = String(agentName ?? '').trim();
+  if (!raw) return '';
+  const lowered = raw.toLowerCase();
+  if (
+    lowered === SINGLE_AGENT_ID ||
+    lowered === 'agents.single_agent' ||
+    lowered.endsWith('.single_agent')
+  ) {
+    return SINGLE_AGENT_ID;
+  }
+  return raw;
+}
+
+/**
+ * Build the Skills page agent-access options:
+ * Single Agent (stable) + workforce workers + custom workers (deduped by value).
+ */
+export function buildSkillScopeAgentOptions(
+  workerList: Array<{ name: string }> = []
+): SkillScopeAgentOption[] {
+  const baseAgents: SkillScopeAgentOption[] = SKILL_SCOPE_AGENT_LIST.filter(
+    (a) => a.id !== 'social_media_agent'
+  ).map((a) => ({ value: a.id, label: a.name }));
+
+  // Guarantee Single Agent stays first even if list construction changes later.
+  const combined: SkillScopeAgentOption[] = [];
+  const seen = new Set<string>();
+  for (const agent of baseAgents) {
+    const value = normalizeSkillScopeAgentId(agent.value) || agent.value;
+    if (seen.has(value)) continue;
+    seen.add(value);
+    combined.push({ value, label: agent.label });
+  }
+
+  for (const worker of workerList) {
+    const value = normalizeSkillScopeAgentId(worker.name);
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    const label =
+      value === SINGLE_AGENT_ID
+        ? 'Single Agent'
+        : String(worker.name || value).trim() || value;
+    combined.push({ value, label });
+  }
+
+  // Last-resort: if somehow dropped, prepend Single Agent.
+  if (!combined.some((agent) => agent.value === SINGLE_AGENT_ID)) {
+    combined.unshift({ value: SINGLE_AGENT_ID, label: 'Single Agent' });
+  } else if (combined[0]?.value !== SINGLE_AGENT_ID) {
+    const single = combined.find((agent) => agent.value === SINGLE_AGENT_ID)!;
+    combined.splice(combined.indexOf(single), 1);
+    combined.unshift(single);
+  }
+
+  return combined;
+}
+
+/** Get display info (name + icon) by agent name; returns undefined if unknown. */
 export function getWorkflowAgentDisplay(
   agentName: string
 ): { name: string; icon: ReactNode } | undefined {
-  const entry = WORKFLOW_AGENT_LIST.find(
-    (a) => a.id.toLowerCase() === agentName.toLowerCase()
+  const normalized = normalizeSkillScopeAgentId(agentName);
+  const entry = SKILL_SCOPE_AGENT_LIST.find(
+    (a) => a.id.toLowerCase() === normalized.toLowerCase()
   );
   if (!entry) return undefined;
   return { name: entry.name, icon: entry.icon };

--- a/src/pages/Agents/components/SkillListItem.tsx
+++ b/src/pages/Agents/components/SkillListItem.tsx
@@ -94,7 +94,7 @@ export default function SkillListItem(props: SkillListItemProps) {
       <div
         role={isClickable ? 'button' : undefined}
         tabIndex={isClickable ? 0 : undefined}
-        className={`focus-visible:ring-ring gap-3 rounded-2xl bg-ds-bg-neutral-subtle-default px-6 py-8 flex w-full flex-col flex-wrap items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 ${isClickable ? 'hover:bg-ds-bg-neutral-strong-hover cursor-pointer' : ''}`}
+        className={`focus-visible:ring-ring flex w-full flex-col flex-wrap items-center justify-center gap-3 rounded-2xl bg-ds-bg-neutral-subtle-default px-6 py-8 transition-colors focus:outline-none focus-visible:ring-2 ${isClickable ? 'cursor-pointer hover:bg-ds-bg-neutral-strong-hover' : ''}`}
         onClick={isClickable ? props.onAddClick : undefined}
         onKeyDown={
           isClickable
@@ -174,7 +174,9 @@ export default function SkillListItem(props: SkillListItemProps) {
         ].filter(
           (value, index, list) =>
             list.findIndex(
-              (item) => normalizeSkillScopeAgentId(item) === normalizeSkillScopeAgentId(value)
+              (item) =>
+                normalizeSkillScopeAgentId(item) ===
+                normalizeSkillScopeAgentId(value)
             ) === index
         );
     handleScopeChange({
@@ -191,17 +193,17 @@ export default function SkillListItem(props: SkillListItemProps) {
 
   return (
     <div
-      className={`rounded-2xl bg-ds-bg-neutral-subtle-default p-4 w-full flex-1 flex-col justify-between transition-colors ${skill.isExample && !skill.enabled ? 'opacity-50' : ''}`}
+      className={`w-full flex-1 flex-col justify-between rounded-2xl bg-ds-bg-neutral-subtle-default p-4 transition-colors ${skill.isExample && !skill.enabled ? 'opacity-50' : ''}`}
     >
       {/* Row 1: Name / Actions */}
       <div className="flex items-center justify-between">
-        <div className="min-w-0 gap-2 flex items-center">
-          <span className="text-body-base font-bold text-ds-text-neutral-default-default truncate">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="text-body-base truncate font-bold text-ds-text-neutral-default-default">
             {skill.name}
           </span>
         </div>
 
-        <div className="gap-md flex flex-shrink-0 items-center">
+        <div className="flex flex-shrink-0 items-center gap-md">
           <Switch
             checked={skill.enabled}
             onCheckedChange={() => toggleSkill(skill.id)}
@@ -241,17 +243,17 @@ export default function SkillListItem(props: SkillListItemProps) {
       {/* Row 2: Description - 5 lines max, hover shows full */}
       <TooltipSimple
         content={skill.description}
-        className="max-w-sm break-words whitespace-pre-wrap"
+        className="max-w-sm whitespace-pre-wrap break-words"
       >
         <div className="w-full cursor-default">
-          <p className="text-body-sm text-ds-text-neutral-muted-default line-clamp-5 overflow-hidden break-words">
+          <p className="line-clamp-5 overflow-hidden break-words text-body-sm text-ds-text-neutral-muted-default">
             {skill.description}
           </p>
         </div>
       </TooltipSimple>
 
       {/* Row 3: Added time / Skill scope */}
-      <div className="gap-2 flex flex-col items-start">
+      <div className="flex flex-col items-start gap-2">
         <Button
           variant="ghost"
           size="sm"
@@ -265,14 +267,14 @@ export default function SkillListItem(props: SkillListItemProps) {
         </Button>
 
         {scopeOpen && (
-          <div className="gap-2 border-ds-border-neutral-default-default pt-4 flex w-full flex-wrap items-center border-x-0 border-t-[0.5px] border-b-0 border-solid">
+          <div className="flex w-full flex-wrap items-center gap-2 border-x-0 border-b-0 border-t-[0.5px] border-solid border-ds-border-neutral-default-default pt-4">
             {/* All agents as first tab; then each agent toggle */}
             <button
               type="button"
               onClick={handleToggleAllAgents}
-              className={`gap-2 bg-ds-bg-neutral-subtle-default px-2 py-1 text-label-xs font-medium text-ds-text-neutral-default-default inline-flex items-center rounded-full transition-opacity hover:opacity-100 [&>svg]:shrink-0 ${
+              className={`inline-flex items-center gap-2 rounded-full bg-ds-bg-neutral-subtle-default px-2 py-1 text-label-xs font-medium text-ds-text-neutral-default-default transition-opacity hover:opacity-100 [&>svg]:shrink-0 ${
                 isAllAgentsSelected
-                  ? '[&>svg]:text-ds-icon-status-completed-default-default opacity-100'
+                  ? 'opacity-100 [&>svg]:text-ds-icon-status-completed-default-default'
                   : 'opacity-60 [&>svg]:text-inherit'
               }`}
             >
@@ -297,9 +299,9 @@ export default function SkillListItem(props: SkillListItemProps) {
                   key={agent.value}
                   type="button"
                   onClick={() => handleToggleAgent(agent.value)}
-                  className={`gap-2 bg-ds-bg-neutral-subtle-default px-2 py-1 text-label-xs font-medium text-ds-text-neutral-default-default inline-flex items-center rounded-full transition-opacity hover:opacity-100 [&>svg]:shrink-0 ${
+                  className={`inline-flex items-center gap-2 rounded-full bg-ds-bg-neutral-subtle-default px-2 py-1 text-label-xs font-medium text-ds-text-neutral-default-default transition-opacity hover:opacity-100 [&>svg]:shrink-0 ${
                     isSelected
-                      ? '[&>svg]:text-ds-icon-status-completed-default-default opacity-100'
+                      ? 'opacity-100 [&>svg]:text-ds-icon-status-completed-default-default'
                       : 'opacity-50 [&>svg]:text-inherit'
                   }`}
                 >

--- a/src/pages/Agents/components/SkillListItem.tsx
+++ b/src/pages/Agents/components/SkillListItem.tsx
@@ -22,8 +22,9 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { TooltipSimple } from '@/components/ui/tooltip';
 import {
+  buildSkillScopeAgentOptions,
   getWorkflowAgentDisplay,
-  WORKFLOW_AGENT_LIST,
+  normalizeSkillScopeAgentId,
 } from '@/components/WorkFlow/agents';
 import useChatStoreAdapter from '@/hooks/useChatStoreAdapter';
 import { useWorkerList } from '@/store/authStore';
@@ -64,6 +65,16 @@ type SkillListItemProps =
   | SkillListItemDefaultProps
   | SkillListItemPlaceholderProps;
 
+function selectedAgentsInclude(
+  selectedAgents: string[],
+  agentValue: string
+): boolean {
+  const target = normalizeSkillScopeAgentId(agentValue);
+  return selectedAgents.some(
+    (agent) => normalizeSkillScopeAgentId(agent) === target
+  );
+}
+
 export default function SkillListItem(props: SkillListItemProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -72,27 +83,10 @@ export default function SkillListItem(props: SkillListItemProps) {
   const workerList = useWorkerList();
   const [scopeOpen, setScopeOpen] = useState(false);
 
-  type AgentOption = {
-    value: string;
-    label: string;
-  };
-
-  const allAgents = useMemo(() => {
-    const workflowAgents: AgentOption[] = WORKFLOW_AGENT_LIST.filter(
-      (a) => a.id !== 'social_media_agent'
-    ).map((a) => ({ value: a.id, label: a.name }));
-    const workerAgents: AgentOption[] = workerList.map((w) => ({
-      value: w.name,
-      label: w.name,
-    }));
-    const combined = [...workflowAgents];
-    workerAgents.forEach((agent) => {
-      if (!combined.some((a) => a.value === agent.value)) {
-        combined.push(agent);
-      }
-    });
-    return combined;
-  }, [workerList]);
+  const allAgents = useMemo(
+    () => buildSkillScopeAgentOptions(workerList),
+    [workerList]
+  );
 
   if (props.variant === 'placeholder') {
     const isClickable = props.onAddClick != null;
@@ -152,9 +146,10 @@ export default function SkillListItem(props: SkillListItemProps) {
   };
 
   const handleToggleAgent = (agentValue: string) => {
+    const canonicalValue = normalizeSkillScopeAgentId(agentValue) || agentValue;
     if (isAllAgentsSelected) {
       const newSelectedAgents = allAgents
-        .filter((a) => a.value !== agentValue)
+        .filter((a) => a.value !== canonicalValue)
         .map((a) => a.value);
       handleScopeChange({
         isGlobal: false,
@@ -163,10 +158,25 @@ export default function SkillListItem(props: SkillListItemProps) {
       return;
     }
 
-    const isSelected = skill.scope.selectedAgents.includes(agentValue);
+    const isSelected = selectedAgentsInclude(
+      skill.scope.selectedAgents,
+      canonicalValue
+    );
     const newSelectedAgents = isSelected
-      ? skill.scope.selectedAgents.filter((a) => a !== agentValue)
-      : [...skill.scope.selectedAgents, agentValue];
+      ? skill.scope.selectedAgents.filter(
+          (a) => normalizeSkillScopeAgentId(a) !== canonicalValue
+        )
+      : [
+          ...skill.scope.selectedAgents.map(
+            (a) => normalizeSkillScopeAgentId(a) || a
+          ),
+          canonicalValue,
+        ].filter(
+          (value, index, list) =>
+            list.findIndex(
+              (item) => normalizeSkillScopeAgentId(item) === normalizeSkillScopeAgentId(value)
+            ) === index
+        );
     handleScopeChange({
       isGlobal: false,
       selectedAgents: newSelectedAgents,
@@ -277,7 +287,7 @@ export default function SkillListItem(props: SkillListItemProps) {
             {allAgents.map((agent) => {
               const isSelected =
                 isAllAgentsSelected ||
-                skill.scope.selectedAgents.includes(agent.value);
+                selectedAgentsInclude(skill.scope.selectedAgents, agent.value);
               const display = getWorkflowAgentDisplay(agent.value);
               const icon = display?.icon ?? (
                 <Bot size={16} className="shrink-0 text-inherit" />

--- a/test/unit/components/WorkFlow/skillScopeAgents.test.ts
+++ b/test/unit/components/WorkFlow/skillScopeAgents.test.ts
@@ -1,0 +1,83 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildSkillScopeAgentOptions,
+  getWorkflowAgentDisplay,
+  normalizeSkillScopeAgentId,
+  SINGLE_AGENT_ID,
+} from '@/components/WorkFlow/agents';
+
+describe('normalizeSkillScopeAgentId', () => {
+  it('canonicalizes Single Agent aliases to single_agent', () => {
+    expect(normalizeSkillScopeAgentId('single_agent')).toBe(SINGLE_AGENT_ID);
+    expect(normalizeSkillScopeAgentId('Agents.single_agent')).toBe(
+      SINGLE_AGENT_ID
+    );
+    expect(normalizeSkillScopeAgentId('foo.single_agent')).toBe(
+      SINGLE_AGENT_ID
+    );
+  });
+});
+
+describe('buildSkillScopeAgentOptions', () => {
+  it('always includes single_agent first so Skills scope can target Single Agent', () => {
+    const options = buildSkillScopeAgentOptions();
+    expect(options[0]).toEqual({
+      value: SINGLE_AGENT_ID,
+      label: 'Single Agent',
+    });
+    expect(options.some((option) => option.value === 'developer_agent')).toBe(
+      true
+    );
+    expect(options.some((option) => option.value === 'social_media_agent')).toBe(
+      false
+    );
+  });
+
+  it('keeps a single Single Agent entry when workerList repeats aliases', () => {
+    const options = buildSkillScopeAgentOptions([
+      { name: 'custom_worker' },
+      { name: 'developer_agent' },
+      { name: SINGLE_AGENT_ID },
+      { name: 'Agents.single_agent' },
+    ]);
+
+    expect(
+      options.filter((option) => option.value === SINGLE_AGENT_ID)
+    ).toHaveLength(1);
+    expect(options[0].value).toBe(SINGLE_AGENT_ID);
+    expect(
+      options.filter((option) => option.value === 'developer_agent')
+    ).toHaveLength(1);
+    expect(options.some((option) => option.value === 'custom_worker')).toBe(
+      true
+    );
+  });
+});
+
+describe('getWorkflowAgentDisplay', () => {
+  it('resolves single_agent display metadata', () => {
+    const display = getWorkflowAgentDisplay(SINGLE_AGENT_ID);
+    expect(display?.name).toBe('Single Agent');
+    expect(display?.icon).toBeTruthy();
+  });
+
+  it('resolves alias display metadata for Single Agent', () => {
+    expect(getWorkflowAgentDisplay('Agents.single_agent')?.name).toBe(
+      'Single Agent'
+    );
+  });
+});

--- a/test/unit/components/WorkFlow/skillScopeAgents.test.ts
+++ b/test/unit/components/WorkFlow/skillScopeAgents.test.ts
@@ -12,13 +12,13 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-import { describe, expect, it } from 'vitest';
 import {
   buildSkillScopeAgentOptions,
   getWorkflowAgentDisplay,
   normalizeSkillScopeAgentId,
   SINGLE_AGENT_ID,
 } from '@/components/WorkFlow/agents';
+import { describe, expect, it } from 'vitest';
 
 describe('normalizeSkillScopeAgentId', () => {
   it('canonicalizes Single Agent aliases to single_agent', () => {
@@ -27,7 +27,7 @@ describe('normalizeSkillScopeAgentId', () => {
       SINGLE_AGENT_ID
     );
     expect(normalizeSkillScopeAgentId('foo.single_agent')).toBe(
-      SINGLE_AGENT_ID
+      'foo.single_agent'
     );
   });
 });
@@ -42,9 +42,9 @@ describe('buildSkillScopeAgentOptions', () => {
     expect(options.some((option) => option.value === 'developer_agent')).toBe(
       true
     );
-    expect(options.some((option) => option.value === 'social_media_agent')).toBe(
-      false
-    );
+    expect(
+      options.some((option) => option.value === 'social_media_agent')
+    ).toBe(false);
   });
 
   it('keeps a single Single Agent entry when workerList repeats aliases', () => {
@@ -53,6 +53,7 @@ describe('buildSkillScopeAgentOptions', () => {
       { name: 'developer_agent' },
       { name: SINGLE_AGENT_ID },
       { name: 'Agents.single_agent' },
+      { name: 'foo.single_agent' },
     ]);
 
     expect(
@@ -63,6 +64,9 @@ describe('buildSkillScopeAgentOptions', () => {
       options.filter((option) => option.value === 'developer_agent')
     ).toHaveLength(1);
     expect(options.some((option) => option.value === 'custom_worker')).toBe(
+      true
+    );
+    expect(options.some((option) => option.value === 'foo.single_agent')).toBe(
       true
     );
   });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

Fixes #1756

### Description

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

The Skills page "Select agent access" list was Workforce-worker-centric, so binding a skill to **Single Agent** alone was incomplete/unreliable in the UI even though the backend already supports `single_agent` / `Agents.single_agent` scoping.

This PR:
- Always shows **Single Agent** (`single_agent`) first in Skills "Select agent access"
- Canonicalizes aliases (`Agents.single_agent`, `*.single_agent`) in the Skills UI and `SkillToolkit` matching
- Adds frontend + backend tests so Single Agent bindings round-trip with the backend

### Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->
<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->
<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

**Automated tests run locally:**
- `npx vitest run test/unit/components/WorkFlow/skillScopeAgents.test.ts`
- `pytest backend/tests/app/service/test_skill_initialization.py -k single_agent`

**Manual verification steps:**
1. Open Skills page → expand "Select agent access" → confirm **Single Agent** is the first chip
2. Bind a skill to Single Agent only → confirm config persists `selectedAgents: ["single_agent"]`
3. Run a Single Agent session and verify the scoped skill is available; a Workforce-only scoped skill is not

**UI evidence (required for this frontend change):**
- Screenshot / screen recording of Skills → "Select agent access" with **Single Agent** listed first (to be attached below)

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)