### PR TITLE
feat: support BYOK model parameters

### DIFF
--- a/backend/app/agent/agent_model.py
+++ b/backend/app/agent/agent_model.py
@@ -73,11 +73,21 @@ def agent_model(
 
     if custom_model_config and custom_model_config.has_custom_config():
         for attr in config_attrs:
-            effective_config[attr] = getattr(
-                custom_model_config, attr, None
-            ) or getattr(options, attr)
+            custom_value = getattr(custom_model_config, attr, None)
+            effective_config[attr] = (
+                custom_value
+                if custom_value is not None
+                else getattr(options, attr)
+            )
         extra_params = (
-            custom_model_config.extra_params or options.extra_params or {}
+            custom_model_config.extra_params
+            if custom_model_config.extra_params is not None
+            else options.extra_params or {}
+        )
+        explicit_model_config = (
+            custom_model_config.model_config_dict
+            if custom_model_config.model_config_dict is not None
+            else options.model_config_dict or {}
         )
         logger.info(
             f"Agent {agent_name} using custom model config: "
@@ -88,6 +98,7 @@ def agent_model(
         for attr in config_attrs:
             effective_config[attr] = getattr(options, attr)
         extra_params = options.extra_params or {}
+        explicit_model_config = options.model_config_dict or {}
 
     has_explicit_custom_api_key = (
         custom_model_config is not None
@@ -100,10 +111,12 @@ def agent_model(
 
     base_effective_config = dict(effective_config)
     base_extra_params = dict(extra_params or {})
+    base_model_config = dict(explicit_model_config or {})
 
     def build_model(force_refresh: bool = False):
         effective_config = dict(base_effective_config)
         extra_params = dict(base_extra_params)
+        explicit_model_config = dict(base_model_config)
 
         if use_subscription_runtime:
             effective_config, extra_params = apply_subscription_runtime(
@@ -113,10 +126,16 @@ def agent_model(
                 force_refresh=force_refresh,
             )
 
+        effective_api_url = effective_config.get("api_url")
+        is_effective_cloud = isinstance(effective_api_url, str) and any(
+            marker in effective_api_url
+            for marker in ("eigent-proxy", "proxy.eigent.ai")
+        )
+
         # Cloud mode: inject default Bedrock region and adjust URL for proxy.
         if (
             effective_config.get("model_platform") == "aws-bedrock-converse"
-            and options.is_cloud()
+            and is_effective_cloud
         ):
             (
                 effective_config["api_url"],
@@ -128,7 +147,7 @@ def agent_model(
         # construction does not blow up when the frontend omits extra_params.
         if (
             effective_config.get("model_platform") == "azure"
-            and options.is_cloud()
+            and is_effective_cloud
         ):
             extra_params = patch_azure_cloud_config(extra_params)
         init_param_keys = {
@@ -151,8 +170,10 @@ def agent_model(
         init_params = {}
         model_config: dict[str, Any] = {}
 
-        if options.is_cloud():
-            model_config["user"] = str(options.project_id)
+        # A nested model_config_dict may arrive inside legacy extra_params
+        # while stored providers migrate to the explicit top-level field.
+        # Treat it as less specific than the explicit request field.
+        nested_model_config = extra_params.pop("model_config_dict", None)
 
         excluded_keys = {"model_platform", "model_type", "api_key", "url"}
 
@@ -168,6 +189,13 @@ def agent_model(
                 init_params[k] = v
             else:
                 model_config[k] = v
+
+        if isinstance(nested_model_config, dict):
+            model_config.update(nested_model_config)
+
+        # The explicit model config is the canonical API and wins over legacy
+        # flat values from extra_params.
+        model_config.update(explicit_model_config)
 
         # Auto-inject prompt caching based on model platform
         try:
@@ -190,6 +218,12 @@ def agent_model(
                 exc_info=True,
             )
 
+        # Runtime-owned values are applied after user configuration.
+        if is_effective_cloud:
+            model_config["user"] = str(options.project_id)
+        if use_subscription_runtime:
+            model_config["stream"] = True
+            model_config["store"] = False
         if agent_name == Agents.task_agent:
             model_config["stream"] = True
         if agent_name == Agents.browser_agent:

--- a/backend/app/controller/task_controller.py
+++ b/backend/app/controller/task_controller.py
@@ -136,7 +136,13 @@ def add_agent(id: str, data: NewAgent):
     )
     logger.debug(
         "New agent data",
-        extra={"task_id": id, "agent_data": data.model_dump_json()},
+        extra={
+            "task_id": id,
+            "agent_name": data.name,
+            "tools": list(data.tools),
+            "has_mcp_tools": bool(data.mcp_tools),
+            "has_custom_model_config": data.custom_model_config is not None,
+        },
     )
     # Set user-specific environment path for this thread
     set_user_env_path(data.env_path)

--- a/backend/app/model/chat.py
+++ b/backend/app/model/chat.py
@@ -83,6 +83,10 @@ class Chat(BaseModel):
     env_path: str | None = None
     summary_prompt: str = DEFAULT_SUMMARY_PROMPT
     new_agents: list["NewAgent"] = []
+    # Parameters forwarded with each inference request, such as temperature,
+    # top_p, or max_tokens. Constructor-only provider settings remain in
+    # extra_params for backward compatibility.
+    model_config_dict: dict[str, Any] | None = None
     # For provider-specific parameters like Azure
     extra_params: dict | None = None
     # User-specific search engine configurations
@@ -230,6 +234,7 @@ class AgentModelConfig(BaseModel):
     model_type: str | None = None
     api_key: str | None = None
     api_url: str | None = None
+    model_config_dict: dict[str, Any] | None = None
     extra_params: dict | None = None
 
     def has_custom_config(self) -> bool:
@@ -240,6 +245,7 @@ class AgentModelConfig(BaseModel):
                 self.model_type is not None,
                 self.api_key is not None,
                 self.api_url is not None,
+                self.model_config_dict is not None,
                 self.extra_params is not None,
             ]
         )

--- a/backend/app/service/chat_service.py
+++ b/backend/app/service/chat_service.py
@@ -2810,7 +2810,15 @@ async def new_agent_model(
         },
     )
     logger.debug(
-        "New agent data", extra={"agent_data": data.model_dump_json()}
+        "New agent data",
+        extra={
+            "agent_name": data.name,
+            "tools": list(data.tools),
+            "has_mcp_tools": bool(data.mcp_tools),
+            "has_custom_model_config": (
+                getattr(data, "custom_model_config", None) is not None
+            ),
+        },
     )
     working_directory = get_working_directory(options)
     tool_names = []

--- a/backend/tests/app/agent/test_agent_model.py
+++ b/backend/tests/app/agent/test_agent_model.py
@@ -18,7 +18,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.agent.agent_model import agent_model
-from app.model.chat import Chat
+from app.model.chat import AgentModelConfig, Chat
+from app.service.task import Agents
 
 pytestmark = pytest.mark.unit
 
@@ -67,6 +68,7 @@ class TestAgentFactoryFunctions:
                 "model_platform": "openai",
                 "model_type": "gpt-5.5",
                 "auth_source": "codex_subscription",
+                "model_config_dict": {"stream": False, "store": True},
             }
         )
         monkeypatch.setenv("CODEX_RESOLVER_URL", "http://127.0.0.1:12345")
@@ -154,6 +156,232 @@ class TestAgentFactoryFunctions:
         assert "store" not in model_config
         assert kwargs["url"] == "https://api.openai.com/v1"
 
+    def test_explicit_model_config_wins_over_legacy_extra_params(
+        self, sample_chat_data
+    ):
+        options = Chat(
+            **{
+                **sample_chat_data,
+                "extra_params": {
+                    "temperature": 0.8,
+                    "top_p": 0.6,
+                    "max_retries": 7,
+                    "model_config_dict": {
+                        "temperature": 0.5,
+                        "presence_penalty": 0.1,
+                    },
+                },
+                "model_config_dict": {
+                    "temperature": 0.2,
+                    "max_tokens": 2048,
+                },
+            }
+        )
+
+        from app.service.task import task_locks
+
+        mock_task_lock = MagicMock()
+        mock_task_lock.put_queue = MagicMock(return_value=None)
+        task_locks[options.project_id] = mock_task_lock
+
+        _m = sys.modules["app.agent.agent_model"]
+        with (
+            patch.object(_m, "ListenChatAgent"),
+            patch.object(_m, "ModelFactory") as mock_model_factory,
+            patch.object(_m, "get_task_lock", return_value=mock_task_lock),
+            patch.object(_m, "_schedule_async_task"),
+        ):
+            mock_model_factory.create.return_value = MagicMock()
+
+            agent_model("TestAgent", "You are helpful", options, [])
+
+        kwargs = mock_model_factory.create.call_args.kwargs
+        assert kwargs["max_retries"] == 7
+        assert kwargs["model_config_dict"]["temperature"] == 0.2
+        assert kwargs["model_config_dict"]["top_p"] == 0.6
+        assert kwargs["model_config_dict"]["presence_penalty"] == 0.1
+        assert kwargs["model_config_dict"]["max_tokens"] == 2048
+        assert "max_retries" not in kwargs["model_config_dict"]
+        assert "model_config_dict" not in kwargs["model_config_dict"]
+
+    def test_runtime_owned_agent_model_values_override_user_config(
+        self, sample_chat_data
+    ):
+        options = Chat(
+            **{
+                **sample_chat_data,
+                "model_config_dict": {
+                    "stream": False,
+                    "parallel_tool_calls": True,
+                },
+            }
+        )
+
+        from app.service.task import task_locks
+
+        mock_task_lock = MagicMock()
+        mock_task_lock.put_queue = MagicMock(return_value=None)
+        task_locks[options.project_id] = mock_task_lock
+
+        _m = sys.modules["app.agent.agent_model"]
+        with (
+            patch.object(_m, "ListenChatAgent"),
+            patch.object(_m, "ModelFactory") as mock_model_factory,
+            patch.object(_m, "get_task_lock", return_value=mock_task_lock),
+            patch.object(_m, "_schedule_async_task"),
+        ):
+            mock_model_factory.create.return_value = MagicMock()
+
+            agent_model(Agents.task_agent, "Task agent", options, [])
+            agent_model(Agents.browser_agent, "Browser agent", options, [])
+
+        task_config = mock_model_factory.create.call_args_list[0].kwargs[
+            "model_config_dict"
+        ]
+        browser_config = mock_model_factory.create.call_args_list[1].kwargs[
+            "model_config_dict"
+        ]
+        assert task_config["stream"] is True
+        assert browser_config["parallel_tool_calls"] is False
+
+    def test_per_agent_explicit_model_config_overrides_task_config(
+        self, sample_chat_data
+    ):
+        options = Chat(
+            **{
+                **sample_chat_data,
+                "model_config_dict": {"temperature": 0.7, "top_p": 0.8},
+            }
+        )
+        custom_config = AgentModelConfig(
+            model_config_dict={"temperature": 0.1}
+        )
+
+        from app.service.task import task_locks
+
+        mock_task_lock = MagicMock()
+        mock_task_lock.put_queue = MagicMock(return_value=None)
+        task_locks[options.project_id] = mock_task_lock
+
+        _m = sys.modules["app.agent.agent_model"]
+        with (
+            patch.object(_m, "ListenChatAgent"),
+            patch.object(_m, "ModelFactory") as mock_model_factory,
+            patch.object(_m, "get_task_lock", return_value=mock_task_lock),
+            patch.object(_m, "_schedule_async_task"),
+        ):
+            mock_model_factory.create.return_value = MagicMock()
+
+            agent_model(
+                "CustomAgent",
+                "Custom agent",
+                options,
+                [],
+                custom_model_config=custom_config,
+            )
+
+        model_config = mock_model_factory.create.call_args.kwargs[
+            "model_config_dict"
+        ]
+        assert model_config["temperature"] == 0.1
+        assert "top_p" not in model_config
+
+    def test_per_agent_empty_credentials_do_not_inherit_task_credentials(
+        self, sample_chat_data
+    ):
+        options = Chat(**sample_chat_data)
+        custom_config = AgentModelConfig(
+            model_platform="aws-bedrock-converse",
+            model_type="anthropic.claude-3-5-sonnet-20241022-v2:0",
+            api_key="",
+            api_url="",
+            extra_params={
+                "region_name": "us-east-1",
+                "aws_access_key_id": "worker-access-key",
+                "aws_secret_access_key": "worker-secret-key",
+            },
+        )
+
+        from app.service.task import task_locks
+
+        mock_task_lock = MagicMock()
+        mock_task_lock.put_queue = MagicMock(return_value=None)
+        task_locks[options.project_id] = mock_task_lock
+
+        _m = sys.modules["app.agent.agent_model"]
+        with (
+            patch.object(_m, "ListenChatAgent"),
+            patch.object(_m, "ModelFactory") as mock_model_factory,
+            patch.object(_m, "get_task_lock", return_value=mock_task_lock),
+            patch.object(_m, "_schedule_async_task"),
+        ):
+            mock_model_factory.create.return_value = MagicMock()
+
+            agent_model(
+                "BedrockAgent",
+                "Bedrock agent",
+                options,
+                [],
+                custom_model_config=custom_config,
+            )
+
+        kwargs = mock_model_factory.create.call_args.kwargs
+        assert kwargs["api_key"] == ""
+        assert kwargs["url"] == ""
+        assert kwargs["aws_access_key_id"] == "worker-access-key"
+        assert kwargs["aws_secret_access_key"] == "worker-secret-key"
+
+    def test_direct_per_agent_provider_is_not_treated_as_task_cloud_model(
+        self, sample_chat_data
+    ):
+        options = Chat(
+            **{
+                **sample_chat_data,
+                "api_url": "https://eigent-proxy.example.com",
+            }
+        )
+        custom_config = AgentModelConfig(
+            model_platform="aws-bedrock-converse",
+            model_type="anthropic.claude-3-5-sonnet-20241022-v2:0",
+            api_key="",
+            api_url="https://bedrock-runtime.us-east-1.amazonaws.com",
+            extra_params={
+                "region_name": "eu-west-1",
+                "aws_access_key_id": "worker-access-key",
+                "aws_secret_access_key": "worker-secret-key",
+            },
+        )
+
+        from app.service.task import task_locks
+
+        mock_task_lock = MagicMock()
+        mock_task_lock.put_queue = MagicMock(return_value=None)
+        task_locks[options.project_id] = mock_task_lock
+
+        _m = sys.modules["app.agent.agent_model"]
+        with (
+            patch.object(_m, "ListenChatAgent"),
+            patch.object(_m, "ModelFactory") as mock_model_factory,
+            patch.object(_m, "get_task_lock", return_value=mock_task_lock),
+            patch.object(_m, "_schedule_async_task"),
+        ):
+            mock_model_factory.create.return_value = MagicMock()
+
+            agent_model(
+                "BedrockAgent",
+                "Bedrock agent",
+                options,
+                [],
+                custom_model_config=custom_config,
+            )
+
+        kwargs = mock_model_factory.create.call_args.kwargs
+        assert kwargs["url"] == (
+            "https://bedrock-runtime.us-east-1.amazonaws.com"
+        )
+        assert kwargs["region_name"] == "eu-west-1"
+        assert "user" not in (kwargs["model_config_dict"] or {})
+
     def test_agent_model_with_missing_options(self):
         """Test agent_model with missing required options."""
         agent_name = "ErrorAgent"
@@ -184,7 +412,7 @@ class TestAgentIntegration:
 
         # Create task lock
         mock_task_lock = MagicMock()
-        mock_task_lock.put_queue = AsyncMock()
+        mock_task_lock.put_queue = MagicMock(return_value=None)
         task_locks[api_task_id] = mock_task_lock
 
         # Create agent

--- a/backend/tests/app/controller/test_task_controller.py
+++ b/backend/tests/app/controller/test_task_controller.py
@@ -25,7 +25,7 @@ from app.controller.task_controller import (
     start,
     take_control,
 )
-from app.model.chat import NewAgent, TaskContent, UpdateData
+from app.model.chat import AgentModelConfig, NewAgent, TaskContent, UpdateData
 from app.service.task import Action
 
 
@@ -126,6 +126,11 @@ class TestTaskController:
             tools=["search", "code"],
             mcp_tools=None,
             env_path=".env",
+            custom_model_config=AgentModelConfig(
+                model_platform="aws-bedrock-converse",
+                api_key="super-secret-api-key",
+                extra_params={"aws_secret_access_key": "super-secret-aws-key"},
+            ),
         )
 
         with (
@@ -137,12 +142,26 @@ class TestTaskController:
             patch(
                 "app.controller.task_controller._queue_action_from_worker"
             ) as mock_queue_action,
+            patch("app.controller.task_controller.logger") as mock_logger,
         ):
             response = add_agent(task_id, new_agent)
 
             assert isinstance(response, Response)
             assert response.status_code == 204
             mock_queue_action.assert_called_once()
+            mock_logger.debug.assert_called_once_with(
+                "New agent data",
+                extra={
+                    "task_id": task_id,
+                    "agent_name": "Test Agent",
+                    "tools": ["search", "code"],
+                    "has_mcp_tools": False,
+                    "has_custom_model_config": True,
+                },
+            )
+            logged_calls = repr(mock_logger.mock_calls)
+            assert "super-secret-api-key" not in logged_calls
+            assert "super-secret-aws-key" not in logged_calls
 
     def test_start_task_nonexistent_task(self):
         """Test start task with nonexistent task ID."""

--- a/backend/tests/app/model/test_chat.py
+++ b/backend/tests/app/model/test_chat.py
@@ -30,6 +30,7 @@ class TestAgentModelConfig:
         assert config.model_type is None
         assert config.api_key is None
         assert config.api_url is None
+        assert config.model_config_dict is None
         assert config.extra_params is None
 
     def test_agent_model_config_creation_with_values(self):
@@ -39,13 +40,18 @@ class TestAgentModelConfig:
             model_type="gpt-4",
             api_key="test-key",
             api_url="https://api.openai.com/v1",
-            extra_params={"temperature": 0.7},
+            model_config_dict={"temperature": 0.7, "stream": False},
+            extra_params={"api_version": "2025-01-01"},
         )
         assert config.model_platform == "openai"
         assert config.model_type == "gpt-4"
         assert config.api_key == "test-key"
         assert config.api_url == "https://api.openai.com/v1"
-        assert config.extra_params == {"temperature": 0.7}
+        assert config.model_config_dict == {
+            "temperature": 0.7,
+            "stream": False,
+        }
+        assert config.extra_params == {"api_version": "2025-01-01"}
 
     def test_has_custom_config_false_when_empty(self):
         """Test has_custom_config returns False for empty config."""
@@ -73,6 +79,36 @@ class TestAgentModelConfig:
         """Test has_custom_config returns True with only api_key."""
         config = AgentModelConfig(api_key="some-key")
         assert config.has_custom_config() is True
+
+    def test_has_custom_config_true_with_only_model_config_dict(self):
+        config = AgentModelConfig(model_config_dict={"temperature": 0.2})
+
+        assert config.has_custom_config() is True
+
+
+class TestChatModelConfig:
+    def test_chat_accepts_and_serializes_model_config_dict(
+        self, sample_chat_data
+    ):
+        chat = Chat(
+            **{
+                **sample_chat_data,
+                "model_config_dict": {
+                    "temperature": 0.2,
+                    "top_p": 0.9,
+                    "response_format": {"type": "json_object"},
+                },
+            }
+        )
+
+        assert chat.model_config_dict == {
+            "temperature": 0.2,
+            "top_p": 0.9,
+            "response_format": {"type": "json_object"},
+        }
+        assert chat.model_dump()["model_config_dict"] == (
+            chat.model_config_dict
+        )
 
 
 class TestNewAgentWithModelConfig:

--- a/backend/tests/app/service/test_chat_service.py
+++ b/backend/tests/app/service/test_chat_service.py
@@ -20,7 +20,7 @@ import pytest
 from camel.tasks import Task
 from camel.tasks.task import TaskState
 
-from app.model.chat import Chat, NewAgent
+from app.model.chat import AgentModelConfig, Chat, NewAgent
 from app.service.chat_service import (
     _extract_stream_chunk_content,
     _render_subtask_report,
@@ -1024,6 +1024,11 @@ class TestChatServiceAgentOperations:
             tools=["search", "code"],
             mcp_tools=None,
             env_path=".env",
+            custom_model_config=AgentModelConfig(
+                model_platform="aws-bedrock-converse",
+                api_key="super-secret-api-key",
+                extra_params={"aws_secret_access_key": "super-secret-aws-key"},
+            ),
         )
 
         mock_agent = MagicMock()
@@ -1038,10 +1043,23 @@ class TestChatServiceAgentOperations:
                 "app.agent.toolkit.human_toolkit.get_task_lock",
                 return_value=MagicMock(),
             ),
+            patch("app.service.chat_service.logger") as mock_logger,
         ):
             result = await new_agent_model(agent_data, options)
 
             assert result is mock_agent
+            mock_logger.debug.assert_any_call(
+                "New agent data",
+                extra={
+                    "agent_name": "TestAgent",
+                    "tools": ["search", "code"],
+                    "has_mcp_tools": False,
+                    "has_custom_model_config": True,
+                },
+            )
+            logged_calls = repr(mock_logger.mock_calls)
+            assert "super-secret-api-key" not in logged_calls
+            assert "super-secret-aws-key" not in logged_calls
 
     @pytest.mark.asyncio
     async def test_construct_workforce(self, sample_chat_data, mock_task_lock):

--- a/src/components/AddWorker/index.tsx
+++ b/src/components/AddWorker/index.tsx
@@ -37,6 +37,11 @@ import { Textarea } from '@/components/ui/textarea';
 import useChatStoreAdapter from '@/hooks/useChatStoreAdapter';
 import { INIT_PROVODERS } from '@/lib/llm';
 import {
+  type AgentModelConfigSource,
+  buildAgentModelConfig,
+  buildAgentModelConfigFromProvider,
+} from '@/lib/modelConfig';
+import {
   getLocalPlatformName,
   LOCAL_MODEL_OPTIONS,
 } from '@/pages/Agents/localModels';
@@ -71,11 +76,10 @@ interface McpItem {
 
 type WorkerModelMode = 'eigent' | 'custom' | 'local';
 
-interface WorkerModelOption {
+interface WorkerModelOption extends AgentModelConfigSource {
   value: string;
   label: string;
-  model_platform: string;
-  model_type: string;
+  provider_id?: number;
 }
 
 export function AddWorker({
@@ -125,6 +129,7 @@ export function AddWorker({
   const [workerModelMode, setWorkerModelMode] =
     useState<WorkerModelMode>('eigent');
   const [workerModelName, setWorkerModelName] = useState('');
+  const [modelSelectionTouched, setModelSelectionTouched] = useState(false);
   const [customModelOptions, setCustomModelOptions] = useState<
     WorkerModelOption[]
   >([]);
@@ -300,6 +305,7 @@ export function AddWorker({
     setShowModelConfig(false);
     setWorkerModelMode('eigent');
     setWorkerModelName('');
+    setModelSelectionTouched(false);
     setCustomModelOptions([]);
     setLocalModelOptions([]);
   };
@@ -322,10 +328,63 @@ export function AddWorker({
     setWorkerName(workerInfo.workerInfo?.name || '');
     setWorkerDescription(workerInfo.workerInfo?.description || '');
     setSelectedTools(workerInfo.workerInfo?.selectedTools || []);
+    setWorkerModelMode('eigent');
+    setWorkerModelName('');
+    setModelSelectionTouched(false);
+    setShowModelConfig(
+      Number.isInteger(workerInfo.workerInfo?.model_provider_id)
+    );
   }, [dialogOpen, edit, workerInfo]);
 
   useEffect(() => {
+    if (
+      !dialogOpen ||
+      !edit ||
+      !showModelConfig ||
+      !workerInfo ||
+      modelSelectionTouched
+    )
+      return;
+    const providerId = workerInfo.workerInfo?.model_provider_id;
+    if (!Number.isInteger(providerId)) return;
+
+    const customOption = customModelOptions.find(
+      (option) => option.provider_id === providerId
+    );
+    if (customOption) {
+      setWorkerModelMode('custom');
+      setWorkerModelName(customOption.value);
+      return;
+    }
+
+    const localOption = localModelOptions.find(
+      (option) => option.provider_id === providerId
+    );
+    if (localOption) {
+      setWorkerModelMode('local');
+      setWorkerModelName(localOption.value);
+    }
+  }, [
+    customModelOptions,
+    dialogOpen,
+    edit,
+    localModelOptions,
+    modelSelectionTouched,
+    showModelConfig,
+    workerInfo,
+  ]);
+
+  useEffect(() => {
     if (!showModelConfig) return;
+    const editingProviderId = workerInfo?.workerInfo?.model_provider_id;
+    if (
+      dialogOpen &&
+      edit &&
+      Number.isInteger(editingProviderId) &&
+      !modelSelectionTouched
+    ) {
+      return;
+    }
     const options = activeWorkerModelOptions;
     if (options.length === 0) {
       setWorkerModelName('');
@@ -334,7 +393,15 @@ export function AddWorker({
     if (!options.some((opt) => opt.value === workerModelName)) {
       setWorkerModelName(options[0].value);
     }
-  }, [activeWorkerModelOptions, showModelConfig, workerModelName]);
+  }, [
+    activeWorkerModelOptions,
+    dialogOpen,
+    edit,
+    modelSelectionTouched,
+    showModelConfig,
+    workerInfo,
+    workerModelName,
+  ]);
 
   useEffect(() => {
     if (!showModelConfig) return;
@@ -358,6 +425,8 @@ export function AddWorker({
           .map((provider: any) => {
             const modelType = String(provider.model_type || '');
             const providerName = String(provider.provider_name || '');
+            const agentModelConfig =
+              buildAgentModelConfigFromProvider(provider);
             return {
               value: `${providerName}::${modelType}`,
               label: modelType
@@ -365,6 +434,11 @@ export function AddWorker({
                 : providerName,
               model_platform: providerName,
               model_type: modelType,
+              provider_id: Number(provider.id),
+              api_key: agentModelConfig.api_key,
+              api_url: agentModelConfig.api_url,
+              model_config_dict: agentModelConfig.model_config_dict,
+              extra_params: agentModelConfig.extra_params,
             };
           });
 
@@ -373,13 +447,10 @@ export function AddWorker({
             localProviderIds.has(provider.provider_name)
           )
           .map((provider: any) => {
-            const config = provider.encrypted_config || {};
-            const modelPlatform = String(
-              config.model_platform || provider.provider_name || ''
-            );
-            const modelType = String(
-              config.model_type || provider.model_type || ''
-            );
+            const agentModelConfig =
+              buildAgentModelConfigFromProvider(provider);
+            const modelPlatform = agentModelConfig.model_platform;
+            const modelType = agentModelConfig.model_type || '';
             const platformName = getLocalPlatformName(modelPlatform);
             return {
               value: `${modelPlatform}::${modelType}`,
@@ -388,6 +459,11 @@ export function AddWorker({
                 : platformName,
               model_platform: modelPlatform,
               model_type: modelType,
+              provider_id: Number(provider.id),
+              api_key: agentModelConfig.api_key,
+              api_url: agentModelConfig.api_url,
+              model_config_dict: agentModelConfig.model_config_dict,
+              extra_params: agentModelConfig.extra_params,
             };
           });
 
@@ -451,6 +527,23 @@ export function AddWorker({
         }
       }
     }
+    const selectedModelOption = workerModelOptions[workerModelMode].find(
+      (option) => option.value === workerModelName
+    );
+    const customModelConfig =
+      showModelConfig && selectedModelOption
+        ? buildAgentModelConfig(selectedModelOption)
+        : undefined;
+    const modelProviderId =
+      showModelConfig && selectedModelOption?.provider_id
+        ? selectedModelOption.provider_id
+        : showModelConfig &&
+            edit &&
+            !modelSelectionTouched &&
+            Number.isInteger(workerInfo?.workerInfo?.model_provider_id)
+          ? workerInfo?.workerInfo?.model_provider_id
+          : undefined;
+
     if (edit) {
       const newWorkerList = workerList.map((worker) => {
         if (worker.type === workerInfo?.type) {
@@ -473,6 +566,7 @@ export function AddWorker({
               tools: localTool,
               mcp_tools: mcpLocal,
               selectedTools: JSON.parse(JSON.stringify(selectedTools)),
+              model_provider_id: modelProviderId,
             },
           };
           return {
@@ -503,22 +597,12 @@ export function AddWorker({
           tools: localTool,
           mcp_tools: mcpLocal,
           selectedTools: JSON.parse(JSON.stringify(selectedTools)),
+          model_provider_id: modelProviderId,
         },
       };
       setWorkerList([...workerList, worker]);
     } else {
       // Add-worker custom model config is applied to this agent only.
-      const selectedModelOption = workerModelOptions[workerModelMode].find(
-        (opt) => opt.value === workerModelName
-      );
-      const customModelConfig =
-        showModelConfig && selectedModelOption
-          ? {
-              model_platform: selectedModelOption.model_platform,
-              model_type: selectedModelOption.model_type || undefined,
-            }
-          : undefined;
-
       if (activeProjectId) {
         fetchPost(`/task/${activeProjectId}/add-agent`, {
           name: workerName,
@@ -542,6 +626,7 @@ export function AddWorker({
           tools: localTool,
           mcp_tools: mcpLocal,
           selectedTools: JSON.parse(JSON.stringify(selectedTools)),
+          model_provider_id: modelProviderId,
         },
       };
       setWorkerList([...workerList, worker]);
@@ -753,6 +838,7 @@ export function AddWorker({
                     <Switch
                       checked={showModelConfig}
                       onCheckedChange={(checked) => {
+                        setModelSelectionTouched(true);
                         setShowModelConfig(checked);
                         if (!checked) {
                           setWorkerModelName('');
@@ -771,9 +857,10 @@ export function AddWorker({
                         </label>
                         <Select
                           value={workerModelMode}
-                          onValueChange={(value) =>
-                            setWorkerModelMode(value as WorkerModelMode)
-                          }
+                          onValueChange={(value) => {
+                            setModelSelectionTouched(true);
+                            setWorkerModelMode(value as WorkerModelMode);
+                          }}
                         >
                           <SelectTrigger
                             className="w-full"
@@ -803,7 +890,10 @@ export function AddWorker({
                         </label>
                         <Select
                           value={workerModelName}
-                          onValueChange={setWorkerModelName}
+                          onValueChange={(value) => {
+                            setModelSelectionTouched(true);
+                            setWorkerModelName(value);
+                          }}
                         >
                           <SelectTrigger
                             className="w-full"

--- a/src/i18n/locales/ar/setting.json
+++ b/src/i18n/locales/ar/setting.json
@@ -198,6 +198,9 @@
   "api-key-setting": "إعداد مفتاح API",
   "api-host-setting": "إعداد مضيف API",
   "model-type-setting": "إعداد نوع النموذج",
+  "model-parameters-setting": "معلمات النموذج (JSON، اختياري)",
+  "model-parameters-placeholder": "أدخل معلمات النموذج ككائن JSON، مثال: {\"temperature\": 0.7}",
+  "model-parameters-must-be-valid-json-object": "يجب أن تكون معلمات النموذج كائن JSON صالحًا.",
   "please-select": "يرجى الاختيار",
   "configuring": "جارٍ التكوين...",
 

--- a/src/i18n/locales/ar/setting.json
+++ b/src/i18n/locales/ar/setting.json
@@ -199,7 +199,7 @@
   "api-host-setting": "إعداد مضيف API",
   "model-type-setting": "إعداد نوع النموذج",
   "model-parameters-setting": "معلمات النموذج (JSON، اختياري)",
-  "model-parameters-placeholder": "أدخل معلمات النموذج ككائن JSON، مثال: {\"temperature\": 0.7}",
+  "model-parameters-placeholder": "أدخل معلمات النموذج ككائن JSON، مثال: {\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}",
   "model-parameters-must-be-valid-json-object": "يجب أن تكون معلمات النموذج كائن JSON صالحًا.",
   "please-select": "يرجى الاختيار",
   "configuring": "جارٍ التكوين...",

--- a/src/i18n/locales/de/setting.json
+++ b/src/i18n/locales/de/setting.json
@@ -300,6 +300,9 @@
   "api-key-setting": "API-Schlüssel-Einstellung",
   "api-host-setting": "API-Host-Einstellung",
   "model-type-setting": "Modelltyp-Einstellung",
+  "model-parameters-setting": "Modellparameter (JSON, optional)",
+  "model-parameters-placeholder": "Modellparameter als JSON-Objekt eingeben, z. B. {\"temperature\": 0.7}",
+  "model-parameters-must-be-valid-json-object": "Modellparameter müssen ein gültiges JSON-Objekt sein.",
   "please-select": "Bitte auswählen",
   "configuring": "Wird konfiguriert...",
 

--- a/src/i18n/locales/de/setting.json
+++ b/src/i18n/locales/de/setting.json
@@ -301,7 +301,7 @@
   "api-host-setting": "API-Host-Einstellung",
   "model-type-setting": "Modelltyp-Einstellung",
   "model-parameters-setting": "Modellparameter (JSON, optional)",
-  "model-parameters-placeholder": "Modellparameter als JSON-Objekt eingeben, z. B. {\"temperature\": 0.7}",
+  "model-parameters-placeholder": "Modellparameter als JSON-Objekt eingeben, z. B. {\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}",
   "model-parameters-must-be-valid-json-object": "Modellparameter müssen ein gültiges JSON-Objekt sein.",
   "please-select": "Bitte auswählen",
   "configuring": "Wird konfiguriert...",

--- a/src/i18n/locales/en-us/setting.json
+++ b/src/i18n/locales/en-us/setting.json
@@ -227,7 +227,7 @@
   "api-host-setting": "API Host Setting",
   "model-type-setting": "Model Type Setting",
   "model-parameters-setting": "Model Parameters (JSON) (Optional)",
-  "model-parameters-placeholder": "Enter model parameters as a JSON object, e.g. {\"temperature\": 0.7}",
+  "model-parameters-placeholder": "Enter model parameters as a JSON object, e.g. {\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}",
   "model-parameters-must-be-valid-json-object": "Model parameters must be a valid JSON object.",
   "please-select": "Please select",
   "configuring": "Configuring...",

--- a/src/i18n/locales/en-us/setting.json
+++ b/src/i18n/locales/en-us/setting.json
@@ -226,6 +226,9 @@
   "api-key-setting": "API Key Setting",
   "api-host-setting": "API Host Setting",
   "model-type-setting": "Model Type Setting",
+  "model-parameters-setting": "Model Parameters (JSON) (Optional)",
+  "model-parameters-placeholder": "Enter model parameters as a JSON object, e.g. {\"temperature\": 0.7}",
+  "model-parameters-must-be-valid-json-object": "Model parameters must be a valid JSON object.",
   "please-select": "Please select",
   "configuring": "Configuring...",
 

--- a/src/i18n/locales/es/setting.json
+++ b/src/i18n/locales/es/setting.json
@@ -301,7 +301,7 @@
   "api-host-setting": "Configuración de host API",
   "model-type-setting": "Configuración de tipo de modelo",
   "model-parameters-setting": "Parámetros del modelo (JSON, opcional)",
-  "model-parameters-placeholder": "Introduce los parámetros del modelo como un objeto JSON, p. ej. {\"temperature\": 0.7}",
+  "model-parameters-placeholder": "Introduce los parámetros del modelo como un objeto JSON, p. ej. {\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}",
   "model-parameters-must-be-valid-json-object": "Los parámetros del modelo deben ser un objeto JSON válido.",
   "please-select": "Por favor seleccione",
   "configuring": "Configurando...",

--- a/src/i18n/locales/es/setting.json
+++ b/src/i18n/locales/es/setting.json
@@ -300,6 +300,9 @@
   "api-key-setting": "Configuración de clave API",
   "api-host-setting": "Configuración de host API",
   "model-type-setting": "Configuración de tipo de modelo",
+  "model-parameters-setting": "Parámetros del modelo (JSON, opcional)",
+  "model-parameters-placeholder": "Introduce los parámetros del modelo como un objeto JSON, p. ej. {\"temperature\": 0.7}",
+  "model-parameters-must-be-valid-json-object": "Los parámetros del modelo deben ser un objeto JSON válido.",
   "please-select": "Por favor seleccione",
   "configuring": "Configurando...",
 

--- a/src/i18n/locales/fr/setting.json
+++ b/src/i18n/locales/fr/setting.json
@@ -301,7 +301,7 @@
   "api-host-setting": "Paramètre d'hôte API",
   "model-type-setting": "Paramètre de type de modèle",
   "model-parameters-setting": "Paramètres du modèle (JSON, facultatif)",
-  "model-parameters-placeholder": "Saisissez les paramètres du modèle sous forme d’objet JSON, par ex. {\"temperature\": 0.7}",
+  "model-parameters-placeholder": "Saisissez les paramètres du modèle sous forme d’objet JSON, par ex. {\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}",
   "model-parameters-must-be-valid-json-object": "Les paramètres du modèle doivent être un objet JSON valide.",
   "please-select": "Veuillez sélectionner",
   "configuring": "Configuration...",

--- a/src/i18n/locales/fr/setting.json
+++ b/src/i18n/locales/fr/setting.json
@@ -300,6 +300,9 @@
   "api-key-setting": "Paramètre de clé API",
   "api-host-setting": "Paramètre d'hôte API",
   "model-type-setting": "Paramètre de type de modèle",
+  "model-parameters-setting": "Paramètres du modèle (JSON, facultatif)",
+  "model-parameters-placeholder": "Saisissez les paramètres du modèle sous forme d’objet JSON, par ex. {\"temperature\": 0.7}",
+  "model-parameters-must-be-valid-json-object": "Les paramètres du modèle doivent être un objet JSON valide.",
   "please-select": "Veuillez sélectionner",
   "configuring": "Configuration...",
 

--- a/src/i18n/locales/it/setting.json
+++ b/src/i18n/locales/it/setting.json
@@ -301,7 +301,7 @@
   "api-host-setting": "Impostazione host API",
   "model-type-setting": "Impostazione tipo di modello",
   "model-parameters-setting": "Parametri del modello (JSON, facoltativo)",
-  "model-parameters-placeholder": "Inserisci i parametri del modello come oggetto JSON, ad es. {\"temperature\": 0.7}",
+  "model-parameters-placeholder": "Inserisci i parametri del modello come oggetto JSON, ad es. {\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}",
   "model-parameters-must-be-valid-json-object": "I parametri del modello devono essere un oggetto JSON valido.",
   "please-select": "Seleziona",
   "configuring": "Configurazione in corso...",

--- a/src/i18n/locales/it/setting.json
+++ b/src/i18n/locales/it/setting.json
@@ -300,6 +300,9 @@
   "api-key-setting": "Impostazione chiave API",
   "api-host-setting": "Impostazione host API",
   "model-type-setting": "Impostazione tipo di modello",
+  "model-parameters-setting": "Parametri del modello (JSON, facoltativo)",
+  "model-parameters-placeholder": "Inserisci i parametri del modello come oggetto JSON, ad es. {\"temperature\": 0.7}",
+  "model-parameters-must-be-valid-json-object": "I parametri del modello devono essere un oggetto JSON valido.",
   "please-select": "Seleziona",
   "configuring": "Configurazione in corso...",
 

--- a/src/i18n/locales/ja/setting.json
+++ b/src/i18n/locales/ja/setting.json
@@ -302,7 +302,7 @@
   "api-host-setting": "APIホスト設定",
   "model-type-setting": "モデルタイプ設定",
   "model-parameters-setting": "モデルパラメータ（JSON、任意）",
-  "model-parameters-placeholder": "モデルパラメータを JSON オブジェクトで入力（例：{\"temperature\": 0.7}）",
+  "model-parameters-placeholder": "モデルパラメータを JSON オブジェクトで入力（例：{\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}）",
   "model-parameters-must-be-valid-json-object": "モデルパラメータは有効な JSON オブジェクトである必要があります。",
   "please-select": "選択してください",
   "configuring": "設定中...",

--- a/src/i18n/locales/ja/setting.json
+++ b/src/i18n/locales/ja/setting.json
@@ -301,6 +301,9 @@
   "api-key-setting": "APIキー設定",
   "api-host-setting": "APIホスト設定",
   "model-type-setting": "モデルタイプ設定",
+  "model-parameters-setting": "モデルパラメータ（JSON、任意）",
+  "model-parameters-placeholder": "モデルパラメータを JSON オブジェクトで入力（例：{\"temperature\": 0.7}）",
+  "model-parameters-must-be-valid-json-object": "モデルパラメータは有効な JSON オブジェクトである必要があります。",
   "please-select": "選択してください",
   "configuring": "設定中...",
 

--- a/src/i18n/locales/ko/setting.json
+++ b/src/i18n/locales/ko/setting.json
@@ -302,7 +302,7 @@
   "api-host-setting": "API 호스트 설정",
   "model-type-setting": "모델 타입 설정",
   "model-parameters-setting": "모델 매개변수(JSON, 선택 사항)",
-  "model-parameters-placeholder": "모델 매개변수를 JSON 객체로 입력하세요. 예: {\"temperature\": 0.7}",
+  "model-parameters-placeholder": "모델 매개변수를 JSON 객체로 입력하세요. 예: {\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}",
   "model-parameters-must-be-valid-json-object": "모델 매개변수는 유효한 JSON 객체여야 합니다.",
   "please-select": "선택하세요",
   "configuring": "구성 중...",

--- a/src/i18n/locales/ko/setting.json
+++ b/src/i18n/locales/ko/setting.json
@@ -301,6 +301,9 @@
   "api-key-setting": "API 키 설정",
   "api-host-setting": "API 호스트 설정",
   "model-type-setting": "모델 타입 설정",
+  "model-parameters-setting": "모델 매개변수(JSON, 선택 사항)",
+  "model-parameters-placeholder": "모델 매개변수를 JSON 객체로 입력하세요. 예: {\"temperature\": 0.7}",
+  "model-parameters-must-be-valid-json-object": "모델 매개변수는 유효한 JSON 객체여야 합니다.",
   "please-select": "선택하세요",
   "configuring": "구성 중...",
 

--- a/src/i18n/locales/ru/setting.json
+++ b/src/i18n/locales/ru/setting.json
@@ -300,6 +300,9 @@
   "api-key-setting": "Настройка API-ключа",
   "api-host-setting": "Настройка API-хоста",
   "model-type-setting": "Настройка типа модели",
+  "model-parameters-setting": "Параметры модели (JSON, необязательно)",
+  "model-parameters-placeholder": "Введите параметры модели как объект JSON, например {\"temperature\": 0.7}",
+  "model-parameters-must-be-valid-json-object": "Параметры модели должны быть допустимым объектом JSON.",
   "please-select": "Пожалуйста, выберите",
   "configuring": "Конфигурирование...",
 

--- a/src/i18n/locales/ru/setting.json
+++ b/src/i18n/locales/ru/setting.json
@@ -301,7 +301,7 @@
   "api-host-setting": "Настройка API-хоста",
   "model-type-setting": "Настройка типа модели",
   "model-parameters-setting": "Параметры модели (JSON, необязательно)",
-  "model-parameters-placeholder": "Введите параметры модели как объект JSON, например {\"temperature\": 0.7}",
+  "model-parameters-placeholder": "Введите параметры модели как объект JSON, например {\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}",
   "model-parameters-must-be-valid-json-object": "Параметры модели должны быть допустимым объектом JSON.",
   "please-select": "Пожалуйста, выберите",
   "configuring": "Конфигурирование...",

--- a/src/i18n/locales/zh-Hans/setting.json
+++ b/src/i18n/locales/zh-Hans/setting.json
@@ -225,6 +225,9 @@
   "api-key-setting": "API 密钥设置",
   "api-host-setting": "API Host 设置",
   "model-type-setting": "模型类型设置",
+  "model-parameters-setting": "模型参数（JSON，可选）",
+  "model-parameters-placeholder": "以 JSON 对象输入模型参数，例如 {\"temperature\": 0.7}",
+  "model-parameters-must-be-valid-json-object": "模型参数必须是有效的 JSON 对象。",
   "please-select": "请选择",
   "configuring": "正在配置...",
 

--- a/src/i18n/locales/zh-Hans/setting.json
+++ b/src/i18n/locales/zh-Hans/setting.json
@@ -226,7 +226,7 @@
   "api-host-setting": "API Host 设置",
   "model-type-setting": "模型类型设置",
   "model-parameters-setting": "模型参数（JSON，可选）",
-  "model-parameters-placeholder": "以 JSON 对象输入模型参数，例如 {\"temperature\": 0.7}",
+  "model-parameters-placeholder": "以 JSON 对象输入模型参数，例如 {\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}",
   "model-parameters-must-be-valid-json-object": "模型参数必须是有效的 JSON 对象。",
   "please-select": "请选择",
   "configuring": "正在配置...",

--- a/src/i18n/locales/zh-Hant/setting.json
+++ b/src/i18n/locales/zh-Hant/setting.json
@@ -217,7 +217,7 @@
   "api-host-setting": "API 主機設定",
   "model-type-setting": "模型類型設定",
   "model-parameters-setting": "模型參數（JSON，選填）",
-  "model-parameters-placeholder": "以 JSON 物件輸入模型參數，例如 {\"temperature\": 0.7}",
+  "model-parameters-placeholder": "以 JSON 物件輸入模型參數，例如 {\"temperature\": 0.7, \"top_p\": 1, \"max_tokens\": 4096}",
   "model-parameters-must-be-valid-json-object": "模型參數必須是有效的 JSON 物件。",
   "please-select": "請選擇",
   "configuring": "正在配置...",

--- a/src/i18n/locales/zh-Hant/setting.json
+++ b/src/i18n/locales/zh-Hant/setting.json
@@ -216,6 +216,9 @@
   "api-key-setting": "API 金鑰設定",
   "api-host-setting": "API 主機設定",
   "model-type-setting": "模型類型設定",
+  "model-parameters-setting": "模型參數（JSON，選填）",
+  "model-parameters-placeholder": "以 JSON 物件輸入模型參數，例如 {\"temperature\": 0.7}",
+  "model-parameters-must-be-valid-json-object": "模型參數必須是有效的 JSON 物件。",
   "please-select": "請選擇",
   "configuring": "正在配置...",
 

--- a/src/lib/modelConfig.ts
+++ b/src/lib/modelConfig.ts
@@ -1,0 +1,169 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+export const MODEL_CONFIG_DICT_KEY = 'model_config_dict' as const;
+
+export type ModelConfigDict = Record<string, unknown>;
+
+export type AgentModelConfig = {
+  model_platform: string;
+  model_type?: string;
+  api_key?: string;
+  api_url?: string;
+  model_config_dict?: ModelConfigDict;
+  extra_params?: Record<string, unknown>;
+};
+
+export type AgentModelConfigSource = {
+  model_platform: string;
+  model_type: string;
+  api_key?: string;
+  api_url?: string;
+  model_config_dict?: ModelConfigDict;
+  extra_params?: Record<string, unknown>;
+};
+
+export type StoredModelProvider = {
+  provider_name?: unknown;
+  model_type?: unknown;
+  api_key?: unknown;
+  endpoint_url?: unknown;
+  api_url?: unknown;
+  encrypted_config?: unknown;
+};
+
+export type ModelConfigJsonErrorCode = 'invalid_json' | 'not_object';
+
+export class ModelConfigJsonError extends Error {
+  readonly code: ModelConfigJsonErrorCode;
+
+  constructor(code: ModelConfigJsonErrorCode, message: string) {
+    super(message);
+    this.name = 'ModelConfigJsonError';
+    this.code = code;
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Parse the BYOK model-parameters field. Blank input represents no overrides. */
+export function parseModelConfigJson(input: string): ModelConfigDict {
+  if (!input.trim()) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch {
+    throw new ModelConfigJsonError(
+      'invalid_json',
+      'Model parameters must be valid JSON.'
+    );
+  }
+
+  if (!isObjectRecord(parsed)) {
+    throw new ModelConfigJsonError(
+      'not_object',
+      'Model parameters must be a JSON object.'
+    );
+  }
+
+  return parsed;
+}
+
+/** Format persisted model parameters for the BYOK JSON editor. */
+export function formatModelConfigJson(value: unknown): string {
+  return JSON.stringify(isObjectRecord(value) ? value : {}, null, 2);
+}
+
+/**
+ * Separate the reserved CAMEL model configuration from provider constructor
+ * parameters stored in the provider's existing `encrypted_config` JSON field.
+ */
+export function splitProviderConfig(config: unknown): {
+  modelConfigDict: ModelConfigDict;
+  extraParams: Record<string, unknown>;
+} {
+  if (!isObjectRecord(config)) {
+    return { modelConfigDict: {}, extraParams: {} };
+  }
+
+  const { [MODEL_CONFIG_DICT_KEY]: storedModelConfig, ...extraParams } = config;
+
+  return {
+    modelConfigDict: isObjectRecord(storedModelConfig)
+      ? { ...storedModelConfig }
+      : {},
+    extraParams,
+  };
+}
+
+/** Build the provider JSON while preventing extra parameters from shadowing the reserved key. */
+export function buildProviderConfig(
+  extraParams: Record<string, unknown>,
+  modelConfigDict: ModelConfigDict
+): Record<string, unknown> {
+  const { extraParams: sanitizedExtraParams } =
+    splitProviderConfig(extraParams);
+  if (Object.keys(modelConfigDict).length === 0) {
+    return sanitizedExtraParams;
+  }
+
+  return {
+    ...sanitizedExtraParams,
+    [MODEL_CONFIG_DICT_KEY]: { ...modelConfigDict },
+  };
+}
+
+/** Build the per-agent payload while preserving explicit empty provider maps. */
+export function buildAgentModelConfig(
+  source: AgentModelConfigSource
+): AgentModelConfig {
+  const config: AgentModelConfig = {
+    model_platform: source.model_platform,
+    ...(source.model_type ? { model_type: source.model_type } : {}),
+  };
+
+  if (source.api_key !== undefined) config.api_key = source.api_key;
+  if (source.api_url !== undefined) config.api_url = source.api_url;
+  if (source.model_config_dict !== undefined) {
+    config.model_config_dict = { ...source.model_config_dict };
+  }
+  if (source.extra_params !== undefined) {
+    config.extra_params = { ...source.extra_params };
+  }
+
+  return config;
+}
+
+/** Resolve a stored custom/local provider into a transient per-agent config. */
+export function buildAgentModelConfigFromProvider(
+  provider: StoredModelProvider
+): AgentModelConfig {
+  const { modelConfigDict, extraParams } = splitProviderConfig(
+    provider.encrypted_config
+  );
+
+  return buildAgentModelConfig({
+    model_platform: String(
+      extraParams.model_platform || provider.provider_name || ''
+    ),
+    model_type: String(extraParams.model_type || provider.model_type || ''),
+    api_key: String(provider.api_key ?? ''),
+    api_url: String(provider.endpoint_url || provider.api_url || ''),
+    model_config_dict: modelConfigDict,
+    extra_params: extraParams,
+  });
+}

--- a/src/pages/Agents/Models.tsx
+++ b/src/pages/Agents/Models.tsx
@@ -19,6 +19,12 @@ import {
   proxyFetchPost,
   proxyFetchPut,
 } from '@/api/http';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -1342,13 +1348,13 @@ export default function SettingModels() {
       <button
         key={tabId}
         onClick={() => setSelectedTab(tabId)}
-        className={`rounded-xl px-3 py-2 flex w-full items-center justify-between transition-all duration-200 ${isSubItem ? 'pl-3' : ''} ${
+        className={`flex w-full items-center justify-between rounded-xl px-3 py-2 transition-all duration-200 ${isSubItem ? 'pl-3' : ''} ${
           isActive
             ? 'bg-ds-bg-neutral-subtle-default hover:bg-ds-bg-neutral-subtle-default'
             : 'bg-fill-fill-transparent hover:bg-fill-fill-transparent-hover'
         } `}
       >
-        <div className="gap-3 flex items-center justify-center">
+        <div className="flex items-center justify-center gap-3">
           {modelImage ? (
             <img
               src={modelImage}
@@ -1386,7 +1392,7 @@ export default function SettingModels() {
               />
             )
           : isConfigured && (
-              <div className="m-1 h-2 w-2 bg-ds-text-success-default-default shrink-0 rounded-full" />
+              <div className="m-1 h-2 w-2 shrink-0 rounded-full bg-ds-text-success-default-default" />
             )}
       </button>
     );
@@ -1533,7 +1539,7 @@ export default function SettingModels() {
     if (selectedTab === 'cloud') {
       if (import.meta.env.VITE_USE_LOCAL_PROXY === 'true') {
         return (
-          <div className="h-64 text-ds-text-neutral-muted-default flex items-center justify-center">
+          <div className="flex h-64 items-center justify-center text-ds-text-neutral-muted-default">
             {t('setting.cloud-not-available-in-local-proxy')}
           </div>
         );
@@ -1545,13 +1551,13 @@ export default function SettingModels() {
       const trialTotalLimit =
         Number(subscription?.trial_total_credits_limit) || 1000;
       return (
-        <div className="rounded-2xl bg-ds-bg-neutral-subtle-default flex w-full flex-col">
-          <div className="mx-6 mb-4 border-ds-border-neutral-default-default pb-4 pt-2 flex flex-col justify-start self-stretch border-x-0 border-t-0 border-b-[0.5px] border-solid">
-            <div className="gap-2 inline-flex items-center justify-start self-stretch">
-              <div className="text-body-base my-2 font-bold text-ds-text-neutral-default-default flex-1 justify-center">
+        <div className="flex w-full flex-col rounded-2xl bg-ds-bg-neutral-subtle-default">
+          <div className="mx-6 mb-4 flex flex-col justify-start self-stretch border-x-0 border-b-[0.5px] border-t-0 border-solid border-ds-border-neutral-default-default pb-4 pt-2">
+            <div className="inline-flex items-center justify-start gap-2 self-stretch">
+              <div className="text-body-base my-2 flex-1 justify-center font-bold text-ds-text-neutral-default-default">
                 {t('setting.eigent-cloud')}
               </div>
-              <div className="gap-2 flex items-center">
+              <div className="flex items-center gap-2">
                 {cloudPrefer ? (
                   <Button
                     variant="primary"
@@ -1606,7 +1612,7 @@ export default function SettingModels() {
                 onClick={() => {
                   window.location.href = `${SITE_URL}/pricing`;
                 }}
-                className="text-body-sm text-ds-text-neutral-muted-default cursor-pointer underline"
+                className="cursor-pointer text-body-sm text-ds-text-neutral-muted-default underline"
               >
                 {t('setting.pricing-options')}
               </span>
@@ -1616,9 +1622,9 @@ export default function SettingModels() {
             </div>
           </div>
           {/*Content Area*/}
-          <div className="gap-4 px-6 pb-4 flex w-full flex-row items-start justify-between">
-            <div className="min-w-0 gap-1 flex flex-1 flex-col">
-              <div className="gap-1 text-body-sm text-text-body flex items-center">
+          <div className="flex w-full flex-row items-start justify-between gap-4 px-6 pb-4">
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <div className="flex items-center gap-1 text-body-sm text-text-body">
                 <span>{t('setting.credits')}:</span>
                 {loadingCredits ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -1627,7 +1633,7 @@ export default function SettingModels() {
                 )}
               </div>
               {isTrialing && (
-                <p className="m-0 text-label-sm leading-5 text-text-label max-w-[560px]">
+                <p className="m-0 max-w-[560px] text-label-sm leading-5 text-text-label">
                   {t('setting.trial-plan-notice-before-upgrade', {
                     defaultValue:
                       "You're on a trial. Your {{planName}} plan includes {{planCredits}} credits; the trial unlocks {{daily}} credits/day (up to {{total}}) before you upgrade.",
@@ -1639,7 +1645,7 @@ export default function SettingModels() {
                   <button
                     type="button"
                     onClick={() => setTrialUpgradeDialogOpen(true)}
-                    className="p-0 text-label-sm font-medium text-text-body cursor-pointer border-0 bg-transparent underline"
+                    className="cursor-pointer border-0 bg-transparent p-0 text-label-sm font-medium text-text-body underline"
                   >
                     {t('setting.upgrade', { defaultValue: 'Upgrade' })}
                   </button>{' '}
@@ -1709,9 +1715,9 @@ export default function SettingModels() {
               />
             </DialogContent>
           </Dialog>
-          <div className="px-6 pb-4 flex w-full flex-1 items-center justify-between">
-            <div className="min-w-0 flex flex-1 items-center">
-              <span className="text-body-sm overflow-hidden text-ellipsis whitespace-nowrap">
+          <div className="flex w-full flex-1 items-center justify-between px-6 pb-4">
+            <div className="flex min-w-0 flex-1 items-center">
+              <span className="overflow-hidden text-ellipsis whitespace-nowrap text-body-sm">
                 {t('setting.select-model-type')}
               </span>
             </div>
@@ -1753,12 +1759,12 @@ export default function SettingModels() {
 
         return (
           <ConfigModelCard status={configCardRing}>
-            <div className="mx-6 mb-4 border-ds-border-neutral-default-default pb-4 pt-2 flex flex-col items-start justify-between border-x-0 border-t-0 border-b-[0.5px] border-solid">
-              <div className="gap-2 inline-flex items-center justify-between self-stretch">
+            <div className="mx-6 mb-4 flex flex-col items-start justify-between border-x-0 border-b-[0.5px] border-t-0 border-solid border-ds-border-neutral-default-default pb-4 pt-2">
+              <div className="inline-flex items-center justify-between gap-2 self-stretch">
                 <div className="text-body-base my-2 font-bold text-ds-text-neutral-default-default">
                   {item.name}
                 </div>
-                <div className="gap-2 flex items-center">
+                <div className="flex items-center gap-2">
                   {isConnected ? (
                     isDefault ? (
                       <Button
@@ -1801,10 +1807,10 @@ export default function SettingModels() {
                 {item.description}
               </div>
             </div>
-            <div className="gap-4 px-6 pb-4 flex w-full flex-col">
+            <div className="flex w-full flex-col gap-4 px-6 pb-4">
               {/* Login row: left status text, right action */}
-              <div className="gap-3 flex w-full items-center justify-between">
-                <div className="min-w-0 flex flex-1 flex-col">
+              <div className="flex w-full items-center justify-between gap-3">
+                <div className="flex min-w-0 flex-1 flex-col">
                   <span className="text-body-sm text-ds-text-neutral-default-default">
                     {isConnected
                       ? codexStatus.account_label ||
@@ -1822,7 +1828,7 @@ export default function SettingModels() {
                     </span>
                   ) : null}
                 </div>
-                <div className="ml-4 gap-2 flex shrink-0 items-center">
+                <div className="ml-4 flex shrink-0 items-center gap-2">
                   {isConnected ? (
                     <Button
                       variant="secondary"
@@ -1858,9 +1864,9 @@ export default function SettingModels() {
               </div>
 
               {/* Model type row: left label, right input */}
-              <div className="gap-3 flex w-full items-center justify-between">
-                <div className="min-w-0 flex flex-1 items-center">
-                  <span className="text-body-sm overflow-hidden text-ellipsis whitespace-nowrap">
+              <div className="flex w-full items-center justify-between gap-3">
+                <div className="flex min-w-0 flex-1 items-center">
+                  <span className="overflow-hidden text-ellipsis whitespace-nowrap text-body-sm">
                     {t('setting.model-type')}
                   </span>
                 </div>
@@ -1880,12 +1886,12 @@ export default function SettingModels() {
 
       return (
         <ConfigModelCard status={configCardRing}>
-          <div className="mx-6 mb-4 border-ds-border-neutral-default-default pb-4 pt-2 flex flex-col items-start justify-between border-x-0 border-t-0 border-b-[0.5px] border-solid">
-            <div className="gap-2 inline-flex items-center justify-between self-stretch">
+          <div className="mx-6 mb-4 flex flex-col items-start justify-between border-x-0 border-b-[0.5px] border-t-0 border-solid border-ds-border-neutral-default-default pb-4 pt-2">
+            <div className="inline-flex items-center justify-between gap-2 self-stretch">
               <div className="text-body-base my-2 font-bold text-ds-text-neutral-default-default">
                 {item.name}
               </div>
-              <div className="gap-2 flex items-center">
+              <div className="flex items-center gap-2">
                 {form[idx].prefer ? (
                   <Button
                     variant="primary"
@@ -1925,9 +1931,9 @@ export default function SettingModels() {
                   </Button>
                 )}
                 {form[idx].provider_id ? (
-                  <div className="h-2 w-2 bg-ds-text-success-default-default shrink-0 rounded-full" />
+                  <div className="h-2 w-2 shrink-0 rounded-full bg-ds-text-success-default-default" />
                 ) : (
-                  <div className="h-2 w-2 bg-ds-text-neutral-default-default shrink-0 rounded-full opacity-10" />
+                  <div className="h-2 w-2 shrink-0 rounded-full bg-ds-text-neutral-default-default opacity-10" />
                 )}
               </div>
             </div>
@@ -1948,7 +1954,7 @@ export default function SettingModels() {
               ) : null}
             </div>
           </div>
-          <div className="gap-4 px-6 flex w-full flex-col items-center">
+          <div className="flex w-full flex-col items-center gap-4 px-6">
             {/* API Key Setting */}
             <Input
               id={`apiKey-${item.id}`}
@@ -2060,38 +2066,50 @@ export default function SettingModels() {
                 }}
               />
             )}
-            <Textarea
-              id={`modelParameters-${item.id}`}
-              variant="enhanced"
-              title={t('setting.model-parameters-setting')}
-              state={errors[idx]?.modelConfigJson ? 'error' : 'default'}
-              note={errors[idx]?.modelConfigJson ?? undefined}
-              placeholder={t('setting.model-parameters-placeholder')}
-              value={form[idx].modelConfigJson}
-              rows={5}
-              spellCheck={false}
-              className="font-mono"
-              onChange={(e) => {
-                const value = e.target.value;
-                setForm((currentForm) =>
-                  currentForm.map((entry, entryIdx) =>
-                    entryIdx === idx
-                      ? { ...entry, modelConfigJson: value }
-                      : entry
-                  )
-                );
-                setErrors((currentErrors) =>
-                  currentErrors.map((entry, entryIdx) =>
-                    entryIdx === idx ? { ...entry, modelConfigJson: '' } : entry
-                  )
-                );
-              }}
-            />
+            <Accordion type="single" collapsible className="w-full">
+              <AccordionItem value="model-parameters" className="border-none">
+                <AccordionTrigger className="bg-transparent px-0 py-2 hover:no-underline">
+                  <span className="text-body-sm font-medium text-ds-text-neutral-default-default">
+                    {t('setting.model-parameters-setting')}
+                  </span>
+                </AccordionTrigger>
+                <AccordionContent>
+                  <Textarea
+                    id={`modelParameters-${item.id}`}
+                    variant="enhanced"
+                    state={errors[idx]?.modelConfigJson ? 'error' : 'default'}
+                    note={errors[idx]?.modelConfigJson ?? undefined}
+                    placeholder={t('setting.model-parameters-placeholder')}
+                    value={form[idx].modelConfigJson}
+                    rows={5}
+                    spellCheck={false}
+                    className="font-mono"
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      setForm((currentForm) =>
+                        currentForm.map((entry, entryIdx) =>
+                          entryIdx === idx
+                            ? { ...entry, modelConfigJson: value }
+                            : entry
+                        )
+                      );
+                      setErrors((currentErrors) =>
+                        currentErrors.map((entry, entryIdx) =>
+                          entryIdx === idx
+                            ? { ...entry, modelConfigJson: '' }
+                            : entry
+                        )
+                      );
+                    }}
+                  />
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
             {/* externalConfig render */}
             {item.externalConfig &&
               form[idx].externalConfig &&
               form[idx].externalConfig.map((ec, ecIdx) => (
-                <div key={ec.key} className="gap-4 flex h-full w-full flex-col">
+                <div key={ec.key} className="flex h-full w-full flex-col gap-4">
                   {ec.options && ec.options.length > 0 ? (
                     <Select
                       value={ec.value}
@@ -2182,7 +2200,7 @@ export default function SettingModels() {
               ))}
           </div>
           {/* Action Button */}
-          <div className="gap-2 px-6 py-4 flex justify-end">
+          <div className="flex justify-end gap-2 px-6 py-4">
             <Button
               variant="ghost"
               tone="neutral"
@@ -2228,9 +2246,9 @@ export default function SettingModels() {
 
       return (
         <ConfigModelCard status={configCardRing}>
-          <div className="mx-6 mb-4 border-ds-border-neutral-default-default pb-4 pt-2 flex flex-col items-start justify-between border-x-0 border-t-0 border-b-[0.5px] border-solid">
-            <div className="gap-2 inline-flex items-center justify-between self-stretch">
-              <div className="gap-2 flex items-center">
+          <div className="mx-6 mb-4 flex flex-col items-start justify-between border-x-0 border-b-[0.5px] border-t-0 border-solid border-ds-border-neutral-default-default pb-4 pt-2">
+            <div className="inline-flex items-center justify-between gap-2 self-stretch">
+              <div className="flex items-center gap-2">
                 <div className="text-body-base my-2 font-bold text-ds-text-neutral-default-default">
                   {getLocalPlatformName(platform)}
                 </div>
@@ -2260,7 +2278,7 @@ export default function SettingModels() {
                     onClick={() => handleLocalSwitch(true)}
                     className={
                       isConfigured
-                        ? 'bg-ds-bg-neutral-default-hover !text-ds-text-neutral-muted-default hover:bg-ds-bg-neutral-default-active shadow-none'
+                        ? 'bg-ds-bg-neutral-default-hover !text-ds-text-neutral-muted-default shadow-none hover:bg-ds-bg-neutral-default-active'
                         : ''
                     }
                   >
@@ -2271,14 +2289,14 @@ export default function SettingModels() {
                 )}
               </div>
               {isConfigured ? (
-                <div className="h-2 w-2 bg-text-success rounded-full" />
+                <div className="h-2 w-2 rounded-full bg-text-success" />
               ) : (
-                <div className="h-2 w-2 bg-text-label rounded-full opacity-10" />
+                <div className="h-2 w-2 rounded-full bg-text-label opacity-10" />
               )}
             </div>
           </div>
           {/* Model Endpoint URL Setting */}
-          <div className="gap-4 px-6 flex w-full flex-col items-center">
+          <div className="flex w-full flex-col items-center gap-4 px-6">
             <Input
               size="default"
               title={t('setting.model-endpoint-url')}
@@ -2320,8 +2338,8 @@ export default function SettingModels() {
               note={localError ?? undefined}
             />
             {isModelListPlatform ? (
-              <div className="gap-1 flex w-full flex-col">
-                <div className="gap-2 flex w-full items-end">
+              <div className="flex w-full flex-col gap-1">
+                <div className="flex w-full items-end gap-2">
                   <div className="flex-1">
                     <Select
                       value={currentType}
@@ -2419,7 +2437,7 @@ export default function SettingModels() {
             )}
           </div>
           {/* Action Button */}
-          <div className="gap-2 px-6 py-4 flex justify-end">
+          <div className="flex justify-end gap-2 px-6 py-4">
             <Button
               variant="ghost"
               tone="neutral"
@@ -2454,8 +2472,8 @@ export default function SettingModels() {
   return (
     <div className="m-auto flex h-auto w-full flex-1 flex-col">
       {/* Header Section */}
-      <div className="px-6 pb-6 pt-8 z-10 flex w-full items-center justify-between">
-        <div className="gap-4 flex w-full flex-col items-start justify-between">
+      <div className="z-10 flex w-full items-center justify-between px-6 pb-6 pt-8">
+        <div className="flex w-full flex-col items-start justify-between gap-4">
           <div className="flex flex-col">
             <div className="text-heading-sm font-bold text-ds-text-neutral-default-default">
               {t('setting.models')}
@@ -2464,10 +2482,10 @@ export default function SettingModels() {
         </div>
       </div>
       {/* Content Section */}
-      <div className="mb-8 gap-6 flex flex-col">
+      <div className="mb-8 flex flex-col gap-6">
         {/* Default Model Cascading Dropdown */}
-        <div className="gap-4 rounded-2xl bg-ds-bg-neutral-default-default px-6 py-4 flex w-full flex-col items-end justify-between">
-          <div className="gap-1 flex w-full flex-col items-start justify-center">
+        <div className="flex w-full flex-col items-end justify-between gap-4 rounded-2xl bg-ds-bg-neutral-default-default px-6 py-4">
+          <div className="flex w-full flex-col items-start justify-center gap-1">
             <div className="text-body-base font-bold text-ds-text-neutral-default-default">
               {t('setting.models-default-setting-title')}
             </div>
@@ -2481,11 +2499,11 @@ export default function SettingModels() {
             }}
           >
             <DropdownMenuTrigger asChild>
-              <button className="gap-2 rounded-lg border-ds-bg-brand-default-default bg-ds-bg-brand-default-default px-3 py-1 font-semibold text-ds-text-brand-inverse-default hover:border-ds-bg-brand-default-hover hover:bg-ds-bg-brand-default-hover active:border-ds-bg-brand-default-active active:bg-ds-bg-brand-default-active flex w-fit items-center border-[0.5px] border-solid transition-colors outline-none focus:outline-none focus-visible:outline-none">
-                <span className="text-body-sm leading-none whitespace-nowrap">
+              <button className="flex w-fit items-center gap-2 rounded-lg border-[0.5px] border-solid border-ds-bg-brand-default-default bg-ds-bg-brand-default-default px-3 py-1 font-semibold text-ds-text-brand-inverse-default outline-none transition-colors hover:border-ds-bg-brand-default-hover hover:bg-ds-bg-brand-default-hover focus:outline-none focus-visible:outline-none active:border-ds-bg-brand-default-active active:bg-ds-bg-brand-default-active">
+                <span className="whitespace-nowrap text-body-sm leading-none">
                   {getDefaultModelDisplayText()}
                 </span>
-                <ChevronDown className="h-4 w-4 !text-ds-text-brand-inverse-default flex-shrink-0" />
+                <ChevronDown className="h-4 w-4 flex-shrink-0 !text-ds-text-brand-inverse-default" />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-[180px]">
@@ -2553,7 +2571,7 @@ export default function SettingModels() {
                         }}
                         className="flex items-center justify-between"
                       >
-                        <div className="gap-2 flex items-center">
+                        <div className="flex items-center gap-2">
                           {modelImage ? (
                             <img
                               src={modelImage}
@@ -2574,15 +2592,15 @@ export default function SettingModels() {
                             {item.name}
                           </span>
                         </div>
-                        <div className="gap-1 flex items-center">
+                        <div className="flex items-center gap-1">
                           {!isConfigured && (
-                            <div className="h-2 w-2 bg-text-label rounded-full opacity-10" />
+                            <div className="h-2 w-2 rounded-full bg-text-label opacity-10" />
                           )}
                           {isPreferred && (
                             <Check className="h-4 w-4 text-ds-text-status-completed-strong-default" />
                           )}
                           {isConfigured && !isPreferred && (
-                            <div className="h-2 w-2 bg-text-success rounded-full" />
+                            <div className="h-2 w-2 rounded-full bg-text-success" />
                           )}
                         </div>
                       </DropdownMenuItem>
@@ -2614,7 +2632,7 @@ export default function SettingModels() {
                         }
                         className="flex items-center justify-between"
                       >
-                        <div className="gap-2 flex items-center">
+                        <div className="flex items-center gap-2">
                           {modelImage ? (
                             <img
                               src={modelImage}
@@ -2635,15 +2653,15 @@ export default function SettingModels() {
                             {model.name}
                           </span>
                         </div>
-                        <div className="gap-1 flex items-center">
+                        <div className="flex items-center gap-1">
                           {!isConfigured && (
-                            <div className="h-2 w-2 bg-text-label rounded-full opacity-10" />
+                            <div className="h-2 w-2 rounded-full bg-text-label opacity-10" />
                           )}
                           {isPreferred && (
                             <Check className="h-4 w-4 text-ds-text-status-completed-strong-default" />
                           )}
                           {isConfigured && !isPreferred && (
-                            <div className="h-2 w-2 bg-text-success rounded-full" />
+                            <div className="h-2 w-2 rounded-full bg-text-success" />
                           )}
                         </div>
                       </DropdownMenuItem>
@@ -2656,17 +2674,17 @@ export default function SettingModels() {
         </div>
 
         {/* Content Section with Sidebar */}
-        <div className="rounded-2xl bg-ds-bg-neutral-default-default px-3 py-2 flex w-full flex-col items-start justify-between">
-          <div className="text-body-base mb-4 border-ds-border-neutral-default-default bg-ds-bg-neutral-default-default px-3 py-2 pb-2 font-bold text-ds-text-neutral-default-default sticky top-[48px] z-10 w-full border-x-0 border-t-0 border-b-[0.5px] border-solid">
+        <div className="flex w-full flex-col items-start justify-between rounded-2xl bg-ds-bg-neutral-default-default px-3 py-2">
+          <div className="text-body-base sticky top-[48px] z-10 mb-4 w-full border-x-0 border-b-[0.5px] border-t-0 border-solid border-ds-border-neutral-default-default bg-ds-bg-neutral-default-default px-3 py-2 pb-2 font-bold text-ds-text-neutral-default-default">
             {t('setting.models-configuration')}
           </div>
 
-          <div className="px-3 flex w-full flex-row items-start justify-between">
+          <div className="flex w-full flex-row items-start justify-between px-3">
             {/* Sidebar */}
-            <div className="-ml-2 mr-4 rounded-2xl bg-ds-bg-neutral-default-default h-full w-[240px]">
-              <div className="gap-4 flex flex-col">
+            <div className="-ml-2 mr-4 h-full w-[240px] rounded-2xl bg-ds-bg-neutral-default-default">
+              <div className="flex flex-col gap-4">
                 {/* Eigent Cloud Section */}
-                <div className="gap-1 flex flex-col">
+                <div className="flex flex-col gap-1">
                   <div className="px-3 py-2 text-body-sm font-bold text-ds-text-neutral-default-default">
                     {t('setting.eigent-cloud')}
                   </div>
@@ -2686,21 +2704,21 @@ export default function SettingModels() {
                     )}
                 </div>
                 {/* Custom Model Section */}
-                <div className="gap-1 flex flex-col">
+                <div className="flex flex-col gap-1">
                   <div className="px-3 py-2 text-body-sm font-bold text-ds-text-neutral-default-default">
                     {t('setting.custom-model')}
                   </div>
-                  <div className="gap-2 flex flex-col">
+                  <div className="flex flex-col gap-2">
                     {/* Subscription sub-accordion (OAuth login providers) */}
                     {items.some(
                       (item) => item.authMode === 'oauth_subscription'
                     ) && (
-                      <div className="gap-1 flex flex-col">
+                      <div className="flex flex-col gap-1">
                         <button
                           onClick={() =>
                             setSubscriptionCollapsed(!subscriptionCollapsed)
                           }
-                          className="rounded-lg px-3 py-2 hover:bg-ds-bg-neutral-default-default flex items-center justify-between bg-transparent transition-colors"
+                          className="flex items-center justify-between rounded-lg bg-transparent px-3 py-2 transition-colors hover:bg-ds-bg-neutral-default-default"
                         >
                           <div className="text-body-sm font-medium text-ds-text-neutral-muted-default">
                             {t('setting.subscription', {
@@ -2714,7 +2732,7 @@ export default function SettingModels() {
                           )}
                         </button>
                         <div
-                          className={`ease-in-out overflow-hidden transition-all duration-300 ${
+                          className={`overflow-hidden transition-all duration-300 ease-in-out ${
                             subscriptionCollapsed
                               ? 'max-h-0 opacity-0'
                               : 'max-h-[2000px] opacity-100'
@@ -2739,12 +2757,12 @@ export default function SettingModels() {
                     {items.some(
                       (item) => item.authMode !== 'oauth_subscription'
                     ) && (
-                      <div className="gap-1 flex flex-col">
+                      <div className="flex flex-col gap-1">
                         <button
                           onClick={() =>
                             setByokGroupCollapsed(!byokGroupCollapsed)
                           }
-                          className="rounded-lg px-3 py-2 hover:bg-ds-bg-neutral-default-default flex items-center justify-between bg-transparent transition-colors"
+                          className="flex items-center justify-between rounded-lg bg-transparent px-3 py-2 transition-colors hover:bg-ds-bg-neutral-default-default"
                         >
                           <div className="text-body-sm font-medium text-ds-text-neutral-muted-default">
                             {t('setting.byok', { defaultValue: 'BYOK' })}
@@ -2756,7 +2774,7 @@ export default function SettingModels() {
                           )}
                         </button>
                         <div
-                          className={`ease-in-out overflow-hidden transition-all duration-300 ${
+                          className={`overflow-hidden transition-all duration-300 ease-in-out ${
                             byokGroupCollapsed
                               ? 'max-h-0 opacity-0'
                               : 'max-h-[2000px] opacity-100'
@@ -2781,10 +2799,10 @@ export default function SettingModels() {
                 </div>
 
                 {/* Local Model Section */}
-                <div className="gap-1 flex flex-col">
+                <div className="flex flex-col gap-1">
                   <button
                     onClick={() => setLocalCollapsed(!localCollapsed)}
-                    className="rounded-lg px-3 py-2 hover:bg-ds-bg-neutral-default-default flex items-center justify-between bg-transparent transition-colors"
+                    className="flex items-center justify-between rounded-lg bg-transparent px-3 py-2 transition-colors hover:bg-ds-bg-neutral-default-default"
                   >
                     <div className="text-body-sm font-bold text-ds-text-neutral-default-default">
                       {t('setting.local-model')}
@@ -2796,7 +2814,7 @@ export default function SettingModels() {
                     )}
                   </button>
                   <div
-                    className={`ease-in-out overflow-hidden transition-all duration-300 ${
+                    className={`overflow-hidden transition-all duration-300 ease-in-out ${
                       localCollapsed
                         ? 'max-h-0 opacity-0'
                         : 'max-h-[2000px] opacity-100'
@@ -2847,7 +2865,7 @@ export default function SettingModels() {
               </div>
             </div>
             {/* Main Content */}
-            <div className="min-w-0 sticky top-[136px] z-10 flex-1">
+            <div className="sticky top-[136px] z-10 min-w-0 flex-1">
               {renderContent()}
             </div>
           </div>

--- a/src/pages/Agents/Models.tsx
+++ b/src/pages/Agents/Models.tsx
@@ -44,9 +44,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
 import { createHost } from '@/host/createHost';
 import { SITE_URL } from '@/lib';
 import { INIT_PROVODERS } from '@/lib/llm';
+import {
+  buildProviderConfig,
+  formatModelConfigJson,
+  parseModelConfigJson,
+  splitProviderConfig,
+} from '@/lib/modelConfig';
 import { getProviderValid, toProviderValidStatus } from '@/lib/providerStatus';
 import { useAuthStore } from '@/store/authStore';
 import { useCloudModelStore } from '@/store/cloudModelStore';
@@ -161,6 +168,7 @@ export default function SettingModels() {
       apiHost: p.apiHost,
       is_valid: p.is_valid ?? false,
       model_type: p.model_type ?? '',
+      modelConfigJson: '',
       externalConfig: p.externalConfig
         ? p.externalConfig.map((ec) => ({ ...ec }))
         : undefined,
@@ -196,6 +204,7 @@ export default function SettingModels() {
       apiKey?: string;
       apiHost?: string;
       model_type?: string;
+      modelConfigJson?: string;
       externalConfig?: string;
     }[]
   >(() =>
@@ -401,6 +410,9 @@ export default function SettingModels() {
               (p: any) => p.provider_name === item.id
             );
             if (found) {
+              const { modelConfigDict } = splitProviderConfig(
+                found.encrypted_config
+              );
               return {
                 ...fi,
                 provider_id: found.id,
@@ -410,6 +422,10 @@ export default function SettingModels() {
                 is_valid: getProviderValid(found),
                 prefer: found.prefer ?? false,
                 model_type: found.model_type ?? '',
+                modelConfigJson:
+                  Object.keys(modelConfigDict).length > 0
+                    ? formatModelConfigJson(modelConfigDict)
+                    : '',
                 externalConfig: fi.externalConfig
                   ? fi.externalConfig.map((ec) => {
                       if (
@@ -633,9 +649,16 @@ export default function SettingModels() {
   };
 
   const handleVerify = async (idx: number) => {
-    const { apiKey, apiHost, externalConfig, model_type, provider_id } =
-      form[idx];
+    const {
+      apiKey,
+      apiHost,
+      externalConfig,
+      model_type,
+      modelConfigJson,
+      provider_id,
+    } = form[idx];
     let hasError = false;
+    let modelConfigDict: Record<string, unknown> = {};
     const newErrors = [...errors];
     if (items[idx].id !== 'local' && items[idx].id !== 'aws-bedrock-converse') {
       if (!apiKey || apiKey.trim() === '') {
@@ -657,6 +680,15 @@ export default function SettingModels() {
     } else {
       newErrors[idx].model_type = '';
     }
+    try {
+      modelConfigDict = parseModelConfigJson(modelConfigJson);
+      newErrors[idx].modelConfigJson = '';
+    } catch {
+      newErrors[idx].modelConfigJson = t(
+        'setting.model-parameters-must-be-valid-json-object'
+      );
+      hasError = true;
+    }
     setErrors(newErrors);
     if (hasError) {
       showConfigCardRing('error');
@@ -666,20 +698,34 @@ export default function SettingModels() {
     showConfigCardRing('configuring');
     setLoading(idx);
     const item = items[idx];
-    let external: any = {};
-    if (form[idx]?.externalConfig) {
-      form[idx]?.externalConfig.map((item) => {
+    const external: Record<string, unknown> = {};
+    if (externalConfig) {
+      externalConfig.forEach((item) => {
         external[item.key] = item.value;
       });
     }
 
-    console.log(form[idx]);
+    setForm((currentForm) =>
+      currentForm.map((entry, entryIdx) =>
+        entryIdx === idx
+          ? {
+              ...entry,
+              modelConfigJson:
+                Object.keys(modelConfigDict).length > 0
+                  ? formatModelConfigJson(modelConfigDict)
+                  : '',
+            }
+          : entry
+      )
+    );
+
     try {
       const res = await fetchPost('/model/validate', {
         model_platform: item.id,
         model_type: form[idx].model_type,
         api_key: form[idx].apiKey || null,
         url: form[idx].apiHost,
+        model_config_dict: modelConfigDict,
         extra_params: external,
       });
       if (res.is_tool_calls && res.is_valid) {
@@ -724,13 +770,8 @@ export default function SettingModels() {
       endpoint_url: form[idx].apiHost,
       is_valid: toProviderValidStatus(true),
       model_type: form[idx].model_type,
+      encrypted_config: buildProviderConfig(external, modelConfigDict),
     };
-    if (externalConfig) {
-      data.encrypted_config = {};
-      externalConfig.forEach((ec) => {
-        data.encrypted_config[ec.key] = ec.value;
-      });
-    }
     try {
       if (provider_id) {
         await proxyFetchPut(`/api/v1/provider/${provider_id}`, data);
@@ -747,6 +788,9 @@ export default function SettingModels() {
             (p: any) => p.provider_name === item.id
           );
           if (found) {
+            const { modelConfigDict } = splitProviderConfig(
+              found.encrypted_config
+            );
             return {
               ...fi,
               provider_id: found.id,
@@ -756,6 +800,10 @@ export default function SettingModels() {
               is_valid: getProviderValid(found),
               prefer: found.prefer ?? false,
               model_type: found.model_type ?? fi.model_type ?? '',
+              modelConfigJson:
+                Object.keys(modelConfigDict).length > 0
+                  ? formatModelConfigJson(modelConfigDict)
+                  : '',
               externalConfig: fi.externalConfig
                 ? fi.externalConfig.map((ec) => {
                     if (
@@ -1123,6 +1171,7 @@ export default function SettingModels() {
             apiHost: item.apiHost,
             is_valid: false,
             model_type: '',
+            modelConfigJson: '',
             externalConfig: item.externalConfig
               ? item.externalConfig.map((ec) => ({ ...ec, value: '' }))
               : undefined,
@@ -1133,7 +1182,14 @@ export default function SettingModels() {
       );
       setErrors((prev) =>
         prev.map((er, i) =>
-          i === idx ? ({ apiKey: '', apiHost: '', model_type: '' } as any) : er
+          i === idx
+            ? ({
+                apiKey: '',
+                apiHost: '',
+                model_type: '',
+                modelConfigJson: '',
+              } as any)
+            : er
         )
       );
       if (activeModelIdx === idx) {
@@ -2004,6 +2060,33 @@ export default function SettingModels() {
                 }}
               />
             )}
+            <Textarea
+              id={`modelParameters-${item.id}`}
+              variant="enhanced"
+              title={t('setting.model-parameters-setting')}
+              state={errors[idx]?.modelConfigJson ? 'error' : 'default'}
+              note={errors[idx]?.modelConfigJson ?? undefined}
+              placeholder={t('setting.model-parameters-placeholder')}
+              value={form[idx].modelConfigJson}
+              rows={5}
+              spellCheck={false}
+              className="font-mono"
+              onChange={(e) => {
+                const value = e.target.value;
+                setForm((currentForm) =>
+                  currentForm.map((entry, entryIdx) =>
+                    entryIdx === idx
+                      ? { ...entry, modelConfigJson: value }
+                      : entry
+                  )
+                );
+                setErrors((currentErrors) =>
+                  currentErrors.map((entry, entryIdx) =>
+                    entryIdx === idx ? { ...entry, modelConfigJson: '' } : entry
+                  )
+                );
+              }}
+            />
             {/* externalConfig render */}
             {item.externalConfig &&
               form[idx].externalConfig &&

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -29,6 +29,10 @@ import { showStorageToast } from '@/components/Toast/storageToast';
 import type { AppHost } from '@/host/types';
 import { generateUniqueId, uploadLog } from '@/lib';
 import {
+  buildAgentModelConfigFromProvider,
+  splitProviderConfig,
+} from '@/lib/modelConfig';
+import {
   normalizeRemoteSubAgentProvider,
   REMOTE_SUB_AGENT_PROVIDER_ID,
   toRemoteSubAgentRuntimeConfig,
@@ -1505,6 +1509,7 @@ const chatStore = (initial?: Partial<ChatStore>) =>
         model_type: '',
         model_platform: '',
         api_url: '',
+        model_config_dict: {},
         extra_params: {},
         auth_source: undefined as 'codex_subscription' | undefined,
       };
@@ -1513,7 +1518,6 @@ const chatStore = (initial?: Partial<ChatStore>) =>
           prefer: true,
         });
         const providerList = res.items || [];
-        console.log('providerList', providerList);
         const provider = providerList[0];
 
         if (!provider) {
@@ -1523,12 +1527,16 @@ const chatStore = (initial?: Partial<ChatStore>) =>
           );
         }
 
+        const { modelConfigDict, extraParams } = splitProviderConfig(
+          provider.encrypted_config
+        );
         apiModel = {
           api_key: provider.api_key,
           model_type: provider.model_type,
           model_platform: provider.provider_name,
           api_url: provider.endpoint_url || provider.api_url,
-          extra_params: provider.encrypted_config,
+          model_config_dict: modelConfigDict,
+          extra_params: extraParams,
           auth_source: undefined,
         };
       } else if (!type && modelType === 'cloud') {
@@ -1598,6 +1606,7 @@ const chatStore = (initial?: Partial<ChatStore>) =>
           model_type: resolvedCloudModel.model.model_type,
           model_platform: resolvedCloudModel.model.model_platform,
           api_url: res.api_url,
+          model_config_dict: {},
           extra_params: {},
           auth_source: undefined,
         };
@@ -1607,6 +1616,7 @@ const chatStore = (initial?: Partial<ChatStore>) =>
           model_type: codex_model_type || 'gpt-5.5',
           model_platform: 'openai',
           api_url: '',
+          model_config_dict: {},
           extra_params: {},
           auth_source: 'codex_subscription',
         };
@@ -1666,12 +1676,61 @@ const chatStore = (initial?: Partial<ChatStore>) =>
         }
       }
 
+      const workerProviderIds = !type
+        ? workerList
+            .map((worker) => worker.workerInfo?.model_provider_id)
+            .filter((providerId): providerId is number =>
+              Number.isInteger(providerId)
+            )
+        : [];
+      const workerProvidersById = new Map<number, any>();
+      if (workerProviderIds.length > 0) {
+        let workerProviderList: any[];
+        try {
+          const providersRes = await proxyFetchGet('/api/v1/providers');
+          workerProviderList = Array.isArray(providersRes)
+            ? providersRes
+            : providersRes.items || [];
+        } catch (error) {
+          finishStartupFailure();
+          throw new Error(
+            'Failed to load the model provider configured for a worker.',
+            { cause: error }
+          );
+        }
+
+        workerProviderList.forEach((provider) => {
+          workerProvidersById.set(Number(provider.id), provider);
+        });
+
+        const missingWorker = workerList.find((worker) => {
+          const providerId = worker.workerInfo?.model_provider_id;
+          return (
+            Number.isInteger(providerId) &&
+            !workerProvidersById.has(providerId as number)
+          );
+        });
+        if (missingWorker) {
+          finishStartupFailure();
+          throw new Error(
+            `The model provider configured for worker "${missingWorker.name}" is no longer available. Please edit the worker and select another model.`
+          );
+        }
+      }
+
       const addWorkers = workerList.map((worker) => {
+        const providerId = worker.workerInfo?.model_provider_id;
+        const provider = Number.isInteger(providerId)
+          ? workerProvidersById.get(providerId as number)
+          : undefined;
         return {
           name: worker.workerInfo?.name,
           description: worker.workerInfo?.description,
           tools: worker.workerInfo?.tools,
           mcp_tools: worker.workerInfo?.mcp_tools,
+          custom_model_config: provider
+            ? buildAgentModelConfigFromProvider(provider)
+            : undefined,
         };
       });
 
@@ -1813,6 +1872,7 @@ const chatStore = (initial?: Partial<ChatStore>) =>
             model_type: apiModel.model_type,
             api_key: apiModel.api_key,
             api_url: apiModel.api_url,
+            model_config_dict: apiModel.model_config_dict,
             extra_params: apiModel.extra_params,
             auth_source: apiModel.auth_source,
             installed_mcp: { mcpServers: {} },

--- a/src/types/chatbox.d.ts
+++ b/src/types/chatbox.d.ts
@@ -95,6 +95,7 @@ declare global {
       tools: any;
       mcp_tools: any;
       selectedTools: any;
+      model_provider_id?: number;
     };
   }
 

--- a/test/unit/lib/modelConfig.test.ts
+++ b/test/unit/lib/modelConfig.test.ts
@@ -1,0 +1,166 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import {
+  MODEL_CONFIG_DICT_KEY,
+  ModelConfigJsonError,
+  buildAgentModelConfig,
+  buildAgentModelConfigFromProvider,
+  buildProviderConfig,
+  formatModelConfigJson,
+  parseModelConfigJson,
+  splitProviderConfig,
+} from '@/lib/modelConfig';
+import { describe, expect, it } from 'vitest';
+
+describe('modelConfig', () => {
+  describe('parseModelConfigJson', () => {
+    it('treats blank input as an empty object', () => {
+      expect(parseModelConfigJson('  \n ')).toEqual({});
+    });
+
+    it('parses a JSON object without changing nested values', () => {
+      expect(
+        parseModelConfigJson(
+          '{"temperature":0.2,"response_format":{"type":"json_object"}}'
+        )
+      ).toEqual({
+        temperature: 0.2,
+        response_format: { type: 'json_object' },
+      });
+    });
+
+    it('reports malformed JSON separately from a non-object root', () => {
+      expect(() => parseModelConfigJson('{')).toThrowError(
+        expect.objectContaining<ModelConfigJsonError>({
+          code: 'invalid_json',
+        })
+      );
+
+      for (const value of ['null', '[]', 'true', '1', '"text"']) {
+        expect(() => parseModelConfigJson(value)).toThrowError(
+          expect.objectContaining<ModelConfigJsonError>({
+            code: 'not_object',
+          })
+        );
+      }
+    });
+  });
+
+  it('pretty-prints objects and safely defaults invalid persisted values', () => {
+    expect(formatModelConfigJson({ temperature: 0.2 })).toBe(
+      '{\n  "temperature": 0.2\n}'
+    );
+    expect(formatModelConfigJson(null)).toBe('{}');
+    expect(formatModelConfigJson([])).toBe('{}');
+  });
+
+  it('splits the reserved model config from provider extra parameters', () => {
+    expect(
+      splitProviderConfig({
+        api_version: '2025-01-01',
+        [MODEL_CONFIG_DICT_KEY]: { temperature: 0.2 },
+      })
+    ).toEqual({
+      modelConfigDict: { temperature: 0.2 },
+      extraParams: { api_version: '2025-01-01' },
+    });
+    expect(splitProviderConfig(null)).toEqual({
+      modelConfigDict: {},
+      extraParams: {},
+    });
+  });
+
+  it('builds a round-trippable provider config and omits empty overrides', () => {
+    const config = buildProviderConfig(
+      {
+        region_name: 'us-east-1',
+        [MODEL_CONFIG_DICT_KEY]: { ignored: true },
+      },
+      { max_tokens: 4096 }
+    );
+
+    expect(config).toEqual({
+      region_name: 'us-east-1',
+      [MODEL_CONFIG_DICT_KEY]: { max_tokens: 4096 },
+    });
+    expect(splitProviderConfig(config)).toEqual({
+      modelConfigDict: { max_tokens: 4096 },
+      extraParams: { region_name: 'us-east-1' },
+    });
+    expect(buildProviderConfig({ api_version: 'v1' }, {})).toEqual({
+      api_version: 'v1',
+    });
+  });
+
+  it('builds a provider-backed agent config with explicit empty maps', () => {
+    expect(
+      buildAgentModelConfig({
+        model_platform: 'openai',
+        model_type: 'gpt-4o',
+        api_key: 'provider-key',
+        api_url: 'https://api.openai.com/v1',
+        model_config_dict: {},
+        extra_params: {},
+      })
+    ).toEqual({
+      model_platform: 'openai',
+      model_type: 'gpt-4o',
+      api_key: 'provider-key',
+      api_url: 'https://api.openai.com/v1',
+      model_config_dict: {},
+      extra_params: {},
+    });
+  });
+
+  it('keeps cloud agent config limited to its existing model selection', () => {
+    expect(
+      buildAgentModelConfig({
+        model_platform: 'azure',
+        model_type: 'gpt-5.5',
+      })
+    ).toEqual({
+      model_platform: 'azure',
+      model_type: 'gpt-5.5',
+    });
+  });
+
+  it('builds transient agent config from a stored local provider', () => {
+    expect(
+      buildAgentModelConfigFromProvider({
+        provider_name: 'ollama',
+        model_type: 'fallback-model',
+        api_key: 'not-required',
+        endpoint_url: 'http://127.0.0.1:11434/v1',
+        encrypted_config: {
+          model_platform: 'openai-compatible-model',
+          model_type: 'qwen3:8b',
+          keep_alive: '10m',
+          model_config_dict: { temperature: 0.1 },
+        },
+      })
+    ).toEqual({
+      model_platform: 'openai-compatible-model',
+      model_type: 'qwen3:8b',
+      api_key: 'not-required',
+      api_url: 'http://127.0.0.1:11434/v1',
+      model_config_dict: { temperature: 0.1 },
+      extra_params: {
+        model_platform: 'openai-compatible-model',
+        model_type: 'qwen3:8b',
+        keep_alive: '10m',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add an optional `Model Parameters (JSON)` editor to every BYOK provider card, using the existing form styles and localized labels
- validate JSON objects inline, persist them under `encrypted_config.model_config_dict`, and restore them when reopening provider settings
- forward `model_config_dict` separately from provider constructor options through chat startup and CAMEL `ModelFactory.create`
- propagate the selected provider configuration to custom/local workers without persisting API keys or provider secrets in local worker state
- preserve runtime-owned settings and legacy flat/nested provider configuration precedence
- redact per-worker model credentials from controller/service logs

## Why

BYOK users could choose a provider and model, but had no supported UI path for inference parameters such as `temperature`, `top_p`, or `max_tokens`, even though CAMEL accepts them through `model_config_dict`.

The worker model path also only carried platform/model identifiers, so a worker selecting a BYOK provider could miss that provider's model parameters and constructor configuration.

## User impact

Users can now tune model behavior with an optional JSON object and get immediate inline feedback for malformed or non-object input. Settings round-trip with the provider and apply both to the default task model and provider-backed worker overrides.

## Security and compatibility

- worker persistence stores only `model_provider_id`; credentials are resolved transiently at task start
- API keys and AWS secrets are excluded from new-agent debug logs
- explicit empty worker credentials no longer fall back to another provider's credentials
- direct BYOK workers are not treated as Eigent cloud proxy models
- legacy provider `extra_params` remain supported

## Validation

- `npm run type-check`
- targeted ESLint checks for the changed frontend files
- `npx vitest run test/unit/lib/modelConfig.test.ts` — 9 passed
- `npm run check:i18n`
- `npm run build:web`
- targeted backend model/agent/controller/service tests — 45 passed
- Ruff lint and format checks for changed Python files
- light, dark, and inline JSON error states checked in the running UI

Fixes #1764
