### PR TITLE
Fix active Space hydration behavior

### DIFF
--- a/src/store/spaceStore.test.ts
+++ b/src/store/spaceStore.test.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import type { ServerProject } from '@/service/spaceApi';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   SPACE_SCHEMA_VERSION,
@@ -64,6 +65,20 @@ const makeSpace = (
   createdAt: 1,
   updatedAt: 1,
   metadata,
+});
+
+const makeServerProject = (
+  id: string,
+  spaceId: string,
+  status: ServerProject['status'] = 'active'
+): ServerProject => ({
+  id,
+  user_id: '2',
+  space_id: spaceId,
+  name: `Project ${id}`,
+  status,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
 });
 
 describe('spaceStore user scoping', () => {
@@ -192,5 +207,63 @@ describe('spaceStore user scoping', () => {
     );
     expect(Object.keys(state.spaces)).toEqual(['space_new_blank']);
     expect(state.activeSpaceId).toBe('space_new_blank');
+  });
+
+  it('keeps the previously selected active space when hydrating existing spaces', async () => {
+    const spaceApi = await import('@/service/spaceApi');
+    vi.mocked(spaceApi.proxyFetchSpaces).mockResolvedValue([
+      makeSpace('space_recent', 'Recent Space', 'blank', '2'),
+      makeSpace('space_selected', 'Selected Space', 'blank', '2'),
+    ]);
+    useSpaceStore.setState({
+      activeSpaceId: 'space_selected',
+      projectsSyncedAt: {
+        space_selected: Date.now(),
+      },
+    });
+
+    await useSpaceStore.getState().hydrateFromServer(2);
+
+    const state = useSpaceStore.getState();
+    expect(spaceApi.proxyCreateSpace).not.toHaveBeenCalled();
+    expect(Object.keys(state.spaces).sort()).toEqual([
+      'space_recent',
+      'space_selected',
+    ]);
+    expect(state.activeSpaceId).toBe('space_selected');
+  });
+
+  it('creates a blank space for legacy migrations and selects it on first hydrate', async () => {
+    const spaceApi = await import('@/service/spaceApi');
+    vi.mocked(spaceApi.proxyFetchSpaces).mockResolvedValue([
+      makeSpace('legacy_2', 'Legacy Space', 'legacy', '2', { legacy: true }),
+    ]);
+    vi.mocked(spaceApi.proxyFetchSpaceProjects).mockImplementation(
+      async (spaceId) =>
+        spaceId === 'legacy_2'
+          ? [makeServerProject('project_legacy', 'legacy_2')]
+          : []
+    );
+    vi.mocked(spaceApi.proxyCreateSpace).mockResolvedValue(
+      makeSpace('space_migration_blank', 'Untitled Space', 'blank')
+    );
+    useSpaceStore.setState({
+      activeSpaceId: 'legacy_2',
+    });
+
+    await useSpaceStore.getState().hydrateFromServer(2);
+
+    const state = useSpaceStore.getState();
+    expect(spaceApi.proxyCreateSpace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Untitled Space',
+        source_type: 'blank',
+      })
+    );
+    expect(Object.keys(state.spaces).sort()).toEqual([
+      'legacy_2',
+      'space_migration_blank',
+    ]);
+    expect(state.activeSpaceId).toBe('space_migration_blank');
   });
 });

--- a/src/store/spaceStore.ts
+++ b/src/store/spaceStore.ts
@@ -621,23 +621,27 @@ export const useSpaceStore = create<SpaceStore>()(
             }
           }
 
-          if (!hasActiveNonLegacySpace) {
-            if (legacySpaceIdsWithProjects.size === 0) {
-              try {
-                initialBlankSpace = await proxyCreateSpace({
-                  name: INITIAL_BLANK_SPACE_NAME,
-                  source_type: 'blank',
-                  metadata: {
-                    createdFrom: INITIAL_BLANK_SPACE_CREATED_FROM,
-                    autoCreatedPlaceholder: true,
-                  },
-                });
-              } catch (error) {
-                console.warn(
-                  '[spaceStore] Failed to create initial blank Space:',
-                  error
-                );
-              }
+          const shouldCreateInitialBlankSpace =
+            !hasActiveNonLegacySpace &&
+            (activeOwnedSpaces.length === 0 || activeLegacySpaces.length > 0);
+          const shouldPreferInitialBlankSpace =
+            legacySpaceIdsWithProjects.size > 0;
+
+          if (shouldCreateInitialBlankSpace) {
+            try {
+              initialBlankSpace = await proxyCreateSpace({
+                name: INITIAL_BLANK_SPACE_NAME,
+                source_type: 'blank',
+                metadata: {
+                  createdFrom: INITIAL_BLANK_SPACE_CREATED_FROM,
+                  autoCreatedPlaceholder: true,
+                },
+              });
+            } catch (error) {
+              console.warn(
+                '[spaceStore] Failed to create initial blank Space:',
+                error
+              );
             }
           }
 
@@ -716,7 +720,9 @@ export const useSpaceStore = create<SpaceStore>()(
                 nextSpaces,
                 state.activeSpaceId,
                 localLegacyId,
-                initialBlankSpace?.id
+                shouldPreferInitialBlankSpace
+                  ? initialBlankSpace?.id
+                  : undefined
               ),
             };
           });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

# Pull Request

## Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

Closes #

## Description

- Preserve the user's previously selected active Space during server hydration.
- Create a new blank Space only for initial setup or legacy migration cases.
- Keep empty legacy Spaces hidden while still supporting legacy Spaces with active projects.

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

## Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->

<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->

<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [ ] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
