### PR TITLE
fix: ignore stale human replies after task lock cleanup

### DIFF
--- a/backend/app/controller/chat_controller.py
+++ b/backend/app/controller/chat_controller.py
@@ -790,7 +790,16 @@ async def human_reply(id: str, data: HumanReply):
         "Human reply received",
         extra={"task_id": id, "reply_length": len(data.reply)},
     )
-    task_lock = get_task_lock(id)
+    task_lock = get_task_lock_if_exists(id)
+    if task_lock is None:
+        chat_logger.warning(
+            "Human reply ignored because task lock no longer exists",
+            extra={"task_id": id, "agent": data.agent},
+        )
+        raise UserException(
+            code.error,
+            "This task is no longer waiting for a human reply. Please send a new message.",
+        )
     try:
         await task_lock.put_human_input(data.agent, data.reply)
     except KeyError as exc:

--- a/backend/tests/app/controller/test_chat_controller.py
+++ b/backend/tests/app/controller/test_chat_controller.py
@@ -436,7 +436,7 @@ class TestChatController:
 
         with (
             patch(
-                "app.controller.chat_controller.get_task_lock",
+                "app.controller.chat_controller.get_task_lock_if_exists",
                 return_value=mock_task_lock,
             ),
         ):
@@ -447,6 +447,19 @@ class TestChatController:
             mock_task_lock.put_human_input.assert_awaited_once_with(
                 "test_agent", "This is my reply"
             )
+
+    @pytest.mark.asyncio
+    async def test_human_reply_missing_task_lock_returns_user_error(self):
+        """Expired human replies should not raise backend program errors."""
+        task_id = "test_task_123"
+        reply_data = HumanReply(agent="test_agent", reply="late reply")
+
+        with patch(
+            "app.controller.chat_controller.get_task_lock_if_exists",
+            return_value=None,
+        ):
+            with pytest.raises(UserException):
+                await human_reply(task_id, reply_data)
 
     def test_install_mcp_success(self, mock_task_lock):
         """Test successful MCP installation."""
@@ -578,7 +591,7 @@ class TestChatControllerIntegration:
 
         with (
             patch(
-                "app.controller.chat_controller.get_task_lock"
+                "app.controller.chat_controller.get_task_lock_if_exists"
             ) as mock_get_lock,
         ):
             mock_task_lock = MagicMock()

--- a/src/components/ChatBox/index.tsx
+++ b/src/components/ChatBox/index.tsx
@@ -35,11 +35,7 @@ import { buildProjectContinuationContext } from '@/store/chatStore';
 import { usePageTabStore } from '@/store/pageTabStore';
 import { useSpaceStore } from '@/store/spaceStore';
 import { ExecutionStatus } from '@/types';
-import {
-  AgentStep,
-  ChatTaskStatus,
-  SessionMode,
-} from '@/types/constants';
+import { AgentStep, ChatTaskStatus, SessionMode } from '@/types/constants';
 import {
   useCallback,
   useEffect,
@@ -746,10 +742,22 @@ export default function ChatBox(): JSX.Element {
 
         chatStore.setIsPending(_taskId, true);
 
-        await fetchPost(`/chat/${targetProjectId}/human-reply`, {
-          agent: chatStore.tasks[_taskId].activeAsk,
-          reply: tempMessageContent,
-        });
+        const replyResult = await fetchPost(
+          `/chat/${targetProjectId}/human-reply`,
+          {
+            agent: chatStore.tasks[_taskId].activeAsk,
+            reply: tempMessageContent,
+          }
+        );
+        if (replyResult?.code === 1) {
+          chatStore.setIsPending(_taskId, false);
+          chatStore.setActiveAskList(_taskId, []);
+          chatStore.setActiveAsk(_taskId, '');
+          toast.error(
+            replyResult.text || 'This task is no longer waiting for a reply.'
+          );
+          return;
+        }
         chatStore.setAttaches(_taskId, []);
         if (chatStore.tasks[_taskId].askList.length === 0) {
           chatStore.setActiveAsk(_taskId, '');

--- a/test/unit/components/ChatBox.test.tsx
+++ b/test/unit/components/ChatBox.test.tsx
@@ -648,6 +648,51 @@ describe('ChatBox Component', async () => {
       });
     });
 
+    it('should clear stale human reply state when backend no longer has the task lock', async () => {
+      const user = userEvent.setup();
+      _mockFetchPost.mockResolvedValueOnce({
+        code: 1,
+        text: 'This task is no longer waiting for a human reply.',
+      });
+
+      const storeObj = {
+        ...defaultChatStoreState,
+        tasks: {
+          'test-task-id': {
+            ...defaultChatStoreState.tasks['test-task-id'],
+            activeAsk: 'test-agent',
+            askList: [],
+            hasMessages: true,
+          },
+        },
+      } as any;
+
+      mockUseChatStoreAdapter.mockReturnValue({
+        projectStore: defaultProjectStoreState as any,
+        chatStore: storeObj,
+      });
+
+      renderChatBox();
+
+      const messageInput = screen.getByTestId('message-input');
+      const sendButton = screen.getByTestId('send-button');
+
+      await user.type(messageInput, 'Late reply');
+      await user.click(sendButton);
+
+      await waitFor(() => {
+        expect(storeObj.setIsPending).toHaveBeenCalledWith(
+          'test-task-id',
+          false
+        );
+        expect(storeObj.setActiveAskList).toHaveBeenCalledWith(
+          'test-task-id',
+          []
+        );
+        expect(storeObj.setActiveAsk).toHaveBeenCalledWith('test-task-id', '');
+      });
+    });
+
     it('should process ask list when human reply is sent', async () => {
       const user = userEvent.setup();
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

# Pull Request

## Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

Closes #

## Description

- Treat late human replies for missing task locks as user-level stale replies instead of backend program errors
- Clear stale `activeAsk` state on the client when the backend reports the task is no longer waiting
- Add backend and ChatBox coverage for stale human-reply handling

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

## Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->

<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->

<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
