### PR TITLE
fix: hide task root folders from Agent Folder

### DIFF
--- a/backend/app/controller/file_controller.py
+++ b/backend/app/controller/file_controller.py
@@ -28,7 +28,7 @@ from starlette.concurrency import run_in_threadpool
 
 from app.component.environment import env
 from app.utils.file_utils import list_files, resolve_under_base
-from app.utils.workspace_paths import runtime_owner_key
+from app.utils.workspace_paths import runtime_owner_key, task_dir_name
 from app.utils.workspace_resolver import get_workspace_resolver
 
 router = APIRouter()
@@ -231,7 +231,7 @@ async def list_project_files(
     project_root = _resolve_file_root(email, project_id, space_id, user_id)
     list_dir = str(project_root)
     if task_id:
-        list_dir = str(project_root / f"task_{task_id}")
+        list_dir = str(project_root / task_dir_name(task_id))
     if not Path(list_dir).exists():
         file_logger.debug(
             "list_project_files: path does not exist: %s",

--- a/backend/app/memory/service.py
+++ b/backend/app/memory/service.py
@@ -50,6 +50,7 @@ from app.memory.events import (
 from app.memory.local_store import LocalMemoryStore
 from app.memory.paths import canonical_user_id
 from app.run_context import RunContext
+from app.utils.workspace_paths import task_dir_name
 
 logger = logging.getLogger("memory.service")
 
@@ -194,7 +195,7 @@ def finalize_task_lock_run_memory(
     try:
         service.register_runtime_log_artifact(
             run_context=run_context,
-            relative_path=f"task_{run_context.run_id}/camel_logs",
+            relative_path=f"{task_dir_name(run_context.run_id)}/camel_logs",
         )
         service.on_run_end(
             run_context=run_context,

--- a/backend/app/model/chat.py
+++ b/backend/app/model/chat.py
@@ -27,6 +27,7 @@ from app.model.model_platform import (
     NormalizedOptionalModelPlatform,
 )
 from app.remote_sub_agent.config import RemoteSubAgentConfig
+from app.utils.workspace_paths import task_dir_name
 
 logger = logging.getLogger("chat_model")
 
@@ -182,14 +183,14 @@ class Chat(BaseModel):
             / "eigent"
             / owner_key
             / f"project_{self.project_id}"
-            / f"task_{run_id}"
+            / task_dir_name(run_id)
         )
         legacy_project_base = (
             Path.home()
             / "eigent"
             / legacy_owner_key
             / f"project_{self.project_id}"
-            / f"task_{run_id}"
+            / task_dir_name(run_id)
         )
         if (
             owner_key != legacy_owner_key

--- a/backend/app/utils/workspace_paths.py
+++ b/backend/app/utils/workspace_paths.py
@@ -49,6 +49,10 @@ def runtime_owner_key(email: str, user_id: str | int | None = None) -> str:
     return sanitize_email(email)
 
 
+def task_dir_name(task_id: str) -> str:
+    return f"task_{str(task_id).removeprefix('task_')}"
+
+
 def project_root(
     email: str, project_id: str, user_id: str | int | None = None
 ) -> Path:
@@ -65,7 +69,7 @@ def project_task_root(
     task_id: str,
     user_id: str | int | None = None,
 ) -> Path:
-    return project_root(email, project_id, user_id) / f"task_{task_id}"
+    return project_root(email, project_id, user_id) / task_dir_name(task_id)
 
 
 def legacy_task_root(
@@ -74,7 +78,7 @@ def legacy_task_root(
     return (
         get_eigent_root()
         / runtime_owner_key(email, user_id)
-        / f"task_{task_id}"
+        / task_dir_name(task_id)
     )
 
 
@@ -89,7 +93,7 @@ def camel_log_root(
         / ".eigent"
         / runtime_owner_key(email, user_id)
         / f"project_{project_id}"
-        / f"task_{task_id}"
+        / task_dir_name(task_id)
         / "camel_logs"
     )
 
@@ -101,7 +105,7 @@ def legacy_camel_log_root(
         Path.home()
         / ".eigent"
         / runtime_owner_key(email, user_id)
-        / f"task_{task_id}"
+        / task_dir_name(task_id)
         / "camel_logs"
     )
 
@@ -118,7 +122,7 @@ def runtime_task_root(
         / runtime_owner_key(email, user_id)
         / "runtime"
         / f"project_{project_id}"
-        / f"task_{task_id}"
+        / task_dir_name(task_id)
     )
 
 

--- a/backend/tests/app/model/test_chat.py
+++ b/backend/tests/app/model/test_chat.py
@@ -333,3 +333,21 @@ class TestFileSavePath:
 
         assert resolved == legacy_path / "screenshots"
         assert resolved.exists()
+
+    def test_file_save_path_does_not_double_task_prefix(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        chat = self._chat()
+        chat.run_id = "task_run-1"
+
+        resolved = Path(chat.file_save_path())
+
+        assert resolved == (
+            tmp_path
+            / "eigent"
+            / "user_42"
+            / "project_project-1"
+            / "task_run-1"
+        )
+        assert resolved.exists()

--- a/electron/main/fileReader.ts
+++ b/electron/main/fileReader.ts
@@ -645,6 +645,18 @@ export class FileReader {
       .replace(/^\.+|\.+$/g, '');
   }
 
+  private normalizeTaskId(taskId: string): string {
+    return String(taskId).replace(/^task_/, '');
+  }
+
+  private taskDirName(taskId: string): string {
+    return `task_${this.normalizeTaskId(taskId)}`;
+  }
+
+  private taskDirNameCandidates(taskId: string): string[] {
+    return [...new Set([this.taskDirName(taskId), `task_${taskId}`])];
+  }
+
   private getStorageIdentityCandidates(
     email: string,
     userId?: string | number | null
@@ -683,15 +695,17 @@ export class FileReader {
     taskId: string
   ): string | null {
     for (const identity of identities) {
-      const taskPath = path.join(
-        userHome,
-        rootDir,
-        identity,
-        `project_${projectId}`,
-        `task_${taskId}`
-      );
-      if (fs.existsSync(taskPath)) {
-        return taskPath;
+      for (const taskDirName of this.taskDirNameCandidates(taskId)) {
+        const taskPath = path.join(
+          userHome,
+          rootDir,
+          identity,
+          `project_${projectId}`,
+          taskDirName
+        );
+        if (fs.existsSync(taskPath)) {
+          return taskPath;
+        }
       }
     }
     return null;
@@ -709,10 +723,12 @@ export class FileReader {
       for (const entry of entries) {
         if (entry.startsWith('project_')) {
           const projectDir = path.join(userDir, entry);
-          const taskDir = path.join(projectDir, `task_${taskId}`);
+          for (const taskDirName of this.taskDirNameCandidates(taskId)) {
+            const taskDir = path.join(projectDir, taskDirName);
 
-          if (fs.existsSync(taskDir)) {
-            return taskDir;
+            if (fs.existsSync(taskDir)) {
+              return taskDir;
+            }
           }
         }
       }
@@ -754,7 +770,7 @@ export class FileReader {
           'eigent',
           safeEmail,
           `project_${projectId}`,
-          `task_${taskId}`
+          this.taskDirName(taskId)
         );
       logPath =
         this.findProjectTaskPath(
@@ -769,7 +785,7 @@ export class FileReader {
           '.eigent',
           safeEmail,
           `project_${projectId}`,
-          `task_${taskId}`
+          this.taskDirName(taskId)
         );
       return { dirPath, logPath };
     }
@@ -786,16 +802,31 @@ export class FileReader {
           '.eigent',
           safeEmail,
           projectMatch[0],
-          `task_${taskId}`
+          this.taskDirName(taskId)
         );
       } else {
-        logPath = path.join(userHome, '.eigent', safeEmail, `task_${taskId}`);
+        logPath = path.join(
+          userHome,
+          '.eigent',
+          safeEmail,
+          this.taskDirName(taskId)
+        );
       }
       return { dirPath, logPath };
     }
 
-    dirPath = path.join(userHome, 'eigent', safeEmail, `task_${taskId}`);
-    logPath = path.join(userHome, '.eigent', safeEmail, `task_${taskId}`);
+    dirPath = path.join(
+      userHome,
+      'eigent',
+      safeEmail,
+      this.taskDirName(taskId)
+    );
+    logPath = path.join(
+      userHome,
+      '.eigent',
+      safeEmail,
+      this.taskDirName(taskId)
+    );
     return { dirPath, logPath };
   }
 
@@ -1051,7 +1082,7 @@ export class FileReader {
           const stats = fs.statSync(taskPath);
 
           if (stats.isDirectory()) {
-            const taskId = entry.replace('task_', '');
+            const taskId = entry.replace(/^task_/, '');
 
             tasks.push({
               id: taskId,
@@ -1084,18 +1115,20 @@ export class FileReader {
     const userHome = app.getPath('home');
 
     // Source path (legacy structure)
-    const sourcePath = path.join(
-      userHome,
-      'eigent',
-      safeEmail,
-      `task_${taskId}`
-    );
-    const sourceLogPath = path.join(
-      userHome,
-      '.eigent',
-      safeEmail,
-      `task_${taskId}`
-    );
+    const sourcePath =
+      this.taskDirNameCandidates(taskId)
+        .map((taskDirName) =>
+          path.join(userHome, 'eigent', safeEmail, taskDirName)
+        )
+        .find((candidate) => fs.existsSync(candidate)) ||
+      path.join(userHome, 'eigent', safeEmail, this.taskDirName(taskId));
+    const sourceLogPath =
+      this.taskDirNameCandidates(taskId)
+        .map((taskDirName) =>
+          path.join(userHome, '.eigent', safeEmail, taskDirName)
+        )
+        .find((candidate) => fs.existsSync(candidate)) ||
+      path.join(userHome, '.eigent', safeEmail, this.taskDirName(taskId));
 
     // Destination paths (project structure)
     const projectPath = path.join(
@@ -1104,13 +1137,13 @@ export class FileReader {
       safeEmail,
       `project_${projectId}`
     );
-    const destPath = path.join(projectPath, `task_${taskId}`);
+    const destPath = path.join(projectPath, this.taskDirName(taskId));
     const destLogPath = path.join(
       userHome,
       '.eigent',
       safeEmail,
       `project_${projectId}`,
-      `task_${taskId}`
+      this.taskDirName(taskId)
     );
 
     try {
@@ -1157,8 +1190,9 @@ export class FileReader {
         return [];
       }
 
-      const allFiles = this.getFilesRecursive(projectPath, projectPath).map(
-        (file) => {
+      const allFiles = this.getFilesRecursive(projectPath, projectPath)
+        .filter((file) => !file.isFolder)
+        .map((file) => {
           const relativePath = path.relative(projectPath, file.path);
           const taskMatch = relativePath.match(/^task_([^/\\]+)/);
 
@@ -1168,8 +1202,7 @@ export class FileReader {
             project_id: projectId,
             relativePath: relativePath === '.' ? '' : relativePath,
           };
-        }
-      );
+        });
 
       return allFiles.sort((a, b) => {
         return a.path.localeCompare(b.path);

--- a/src/components/Session/SidePanelSections/AgentFolderSection.tsx
+++ b/src/components/Session/SidePanelSections/AgentFolderSection.tsx
@@ -14,6 +14,7 @@
 
 import { SidePanelAccordionBox } from '@/components/Session/SidePanelAccordionBox';
 import { SidePanelListRow } from '@/components/Session/SidePanelSections/primitives';
+import { isVisibleAgentFile } from '@/lib/agentFileFilters';
 import { cn } from '@/lib/utils';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
@@ -92,6 +93,7 @@ export function AgentFolderSection({
     const seen = new Set<string>();
     const out: FileInfo[] = [];
     for (const f of files) {
+      if (!isVisibleAgentFile(f)) continue;
       const key = f.path || f.name;
       if (!key || seen.has(key)) continue;
       seen.add(key);
@@ -103,12 +105,12 @@ export function AgentFolderSection({
   return (
     <SidePanelAccordionBox title={title}>
       {unique.length === 0 ? (
-        <div className="text-ds-text-neutral-subtle-default text-body-sm px-1 py-1 opacity-60">
+        <div className="px-1 py-1 text-body-sm text-ds-text-neutral-subtle-default opacity-60">
           Files the agent writes or updates during this task appear here so you
           can open them.
         </div>
       ) : (
-        <motion.ul layout className="p-0 m-0 space-y-0.5 list-none">
+        <motion.ul layout className="m-0 list-none space-y-0.5 p-0">
           <AnimatePresence initial={false}>
             {unique.map((file) => {
               const Icon = iconFor(file);

--- a/src/components/Session/SidePanelSections/collectSidePanelOutputFiles.ts
+++ b/src/components/Session/SidePanelSections/collectSidePanelOutputFiles.ts
@@ -19,7 +19,7 @@
  * The chat task's top-level `fileList` is not kept in sync, so the side panel
  * must aggregate every known source.
  */
-import { isRuntimeOnlyAgentFile } from '@/lib/agentFileFilters';
+import { isVisibleAgentFile } from '@/lib/agentFileFilters';
 
 function fileInfoDedupKey(f: FileInfo): string {
   const rel = (f.relativePath ?? '').trim();
@@ -35,7 +35,7 @@ export function mergeSidePanelOutputFiles(
   const seen = new Set<string>();
   const out: FileInfo[] = [];
   for (const f of sources.flat()) {
-    if (isRuntimeOnlyAgentFile(f)) continue;
+    if (!isVisibleAgentFile(f)) continue;
     const k = fileInfoDedupKey(f);
     if (!k || seen.has(k)) continue;
     seen.add(k);

--- a/src/lib/agentFileFilters.ts
+++ b/src/lib/agentFileFilters.ts
@@ -17,12 +17,20 @@ type AgentFileLike = {
   relativePath?: string;
   name?: string;
   source?: string;
+  isFolder?: boolean;
 };
 
 const RUNTIME_ONLY_DIRS = new Set(['camel_logs']);
+const TASK_ROOT_NAME_PATTERN =
+  /^task_(?:task_)?(?:\d{10,}(?:-\d+)?|[0-9a-f]{12,}(?:-[0-9a-f]{4,})*)$/i;
 
 function pathSegments(value: string | undefined): string[] {
   return (value || '').replace(/\\/g, '/').split('/').filter(Boolean);
+}
+
+function basename(value: string | undefined): string {
+  const segments = pathSegments(value);
+  return segments[segments.length - 1] || '';
 }
 
 export function isRuntimeOnlyAgentFile(file: AgentFileLike): boolean {
@@ -37,8 +45,26 @@ export function isRuntimeOnlyAgentFile(file: AgentFileLike): boolean {
   return segments.some((segment) => RUNTIME_ONLY_DIRS.has(segment));
 }
 
+export function isAgentTaskRootEntry(file: AgentFileLike): boolean {
+  const name = file.name || basename(file.path);
+  if (!TASK_ROOT_NAME_PATTERN.test(name)) return false;
+
+  const relativeSegments = pathSegments(file.relativePath);
+  if (relativeSegments.length === 0) return basename(file.path) === name;
+
+  return relativeSegments.length === 1 && relativeSegments[0] === name;
+}
+
+export function isVisibleAgentFile(file: AgentFileLike): boolean {
+  return (
+    !file.isFolder &&
+    !isRuntimeOnlyAgentFile(file) &&
+    !isAgentTaskRootEntry(file)
+  );
+}
+
 export function filterVisibleAgentFiles<T extends AgentFileLike>(
   files: T[]
 ): T[] {
-  return files.filter((file) => !isRuntimeOnlyAgentFile(file));
+  return files.filter(isVisibleAgentFile);
 }

--- a/test/unit/lib/agentFileFilters.test.ts
+++ b/test/unit/lib/agentFileFilters.test.ts
@@ -1,0 +1,57 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest';
+
+import { filterVisibleAgentFiles } from '@/lib/agentFileFilters';
+
+describe('filterVisibleAgentFiles', () => {
+  it('keeps only user-visible output files', () => {
+    const files = [
+      {
+        name: 'index.html',
+        path: '/Users/test/eigent/user/project_p/task_1/index.html',
+        relativePath: 'task_1/index.html',
+      },
+      {
+        name: 'task_1',
+        path: '/Users/test/eigent/user/project_p/task_1',
+        relativePath: 'task_1',
+        isFolder: true,
+      },
+      {
+        name: 'task_1784197841790-917',
+        path: '/Users/test/eigent/user/project_p/task_1784197841790-917',
+        relativePath: 'task_1784197841790-917',
+      },
+      {
+        name: 'task_task_9cf6edb4be72400eb48338bb387',
+        path: '/Users/test/eigent/user/project_p/task_task_9cf6edb4be72400eb48338bb387',
+        relativePath: 'task_task_9cf6edb4be72400eb48338bb387',
+      },
+      {
+        name: 'events.jsonl',
+        path: '/Users/test/.eigent/user/project_p/task_1/camel_logs/events.jsonl',
+        relativePath: 'task_1/camel_logs/events.jsonl',
+      },
+      {
+        name: 'trace.jsonl',
+        path: '/Users/test/.eigent/user/project_p/task_1/trace.jsonl',
+        source: 'camel_log',
+      },
+    ];
+
+    expect(filterVisibleAgentFiles(files)).toEqual([files[0]]);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

# Pull Request

## Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

Closes #

## Description

- Filter task root entries like `task_*` / `task_task_*` out of Agent Folder
- Stop Electron project file listing from returning directory nodes as clickable files
- Normalize task directory names to avoid generating `task_task_*` paths while keeping legacy lookup compatibility

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

## Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->

<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->

<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
