### PR TITLE
fix: resolve user-scoped project output files

### DIFF
--- a/backend/app/controller/file_controller.py
+++ b/backend/app/controller/file_controller.py
@@ -28,6 +28,7 @@ from starlette.concurrency import run_in_threadpool
 
 from app.component.environment import env
 from app.utils.file_utils import list_files, resolve_under_base
+from app.utils.workspace_paths import runtime_owner_key
 from app.utils.workspace_resolver import get_workspace_resolver
 
 router = APIRouter()
@@ -40,7 +41,6 @@ WORKSPACE_ROOT = env("EIGENT_WORKSPACE", "~/.eigent/workspace")
 SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 FILE_LIST_SEMAPHORE = asyncio.Semaphore(4)
 SLOW_FILE_LIST_LOG_MS = 300
-_PROJECT_ROOT_FALLBACK_CACHE: dict[tuple[str, str, str], Path] = {}
 
 
 def _get_eigent_root() -> Path:
@@ -152,17 +152,6 @@ async def upload_file(
     }
 
 
-def _sanitize_email(email: str) -> str:
-    """Sanitize email for use in path (match chat_controller logic)."""
-    return re.sub(r'[\\/*?:"<>|\s]', "_", email.split("@")[0]).strip(".")
-
-
-def _sanitize_identity(value: str | int | None) -> str:
-    if value is None:
-        return ""
-    return re.sub(r'[\\/*?:"<>|\s]', "_", str(value)).strip(".")
-
-
 def _normalize_relative_path(path: str) -> str:
     """Normalize relative path to URL-safe POSIX style."""
     return path.replace("\\", "/")
@@ -172,10 +161,11 @@ def _get_project_root(
     email: str, project_id: str, user_id: str | int | None = None
 ) -> Path:
     """Get project root path under the canonical user_id or legacy email key."""
-    root = _get_eigent_root()
-    user_key = _sanitize_identity(user_id)
-    owner_key = f"user_{user_key}" if user_key else _sanitize_email(email)
-    return root / owner_key / f"project_{project_id}"
+    return (
+        _get_eigent_root()
+        / runtime_owner_key(email, user_id)
+        / f"project_{project_id}"
+    )
 
 
 def _resolve_project_root(
@@ -183,44 +173,16 @@ def _resolve_project_root(
 ) -> Path:
     """
     Resolve project root, preferring the canonical user_id-scoped path when
-    available, then legacy email-scoped storage, then any local project match.
+    available, then legacy email-scoped storage.
     """
     preferred = _get_project_root(email, project_id, user_id)
     if preferred.exists():
         return preferred
 
-    user_key = _sanitize_identity(user_id)
-    if user_key:
+    if user_id is not None and str(user_id).strip():
         legacy_preferred = _get_project_root(email, project_id)
         if legacy_preferred.exists():
             return legacy_preferred
-
-    cache_key = (email, project_id, user_key)
-    cached = _PROJECT_ROOT_FALLBACK_CACHE.get(cache_key)
-    if cached is not None:
-        if cached.exists():
-            return cached
-        _PROJECT_ROOT_FALLBACK_CACHE.pop(cache_key, None)
-
-    root = _get_eigent_root()
-    candidate_name = f"project_{project_id}"
-    try:
-        for child in root.iterdir():
-            if not child.is_dir():
-                continue
-            candidate = child / candidate_name
-            if candidate.exists():
-                _PROJECT_ROOT_FALLBACK_CACHE[cache_key] = candidate
-                file_logger.info(
-                    "Resolved project root via fallback lookup: %s -> %s",
-                    preferred,
-                    candidate,
-                )
-                return candidate
-    except FileNotFoundError:
-        pass
-    except Exception as e:
-        file_logger.warning("project root fallback lookup failed: %s", e)
 
     return preferred
 

--- a/backend/app/controller/file_controller.py
+++ b/backend/app/controller/file_controller.py
@@ -40,6 +40,7 @@ WORKSPACE_ROOT = env("EIGENT_WORKSPACE", "~/.eigent/workspace")
 SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 FILE_LIST_SEMAPHORE = asyncio.Semaphore(4)
 SLOW_FILE_LIST_LOG_MS = 300
+_PROJECT_ROOT_FALLBACK_CACHE: dict[tuple[str, str, str], Path] = {}
 
 
 def _get_eigent_root() -> Path:
@@ -156,27 +157,50 @@ def _sanitize_email(email: str) -> str:
     return re.sub(r'[\\/*?:"<>|\s]', "_", email.split("@")[0]).strip(".")
 
 
+def _sanitize_identity(value: str | int | None) -> str:
+    if value is None:
+        return ""
+    return re.sub(r'[\\/*?:"<>|\s]', "_", str(value)).strip(".")
+
+
 def _normalize_relative_path(path: str) -> str:
     """Normalize relative path to URL-safe POSIX style."""
     return path.replace("\\", "/")
 
 
-def _get_project_root(email: str, project_id: str) -> Path:
-    """Get project root path: ~/eigent/{email}/project_{project_id}/."""
+def _get_project_root(
+    email: str, project_id: str, user_id: str | int | None = None
+) -> Path:
+    """Get project root path under the canonical user_id or legacy email key."""
     root = _get_eigent_root()
-    email_sanitized = _sanitize_email(email)
-    return root / email_sanitized / f"project_{project_id}"
+    user_key = _sanitize_identity(user_id)
+    owner_key = f"user_{user_key}" if user_key else _sanitize_email(email)
+    return root / owner_key / f"project_{project_id}"
 
 
-def _resolve_project_root(email: str, project_id: str) -> Path:
+def _resolve_project_root(
+    email: str, project_id: str, user_id: str | int | None = None
+) -> Path:
     """
-    Resolve project root, preferring the email-scoped path but falling back to
-    any local project_{project_id} directory when the stored email differs from
-    the current login identity.
+    Resolve project root, preferring the canonical user_id-scoped path when
+    available, then legacy email-scoped storage, then any local project match.
     """
-    preferred = _get_project_root(email, project_id)
+    preferred = _get_project_root(email, project_id, user_id)
     if preferred.exists():
         return preferred
+
+    user_key = _sanitize_identity(user_id)
+    if user_key:
+        legacy_preferred = _get_project_root(email, project_id)
+        if legacy_preferred.exists():
+            return legacy_preferred
+
+    cache_key = (email, project_id, user_key)
+    cached = _PROJECT_ROOT_FALLBACK_CACHE.get(cache_key)
+    if cached is not None:
+        if cached.exists():
+            return cached
+        _PROJECT_ROOT_FALLBACK_CACHE.pop(cache_key, None)
 
     root = _get_eigent_root()
     candidate_name = f"project_{project_id}"
@@ -186,6 +210,7 @@ def _resolve_project_root(email: str, project_id: str) -> Path:
                 continue
             candidate = child / candidate_name
             if candidate.exists():
+                _PROJECT_ROOT_FALLBACK_CACHE[cache_key] = candidate
                 file_logger.info(
                     "Resolved project root via fallback lookup: %s -> %s",
                     preferred,
@@ -216,7 +241,7 @@ def _resolve_file_root(
         )
         if space_root is not None:
             return space_root
-    return _resolve_project_root(email, project_id)
+    return _resolve_project_root(email, project_id, user_id)
 
 
 @router.get("/files")

--- a/backend/tests/app/controller/test_file_controller.py
+++ b/backend/tests/app/controller/test_file_controller.py
@@ -1,0 +1,58 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import logging
+
+from app.controller import file_controller
+
+
+def test_resolve_project_root_prefers_user_id_root(monkeypatch, tmp_path, caplog):
+    eigent_root = tmp_path / "eigent"
+    user_project = eigent_root / "user_20" / "project_p1"
+    user_project.mkdir(parents=True)
+    (eigent_root / "other_user" / "project_p1").mkdir(parents=True)
+
+    monkeypatch.setattr(file_controller, "_get_eigent_root", lambda: eigent_root)
+    file_controller._PROJECT_ROOT_FALLBACK_CACHE.clear()
+    caplog.set_level(logging.INFO, logger="file_controller")
+
+    resolved = file_controller._resolve_project_root(
+        "yueming.lai@example.com", "p1", "20"
+    )
+
+    assert resolved == user_project
+    assert "Resolved project root via fallback lookup" not in caplog.text
+
+
+def test_resolve_project_root_caches_fallback_lookup(
+    monkeypatch, tmp_path, caplog
+):
+    eigent_root = tmp_path / "eigent"
+    fallback_project = eigent_root / "user_20" / "project_p1"
+    fallback_project.mkdir(parents=True)
+
+    monkeypatch.setattr(file_controller, "_get_eigent_root", lambda: eigent_root)
+    file_controller._PROJECT_ROOT_FALLBACK_CACHE.clear()
+    caplog.set_level(logging.INFO, logger="file_controller")
+
+    first = file_controller._resolve_project_root(
+        "yueming.lai@example.com", "p1"
+    )
+    second = file_controller._resolve_project_root(
+        "yueming.lai@example.com", "p1"
+    )
+
+    assert first == fallback_project
+    assert second == fallback_project
+    assert caplog.text.count("Resolved project root via fallback lookup") == 1

--- a/backend/tests/app/controller/test_file_controller.py
+++ b/backend/tests/app/controller/test_file_controller.py
@@ -12,20 +12,20 @@
 # limitations under the License.
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-import logging
-
 from app.controller import file_controller
 
 
-def test_resolve_project_root_prefers_user_id_root(monkeypatch, tmp_path, caplog):
+def test_resolve_project_root_prefers_user_id_root(
+    monkeypatch, tmp_path, caplog
+):
     eigent_root = tmp_path / "eigent"
     user_project = eigent_root / "user_20" / "project_p1"
     user_project.mkdir(parents=True)
     (eigent_root / "other_user" / "project_p1").mkdir(parents=True)
 
-    monkeypatch.setattr(file_controller, "_get_eigent_root", lambda: eigent_root)
-    file_controller._PROJECT_ROOT_FALLBACK_CACHE.clear()
-    caplog.set_level(logging.INFO, logger="file_controller")
+    monkeypatch.setattr(
+        file_controller, "_get_eigent_root", lambda: eigent_root
+    )
 
     resolved = file_controller._resolve_project_root(
         "yueming.lai@example.com", "p1", "20"
@@ -35,24 +35,55 @@ def test_resolve_project_root_prefers_user_id_root(monkeypatch, tmp_path, caplog
     assert "Resolved project root via fallback lookup" not in caplog.text
 
 
-def test_resolve_project_root_caches_fallback_lookup(
-    monkeypatch, tmp_path, caplog
+def test_resolve_project_root_falls_back_to_legacy_email_root(
+    monkeypatch, tmp_path
 ):
     eigent_root = tmp_path / "eigent"
-    fallback_project = eigent_root / "user_20" / "project_p1"
-    fallback_project.mkdir(parents=True)
+    legacy_project = eigent_root / "yueming.lai" / "project_p1"
+    legacy_project.mkdir(parents=True)
 
-    monkeypatch.setattr(file_controller, "_get_eigent_root", lambda: eigent_root)
-    file_controller._PROJECT_ROOT_FALLBACK_CACHE.clear()
-    caplog.set_level(logging.INFO, logger="file_controller")
-
-    first = file_controller._resolve_project_root(
-        "yueming.lai@example.com", "p1"
-    )
-    second = file_controller._resolve_project_root(
-        "yueming.lai@example.com", "p1"
+    monkeypatch.setattr(
+        file_controller, "_get_eigent_root", lambda: eigent_root
     )
 
-    assert first == fallback_project
-    assert second == fallback_project
-    assert caplog.text.count("Resolved project root via fallback lookup") == 1
+    resolved = file_controller._resolve_project_root(
+        "yueming.lai@example.com", "p1", "20"
+    )
+
+    assert resolved == legacy_project
+
+
+def test_resolve_project_root_does_not_fallback_to_other_user_root(
+    monkeypatch, tmp_path
+):
+    eigent_root = tmp_path / "eigent"
+    (eigent_root / "user_20" / "project_p1").mkdir(parents=True)
+    expected = eigent_root / "user_42" / "project_p1"
+
+    monkeypatch.setattr(
+        file_controller, "_get_eigent_root", lambda: eigent_root
+    )
+
+    resolved = file_controller._resolve_project_root(
+        "yueming.lai@example.com", "p1", "42"
+    )
+
+    assert resolved == expected
+
+
+def test_resolve_project_root_without_user_id_stays_email_scoped(
+    monkeypatch, tmp_path
+):
+    eigent_root = tmp_path / "eigent"
+    (eigent_root / "user_20" / "project_p1").mkdir(parents=True)
+    expected = eigent_root / "yueming.lai" / "project_p1"
+
+    monkeypatch.setattr(
+        file_controller, "_get_eigent_root", lambda: eigent_root
+    )
+
+    resolved = file_controller._resolve_project_root(
+        "yueming.lai@example.com", "p1"
+    )
+
+    assert resolved == expected

--- a/electron/main/fileReader.ts
+++ b/electron/main/fileReader.ts
@@ -13,17 +13,18 @@
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
 import { BrowserWindow, app } from 'electron';
-import fs from 'fs';
-import http from 'http';
-import https from 'https';
 import mammoth from 'mammoth';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import path from 'node:path';
+import { URL } from 'node:url';
 import Papa from 'papaparse';
-import path from 'path';
 import * as unzipper from 'unzipper';
-import { URL } from 'url';
 import { parseStringPromise } from 'xml2js';
 import { normalizeLegacySandboxPath } from './utils/filePath';
 import { findDirectoriesByName } from './utils/log';
+import { resolveProjectStoragePath } from './utils/projectStoragePath';
 
 interface FileInfo {
   path: string;
@@ -660,6 +661,20 @@ export class FileReader {
     return [...new Set(candidates.filter(Boolean))];
   }
 
+  private resolveProjectPath(
+    email: string,
+    projectId: string,
+    userId?: string | number | null
+  ): string {
+    return resolveProjectStoragePath({
+      homeDir: app.getPath('home'),
+      email,
+      projectId,
+      userId,
+      existsSync: fs.existsSync,
+    });
+  }
+
   private findProjectTaskPath(
     userHome: string,
     rootDir: 'eigent' | '.eigent',
@@ -926,19 +941,10 @@ export class FileReader {
 
   public createProjectStructure(
     email: string,
-    projectId: string
+    projectId: string,
+    userId?: string | number | null
   ): { success: boolean; path: string } {
-    const safeEmail = email
-      .split('@')[0]
-      .replace(/[\\/*?:"<>|\s]/g, '_')
-      .replace(/^\.+|\.+$/g, '');
-    const userHome = app.getPath('home');
-    const projectPath = path.join(
-      userHome,
-      'eigent',
-      safeEmail,
-      `project_${projectId}`
-    );
+    const projectPath = this.resolveProjectPath(email, projectId, userId);
 
     try {
       if (!fs.existsSync(projectPath)) {
@@ -1139,18 +1145,12 @@ export class FileReader {
     }
   }
 
-  public getProjectFileList(email: string, projectId: string): FileInfo[] {
-    const safeEmail = email
-      .split('@')[0]
-      .replace(/[\\/*?:"<>|\s]/g, '_')
-      .replace(/^\.+|\.+$/g, '');
-    const userHome = app.getPath('home');
-    const projectPath = path.join(
-      userHome,
-      'eigent',
-      safeEmail,
-      `project_${projectId}`
-    );
+  public getProjectFileList(
+    email: string,
+    projectId: string,
+    userId?: string | number | null
+  ): FileInfo[] {
+    const projectPath = this.resolveProjectPath(email, projectId, userId);
 
     try {
       if (!fs.existsSync(projectPath)) {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1585,10 +1585,7 @@ function registerIpcHandlers() {
           .replace(/[-:]/g, '')
           .replace(/\..+/, '')
           .replace('T', '-');
-        const safeName = (fileName || 'pasted-file').replace(
-          /[^\w.-]+/g,
-          '_'
-        );
+        const safeName = (fileName || 'pasted-file').replace(/[^\w.-]+/g, '_');
         const unique = crypto.randomUUID();
         const filePath = path.join(pastedDir, `${stamp}-${unique}-${safeName}`);
         await fsp.writeFile(filePath, Buffer.from(new Uint8Array(data)));
@@ -1708,9 +1705,14 @@ function registerIpcHandlers() {
   // ==================== IDE integration handler ====================
   ipcMain.handle(
     'get-project-folder-path',
-    async (_event, email: string, projectId: string) => {
+    async (
+      _event,
+      email: string,
+      projectId: string,
+      userId?: string | number | null
+    ) => {
       const manager = checkManagerInstance(fileReader, 'FileReader');
-      const result = manager.createProjectStructure(email, projectId);
+      const result = manager.createProjectStructure(email, projectId, userId);
       return result.path;
     }
   );
@@ -2058,9 +2060,14 @@ function registerIpcHandlers() {
   // New project management handlers
   ipcMain.handle(
     'create-project-structure',
-    async (_, email: string, projectId: string) => {
+    async (
+      _,
+      email: string,
+      projectId: string,
+      userId?: string | number | null
+    ) => {
       const manager = checkManagerInstance(fileReader, 'FileReader');
-      return manager.createProjectStructure(email, projectId);
+      return manager.createProjectStructure(email, projectId, userId);
     }
   );
 
@@ -2087,9 +2094,14 @@ function registerIpcHandlers() {
 
   ipcMain.handle(
     'get-project-file-list',
-    async (_, email: string, projectId: string) => {
+    async (
+      _,
+      email: string,
+      projectId: string,
+      userId?: string | number | null
+    ) => {
       const manager = checkManagerInstance(fileReader, 'FileReader');
-      return manager.getProjectFileList(email, projectId);
+      return manager.getProjectFileList(email, projectId, userId);
     }
   );
 

--- a/electron/main/utils/projectStoragePath.ts
+++ b/electron/main/utils/projectStoragePath.ts
@@ -1,0 +1,75 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import path from 'node:path';
+
+export function sanitizeStorageIdentity(identity: string): string {
+  return identity
+    .split('@')[0]
+    .replace(/[\\/*?:"<>|\s]/g, '_')
+    .replace(/^\.+|\.+$/g, '');
+}
+
+export function getProjectIdentityCandidates(
+  email: string,
+  userId?: string | number | null
+): string[] {
+  const candidates: string[] = [];
+  if (userId !== undefined && userId !== null && userId !== '') {
+    const rawUserId = String(userId);
+    candidates.push(
+      sanitizeStorageIdentity(
+        rawUserId.startsWith('user_') ? rawUserId : `user_${rawUserId}`
+      )
+    );
+  }
+  candidates.push(sanitizeStorageIdentity(email));
+  return [...new Set(candidates.filter(Boolean))];
+}
+
+export function resolveProjectStoragePath({
+  homeDir,
+  email,
+  projectId,
+  userId,
+  existsSync,
+}: {
+  homeDir: string;
+  email: string;
+  projectId: string;
+  userId?: string | number | null;
+  existsSync: (path: string) => boolean;
+}): string {
+  const identities = getProjectIdentityCandidates(email, userId);
+  const fallbackIdentity = identities[0] || sanitizeStorageIdentity(email);
+  const fallbackPath = path.join(
+    homeDir,
+    'eigent',
+    fallbackIdentity,
+    `project_${projectId}`
+  );
+
+  for (const identity of identities) {
+    const projectPath = path.join(
+      homeDir,
+      'eigent',
+      identity,
+      `project_${projectId}`
+    );
+    if (existsSync(projectPath)) {
+      return projectPath;
+    }
+  }
+  return fallbackPath;
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -173,8 +173,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('subscription-auth:codex-login', email),
   codexSubscriptionDisconnect: (email: string) =>
     ipcRenderer.invoke('subscription-auth:codex-disconnect', email),
-  getProjectFolderPath: (email: string, projectId: string) =>
-    ipcRenderer.invoke('get-project-folder-path', email, projectId),
+  getProjectFolderPath: (
+    email: string,
+    projectId: string,
+    userId?: string | number | null
+  ) => ipcRenderer.invoke('get-project-folder-path', email, projectId, userId),
   openInIDE: (folderPath: string, ide: string) =>
     ipcRenderer.invoke('open-in-ide', folderPath, ide),
   setBrowserPort: (port: number, isExternal?: boolean) =>

--- a/src/components/Folder/index.tsx
+++ b/src/components/Folder/index.tsx
@@ -1206,7 +1206,8 @@ export default function Folder({ data: _data }: { data?: Agent }) {
       try {
         const folderPath = await electronAPI.getProjectFolderPath(
           authStore.email,
-          projectStore.activeProjectId as string
+          projectStore.activeProjectId as string,
+          authStore.user_id
         );
         if (!cancelled) setWorkingFolderPath(folderPath || null);
       } catch {
@@ -1277,7 +1278,8 @@ export default function Folder({ data: _data }: { data?: Agent }) {
           const localFiles = await ipcRenderer.invoke(
             'get-project-file-list',
             authStore.email,
-            primaryProjectId
+            primaryProjectId,
+            authStore.user_id
           );
           if (cancelled || signal?.aborted) return false;
           if (Array.isArray(localFiles)) {
@@ -1561,7 +1563,8 @@ export default function Folder({ data: _data }: { data?: Agent }) {
       ) {
         folderPath = await electronAPI.getProjectFolderPath(
           authStore.email,
-          projectStore.activeProjectId
+          projectStore.activeProjectId,
+          authStore.user_id
         );
       }
       if (!folderPath) return;

--- a/src/components/Session/SidePanelSections/useProjectOutputFiles.ts
+++ b/src/components/Session/SidePanelSections/useProjectOutputFiles.ts
@@ -61,6 +61,7 @@ export function useProjectOutputFiles(
 ): FileInfo[] {
   const host = useHost();
   const email = useAuthStore((s) => s.email);
+  const userId = useAuthStore((s) => s.user_id);
   const [files, setFiles] = useState<FileInfo[]>([]);
   const live = useMemo(() => isTaskLive(activeTask), [activeTask]);
 
@@ -105,6 +106,7 @@ export function useProjectOutputFiles(
             const listRes = await fetchGet('/files', {
               project_id: projectId,
               email,
+              ...(userId != null ? { user_id: String(userId) } : {}),
             });
             if (Array.isArray(listRes)) {
               nextFiles = normalizeRemoteFiles(listRes, baseURL);
@@ -141,7 +143,7 @@ export function useProjectOutputFiles(
       cancelled = true;
       clearInterval(timer);
     };
-  }, [email, host?.ipcRenderer, live, projectId, taskId]);
+  }, [email, host?.ipcRenderer, live, projectId, taskId, userId]);
 
   return files;
 }

--- a/src/components/Session/SidePanelSections/useProjectOutputFiles.ts
+++ b/src/components/Session/SidePanelSections/useProjectOutputFiles.ts
@@ -82,7 +82,8 @@ export function useProjectOutputFiles(
           const localFiles = await ipcRenderer.invoke(
             'get-project-file-list',
             email,
-            projectId
+            projectId,
+            userId
           );
           if (Array.isArray(localFiles)) {
             nextFiles = localFiles;

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -124,6 +124,7 @@ export default function WorkspacePage() {
   );
 
   const email = useAuthStore((s) => s.email);
+  const userId = useAuthStore((s) => s.user_id);
   const workspaceMainBackground = useAuthStore(
     (s) => s.workspaceMainBackground
   );
@@ -453,7 +454,8 @@ export default function WorkspacePage() {
         const files = await ipc?.invoke(
           'get-project-file-list',
           email,
-          projectStore.activeProjectId
+          projectStore.activeProjectId,
+          userId
         );
         setHasAgentFiles(
           Array.isArray(files) && filterVisibleAgentFiles(files).length > 0
@@ -464,7 +466,7 @@ export default function WorkspacePage() {
     };
 
     detectAgentFiles();
-  }, [projectStore.activeProjectId, email, setHasAgentFiles, ipc]);
+  }, [projectStore.activeProjectId, email, userId, setHasAgentFiles, ipc]);
 
   // Add webview-show listener in useEffect with cleanup
   useEffect(() => {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -206,7 +206,11 @@ interface ElectronAPI {
   codexSubscriptionDisconnect: (
     email: string
   ) => Promise<{ success: boolean; error_code?: string; error?: string }>;
-  getProjectFolderPath: (email: string, projectId: string) => Promise<string>;
+  getProjectFolderPath: (
+    email: string,
+    projectId: string,
+    userId?: string | number | null
+  ) => Promise<string>;
   openInIDE: (
     folderPath: string,
     ide: string

--- a/test/unit/electron/main/projectStoragePath.test.ts
+++ b/test/unit/electron/main/projectStoragePath.test.ts
@@ -1,0 +1,81 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getProjectIdentityCandidates,
+  resolveProjectStoragePath,
+} from '../../../../electron/main/utils/projectStoragePath';
+
+describe('projectStoragePath', () => {
+  it('prefers user-id project directories over legacy email directories', () => {
+    const homeDir = '/Users/test';
+    const userProjectPath = path.join(
+      homeDir,
+      'eigent',
+      'user_42',
+      'project_p1'
+    );
+    const legacyProjectPath = path.join(
+      homeDir,
+      'eigent',
+      'alice',
+      'project_p1'
+    );
+    const existsSync = vi.fn(
+      (candidate: string) =>
+        candidate === userProjectPath || candidate === legacyProjectPath
+    );
+
+    const resolved = resolveProjectStoragePath({
+      homeDir,
+      email: 'alice@example.com',
+      projectId: 'p1',
+      userId: 42,
+      existsSync,
+    });
+
+    expect(resolved).toBe(userProjectPath);
+    expect(existsSync.mock.calls.map(([candidate]) => candidate)).not.toContain(
+      legacyProjectPath
+    );
+  });
+
+  it('falls back to legacy email directories when user-id directories are missing', () => {
+    const homeDir = '/Users/test';
+    const legacyProjectPath = path.join(
+      homeDir,
+      'eigent',
+      'alice',
+      'project_p1'
+    );
+
+    const resolved = resolveProjectStoragePath({
+      homeDir,
+      email: 'alice@example.com',
+      projectId: 'p1',
+      userId: 42,
+      existsSync: (candidate) => candidate === legacyProjectPath,
+    });
+
+    expect(resolved).toBe(legacyProjectPath);
+  });
+
+  it('does not search user-id directories when no user id is supplied', () => {
+    expect(getProjectIdentityCandidates('alice@example.com')).toEqual([
+      'alice',
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

Closes #

## Description

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

Fix project output file resolution for user-scoped local storage.

Previously, output file listing preferred the legacy email-scoped path:

`~/.eigent/<email>/project_<project_id>`

After local sign-in/account changes, project files may live under the canonical user-id scoped path:

`~/.eigent/user_<user_id>/project_<project_id>`

This PR updates file resolution to prefer the user-id scoped directory while preserving legacy email-based fallback behavior.

## Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->

<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->

<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- [x] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
