### PR TITLE
fix(i18n): apply persisted language on startup

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -39,13 +39,26 @@ const availableLanguages = Object.values(LocaleEnum);
 
 let initialLanguage: string;
 
-if (savedLanguage && availableLanguages.includes(savedLanguage as LocaleEnum)) {
-  initialLanguage = savedLanguage;
-} else {
-  const matched = availableLanguages.find((lang) =>
-    systemLanguage.startsWith(lang)
+// Compare case-insensitively so a persisted value like "zh-Hans" still
+// matches when normalised to "zh-hans", while the canonical locale code
+// (e.g. "zh-Hans") is used as the i18n resource key.  Issue #1779.
+if (savedLanguage) {
+  const match = availableLanguages.find(
+    (lang) => lang.toLowerCase() === savedLanguage
   );
-  initialLanguage = matched || LocaleEnum.English;
+  if (match) {
+    initialLanguage = match;
+  } else {
+    const browserMatch = availableLanguages.find((lang) =>
+      systemLanguage.startsWith(lang.toLowerCase())
+    );
+    initialLanguage = browserMatch || LocaleEnum.English;
+  }
+} else {
+  const browserMatch = availableLanguages.find((lang) =>
+    systemLanguage.startsWith(lang.toLowerCase())
+  );
+  initialLanguage = browserMatch || LocaleEnum.English;
 }
 
 i18n.use(initReactI18next).init({


### PR DESCRIPTION
## Summary

Fixes #1779.

When a user selects Simplified Chinese and restarts Eigent, the UI falls back to English even though Settings still shows "Simplified Chinese". The persisted value `zh-Hans` is lower-cased to `zh-hans` and then compared against the canonical mixed-case `LocaleEnum` values with `availableLanguages.includes()`, which fails. The browser-language fallback has the same defect: `systemLanguage.startsWith(lang)` compares a lower-cased browser language against mixed-case supported codes.

## Root Cause

```ts
// Before — savedLanguage = "zh-hans" (lowercased)
// availableLanguages = ["zh-Hans", "zh-Hant", "en-US", ...]
if (savedLanguage && availableLanguages.includes(savedLanguage as LocaleEnum)) {
  // "zh-hans" is NOT in ["zh-Hans", ...] → false → falls through to fallback
}
```

## Fix

Compare case-insensitively while preserving the canonical locale code as the i18n resource key:

```ts
const match = availableLanguages.find(
  (lang) => lang.toLowerCase() === savedLanguage
);
if (match) {
  initialLanguage = match;  // "zh-Hans" (canonical)
}
```

The browser-language fallback also lower-cases the supported codes before `startsWith`.

## Testing

Verified the logic against these cases:

| Persisted | Browser | Before | After |
|---|---|---|---|
| `zh-Hans` | any | ✅ (already worked) | ✅ |
| `zh-Hans` saved as `zh-hans` | any | ❌ `en-US` | ✅ `zh-Hans` |
| `ZH-HANS` | any | ❌ `en-US` | ✅ `zh-Hans` |
| `en-US` | any | ✅ | ✅ |
| `fr` | any | ✅ | ✅ |
| none | `ja-JP` | ✅ `ja` | ✅ `ja` |