### PR TITLE
chore: bump camel-ai to 0.2.91a5

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.12"
 dependencies = [
     "pip>=23.0",
-    "camel-ai[eigent]==0.2.91a3",
+    "camel-ai[eigent]==0.2.91a5",
     "fastapi>=0.115.12",
     "fastapi-babel>=1.0.0",
     "uvicorn[standard]>=0.34.2",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -244,7 +244,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
-    { name = "camel-ai", extras = ["eigent"], specifier = "==0.2.91a3" },
+    { name = "camel-ai", extras = ["eigent"], specifier = "==0.2.91a5" },
     { name = "debugpy", specifier = ">=1.8.17" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "fastapi-babel", specifier = ">=1.0.0" },
@@ -315,7 +315,7 @@ wheels = [
 
 [[package]]
 name = "camel-ai"
-version = "0.2.91a3"
+version = "0.2.91a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astor" },
@@ -333,9 +333,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/ce/44a09fb47372d8ebea3a0c7aafefd5640caa1c1ab0cdfccfd0260de5b495/camel_ai-0.2.91a3.tar.gz", hash = "sha256:eb94ba4bd084967f55fe73568bbeda4a49d3bf5ac2eb79e018870df3661d1d85", size = 1230710, upload-time = "2026-04-25T14:00:37.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/c9/7015c4f4733b535e2f56eef9a4c1da7b9e49db8d209dc850e996f2b6b5da/camel_ai-0.2.91a5.tar.gz", hash = "sha256:9606d50d7ec4062cc44e0f4c085e043c7d5b7b2779ea66c4ac9142c98a3380a7", size = 1239665, upload-time = "2026-07-13T11:24:06.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/8c/ba682c71766bc61a1a1115af50bddb6040432f85784a0ec5df2ed91897a9/camel_ai-0.2.91a3-py3-none-any.whl", hash = "sha256:ead956ab8d2f22685cded8c03e7ecad6bdee3fee85041eb1488bdaad7e115372", size = 1718236, upload-time = "2026-04-25T14:00:34.606Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c7/80317df8f49ff9d16e8e29eb838b4f9e3f537a02c697c55b18bc6a24d9f4/camel_ai-0.2.91a5-py3-none-any.whl", hash = "sha256:dd1f3ce9ce324bbd29952d4f2020c5279d31ebc70c428661c258bdb67c9943d1", size = 1729980, upload-time = "2026-07-13T11:24:03.785Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Related Issue

Closes #1711

### Description

Bump `camel-ai[eigent]` from `0.2.91a3` to `0.2.91a5` and refresh the backend lockfile.

CAMEL `0.2.91a5` includes camel-ai/camel#4171, which keeps all tools available but disables strict input grammar constraints when an Anthropic request exceeds the provider's request-wide structured-output limits. This prevents Sonnet and Fable requests routed through LiteLLM from failing with `Too many strict tools` before inference starts.

### Testing Evidence (REQUIRED)

- `uvx --from uv==0.11.28 uv lock --check`
  - Passed; 208 packages resolved.
- `.venv/bin/pytest -q tests/app/model/test_chat.py tests/app/controller/test_model_controller.py`
  - `38 passed in 0.99s`
- Installed the frozen backend environment and confirmed `camel-ai 0.2.91a5` loads from the PyPI wheel.
- Replayed the two real 49-tool payloads that previously failed:
  - `claude-sonnet-5`: 49 tools retained, 0 tools left strict, original input unchanged.
  - `claude-fable-5`: 49 tools retained, 0 tools left strict, original input unchanged.

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [x] No frontend/UI changes in this PR.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Contribution Guidelines Acknowledgement

- [ ] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
