### PR TITLE
fix: persist human replies and normalize preview file paths

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -81,3 +81,9 @@ api.add_middleware(SecurityHeadersMiddleware)
 from app.router_layer import ChannelSessionMiddleware
 
 api.add_middleware(ChannelSessionMiddleware)
+
+# Exception handlers are part of the application boundary and must be
+# registered whenever the shared FastAPI instance is imported by Uvicorn.
+from app.exception.handler import register_exception_handlers  # noqa: E402
+
+register_exception_handlers(api)

--- a/backend/app/controller/chat_controller.py
+++ b/backend/app/controller/chat_controller.py
@@ -70,6 +70,7 @@ from app.utils.cdp_browser_state import (
     get_connected_cdp_endpoint_for_request,
 )
 from app.utils.event_loop_utils import schedule_async_task_from_worker
+from app.utils.server.sync_step import sync_step_event
 from app.utils.workspace_paths import camel_log_root
 from app.utils.workspace_resolver import get_workspace_resolver
 
@@ -785,7 +786,7 @@ async def stop(id: str):
 
 
 @router.post("/chat/{id}/human-reply")
-async def human_reply(id: str, data: HumanReply):
+async def human_reply(id: str, data: HumanReply, request: Request):
     chat_logger.info(
         "Human reply received",
         extra={"task_id": id, "reply_length": len(data.reply)},
@@ -811,6 +812,27 @@ async def human_reply(id: str, data: HumanReply):
             code.error,
             "This task is no longer waiting for a human reply. Please send a new message.",
         ) from exc
+
+    task_lock.add_conversation(
+        "human_reply",
+        {"agent": data.agent, "reply": data.reply},
+    )
+    memory_service = getattr(task_lock, "memory_service", None)
+    run_context = getattr(task_lock, "run_context", None)
+    if memory_service is not None and run_context is not None:
+        memory_service.on_human_reply(
+            run_context=run_context,
+            content=data.reply,
+        )
+
+    cloud_task_id = getattr(task_lock, "current_task_id", None) or id
+    sync_step_event(
+        task_id=cloud_task_id,
+        run_id=cloud_task_id,
+        step="human_reply",
+        data={"agent": data.agent, "reply": data.reply},
+        authorization=request.headers.get("authorization"),
+    )
     chat_logger.debug("Human reply processed", extra={"task_id": id})
     return Response(status_code=201)
 

--- a/backend/app/exception/handler.py
+++ b/backend/app/exception/handler.py
@@ -14,14 +14,12 @@
 
 import logging
 
-from fastapi import Request
+from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
-from app import api
 from app.component import code
-from app.component.pydantic.i18n import get_language, trans
 from app.exception.exception import (
     NoPermissionException,
     ProgramException,
@@ -32,35 +30,38 @@ from app.exception.exception import (
 logger = logging.getLogger("exception_handler")
 
 
-@api.exception_handler(RequestValidationError)
 async def request_exception(request: Request, e: RequestValidationError):
-    if (lang := get_language(request.headers.get("Accept-Language"))) is None:
-        lang = "en_US"
     logger.warning(f"Validation error on {request.url.path}: {e.errors()}")
+    errors = list(e.errors())
+    try:
+        # Translation support is optional in the packaged local runtime. Keep
+        # exception registration independent from fastapi-babel/Jinja2 so a
+        # missing template dependency cannot prevent the API from starting.
+        from app.component.pydantic.i18n import get_language, trans
+
+        lang = get_language(request.headers.get("Accept-Language")) or "en_US"
+        errors = trans.translate(errors, locale=lang)
+    except ImportError:
+        logger.info("Validation translation unavailable; using raw errors")
 
     return JSONResponse(
         content={
             "code": code.form_error,
-            "error": jsonable_encoder(
-                trans.translate(list(e.errors()), locale=lang)
-            ),
+            "error": jsonable_encoder(errors),
         }
     )
 
 
-@api.exception_handler(TokenException)
 async def token_exception(request: Request, e: TokenException):
     logger.warning(f"Token exception on {request.url.path}: {e.text}")
     return JSONResponse(content={"code": e.code, "text": e.text})
 
 
-@api.exception_handler(UserException)
 async def user_exception(request: Request, e: UserException):
     logger.info(f"User exception on {request.url.path}: {e.description}")
     return JSONResponse(content={"code": e.code, "text": e.description})
 
 
-@api.exception_handler(NoPermissionException)
 async def no_permission(request: Request, exception: NoPermissionException):
     logger.warning(f"No permission on {request.url.path}: {exception.text}")
     return JSONResponse(
@@ -69,10 +70,7 @@ async def no_permission(request: Request, exception: NoPermissionException):
     )
 
 
-@api.exception_handler(ProgramException)
-async def program_exception(
-    request: Request, exception: NoPermissionException
-):
+async def program_exception(request: Request, exception: ProgramException):
     logger.error(
         f"Program exception on {request.url.path}: {exception.text}",
         exc_info=True,
@@ -83,7 +81,6 @@ async def program_exception(
     )
 
 
-@api.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     logger.error(
         f"Unhandled exception on {request.method} {request.url.path}: {exc}",
@@ -103,3 +100,13 @@ async def global_exception_handler(request: Request, exc: Exception):
             "message": str(exc),
         },
     )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register Eigent's API error envelope on a FastAPI application."""
+    app.add_exception_handler(RequestValidationError, request_exception)
+    app.add_exception_handler(TokenException, token_exception)
+    app.add_exception_handler(UserException, user_exception)
+    app.add_exception_handler(NoPermissionException, no_permission)
+    app.add_exception_handler(ProgramException, program_exception)
+    app.add_exception_handler(Exception, global_exception_handler)

--- a/backend/app/memory/service.py
+++ b/backend/app/memory/service.py
@@ -346,6 +346,38 @@ class MemoryService:
             )
             return None
 
+    def on_human_reply(
+        self,
+        *,
+        run_context: RunContext,
+        content: str,
+    ) -> str | None:
+        """Persist a mid-run Human Toolkit reply as a user conversation turn."""
+        if not content.strip():
+            return None
+        user_key = _resolve_user_key(run_context)
+        if user_key is None:
+            return None
+        try:
+            return self._append_conversation(
+                user_key=user_key,
+                run_context=run_context,
+                role="user",
+                content=content,
+                source="chat",
+                now=_utc_now(),
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "memory.service.on_human_reply: append failed",
+                extra={
+                    "project_id": run_context.project_id,
+                    "run_id": run_context.run_id,
+                },
+                exc_info=True,
+            )
+            return None
+
     # ----- Run End -----
 
     def on_run_end(

--- a/backend/app/service/task.py
+++ b/backend/app/service/task.py
@@ -362,6 +362,9 @@ class TaskLock:
     human_input: dict[str, asyncio.Queue[str]]
     """After receiving user's reply, put the reply into the
     corresponding agent's queue"""
+    human_input_waiters: dict[str, list[asyncio.Future[Any]]]
+    """Live human-input waits. Replies are delivered directly to one waiter
+    so stale or duplicate HTTP requests cannot leak into a future question."""
     created_at: datetime
     last_accessed: datetime
     background_tasks: set[asyncio.Task]
@@ -419,6 +422,7 @@ class TaskLock:
         self.id = id
         self.queue = queue
         self.human_input = human_input
+        self.human_input_waiters = {}
         self.created_at = datetime.now()
         self.last_accessed = datetime.now()
         self.background_tasks = set()
@@ -476,20 +480,44 @@ class TaskLock:
                 "has_data": data is not None,
             },
         )
-        await self.human_input[agent].put(data)
+        if agent not in self.human_input:
+            raise KeyError(agent)
+
+        waiters = self.human_input_waiters.get(agent, [])
+        while waiters:
+            waiter = waiters.pop(0)
+            if waiter.done():
+                continue
+            waiter.set_result(data)
+            return
+
+        raise KeyError(agent)
 
     async def get_human_input(self, agent: str):
         logger.debug(
             "Getting human input", extra={"task_id": self.id, "agent": agent}
         )
-        return await self.human_input[agent].get()
+        if agent not in self.human_input:
+            raise KeyError(agent)
+
+        waiter = asyncio.get_running_loop().create_future()
+        waiters = self.human_input_waiters.setdefault(agent, [])
+        waiters.append(waiter)
+        try:
+            return await waiter
+        finally:
+            if waiter in waiters:
+                waiters.remove(waiter)
 
     def add_human_input_listen(self, agent: str):
         logger.debug(
             "Adding human input listener",
             extra={"task_id": self.id, "agent": agent},
         )
-        self.human_input[agent] = asyncio.Queue(1)
+        # Toolkit recreation must not replace a queue while an earlier
+        # instance is already waiting for the user's answer.
+        self.human_input.setdefault(agent, asyncio.Queue(1))
+        self.human_input_waiters.setdefault(agent, [])
 
     def add_background_task(self, task: asyncio.Task) -> None:
         r"""Add a task to track and clean up weak references"""
@@ -521,15 +549,14 @@ class TaskLock:
                     pass
         self.background_tasks.clear()
 
-        # Unblock agents waiting on human input so shutdown can proceed.
-        for agent, queue in self.human_input.items():
-            try:
-                queue.put_nowait(TASK_LOCK_CLEANUP_SENTINEL)
-            except asyncio.QueueFull:
-                logger.debug(
-                    "Human input queue already full during cleanup",
-                    extra={"task_id": self.id, "agent": agent},
-                )
+        # Unblock every agent currently waiting on human input so shutdown can
+        # proceed. Future-based delivery avoids leaving cleanup sentinels in a
+        # queue where a later question could consume them.
+        for waiters in self.human_input_waiters.values():
+            for waiter in list(waiters):
+                if not waiter.done():
+                    waiter.set_result(TASK_LOCK_CLEANUP_SENTINEL)
+            waiters.clear()
 
         # Clean up registered toolkits (e.g., remove TerminalToolkit venvs)
         for toolkit in self.registered_toolkits:

--- a/backend/app/utils/server/sync_step.py
+++ b/backend/app/utils/server/sync_step.py
@@ -93,6 +93,36 @@ def sync_step(func):
     return wrapper
 
 
+def sync_step_event(
+    *,
+    task_id: str,
+    step: str,
+    data: dict,
+    authorization: str | None,
+    run_id: str | None = None,
+    server_url: str | None = None,
+) -> None:
+    """Schedule one non-SSE event for cloud playback history."""
+    sync_base = _normalize_server_url(server_url or env("SERVER_URL", ""))
+    if not sync_base or not authorization:
+        return
+
+    payload = {
+        "task_id": task_id,
+        "run_id": run_id or task_id,
+        "step": step,
+        "data": data,
+        "timestamp": time.time_ns() / 1_000_000_000,
+    }
+    asyncio.create_task(
+        _send(
+            f"{sync_base}/chat/steps",
+            payload,
+            {"Authorization": authorization},
+        )
+    )
+
+
 def _try_sync(args, value, sync_url):
     data = _parse_value(value)
     if not data:

--- a/backend/tests/app/controller/test_chat_controller.py
+++ b/backend/tests/app/controller/test_chat_controller.py
@@ -429,7 +429,7 @@ class TestChatController:
             mock_task_lock.put_queue.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_human_reply_success(self, mock_task_lock):
+    async def test_human_reply_success(self, mock_task_lock, mock_request):
         """Test successful human reply."""
         task_id = "test_task_123"
         reply_data = HumanReply(agent="test_agent", reply="This is my reply")
@@ -439,17 +439,40 @@ class TestChatController:
                 "app.controller.chat_controller.get_task_lock_if_exists",
                 return_value=mock_task_lock,
             ),
+            patch(
+                "app.controller.chat_controller.sync_step_event"
+            ) as mock_sync_step,
         ):
-            response = await human_reply(task_id, reply_data)
+            mock_request.headers = {"authorization": "Bearer test"}
+            mock_task_lock.memory_service = None
+            mock_task_lock.run_context = None
+            mock_task_lock.current_task_id = task_id
+            response = await human_reply(task_id, reply_data, mock_request)
 
             assert isinstance(response, Response)
             assert response.status_code == 201
             mock_task_lock.put_human_input.assert_awaited_once_with(
                 "test_agent", "This is my reply"
             )
+            mock_task_lock.add_conversation.assert_called_once_with(
+                "human_reply",
+                {"agent": "test_agent", "reply": "This is my reply"},
+            )
+            mock_sync_step.assert_called_once_with(
+                task_id=task_id,
+                run_id=task_id,
+                step="human_reply",
+                data={
+                    "agent": "test_agent",
+                    "reply": "This is my reply",
+                },
+                authorization="Bearer test",
+            )
 
     @pytest.mark.asyncio
-    async def test_human_reply_missing_task_lock_returns_user_error(self):
+    async def test_human_reply_missing_task_lock_returns_user_error(
+        self, mock_request
+    ):
         """Expired human replies should not raise backend program errors."""
         task_id = "test_task_123"
         reply_data = HumanReply(agent="test_agent", reply="late reply")
@@ -459,7 +482,7 @@ class TestChatController:
             return_value=None,
         ):
             with pytest.raises(UserException):
-                await human_reply(task_id, reply_data)
+                await human_reply(task_id, reply_data, mock_request)
 
     def test_install_mcp_success(self, mock_task_lock):
         """Test successful MCP installation."""

--- a/backend/tests/app/memory/test_service_lifecycle.py
+++ b/backend/tests/app/memory/test_service_lifecycle.py
@@ -203,6 +203,29 @@ class TestRunStart:
         assert space.source_type == "legacy"
 
 
+class TestPerTurnWrites:
+    def test_human_reply_is_persisted_as_user_turn(self, service, run_context):
+        service.on_run_start(
+            run_context=run_context,
+            space_name="W",
+            project_name="P",
+            mode="single_agent",
+            user_prompt="create a script",
+        )
+
+        event_id = service.on_human_reply(
+            run_context=run_context,
+            content="a simple script is enough",
+        )
+
+        assert event_id is not None
+        tail = service.store.read_conversation_tail(
+            "user_42", run_context.space_id, run_context.project_id, limit=10
+        )
+        assert [event.role for event in tail] == ["user", "user"]
+        assert tail[-1].content == "a simple script is enough"
+
+
 class TestRunEnd:
     def test_on_run_end_done_appends_assistant_and_status(
         self, service, run_context

--- a/backend/tests/app/service/test_task.py
+++ b/backend/tests/app/service/test_task.py
@@ -23,6 +23,7 @@ from camel.tasks import Task
 from app.exception.exception import ProgramException
 from app.model.chat import Status, SupplementChat, TaskContent, UpdateData
 from app.service.task import (
+    TASK_LOCK_CLEANUP_SENTINEL,
     Action,
     ActionAskData,
     ActionCreateAgentData,
@@ -248,10 +249,48 @@ class TestTaskLock:
         task_lock.add_human_input_listen(agent_name)
         assert agent_name in task_lock.human_input
 
-        # Put and get human input
+        # A reply is accepted only while the agent is actively waiting.
+        waiting_reply = asyncio.create_task(
+            task_lock.get_human_input(agent_name)
+        )
+        await asyncio.sleep(0)
         await task_lock.put_human_input(agent_name, "user response")
-        response = await task_lock.get_human_input(agent_name)
+        response = await waiting_reply
         assert response == "user response"
+
+        # Duplicate/stale replies must not remain queued for a future ask.
+        with pytest.raises(KeyError):
+            await task_lock.put_human_input(agent_name, "stale response")
+
+    @pytest.mark.asyncio
+    async def test_task_lock_delivers_only_one_reply_per_wait(self):
+        task_lock = TaskLock("test_123", asyncio.Queue(), {})
+        agent_name = "test_agent"
+        task_lock.add_human_input_listen(agent_name)
+
+        waiting_reply = asyncio.create_task(
+            task_lock.get_human_input(agent_name)
+        )
+        await asyncio.sleep(0)
+        await task_lock.put_human_input(agent_name, "first response")
+
+        with pytest.raises(KeyError):
+            await task_lock.put_human_input(agent_name, "duplicate response")
+
+        assert await waiting_reply == "first response"
+
+    @pytest.mark.asyncio
+    async def test_task_lock_cleanup_unblocks_human_input_wait(self):
+        task_lock = TaskLock("test_123", asyncio.Queue(), {})
+        task_lock.add_human_input_listen("test_agent")
+        waiting_reply = asyncio.create_task(
+            task_lock.get_human_input("test_agent")
+        )
+        await asyncio.sleep(0)
+
+        await task_lock.cleanup()
+
+        assert await waiting_reply == TASK_LOCK_CLEANUP_SENTINEL
 
     @pytest.mark.asyncio
     async def test_task_lock_background_task_management(self):
@@ -577,8 +616,12 @@ class TestTaskServiceIntegration:
         assert retrieved_data.data.question == "Improve this"
 
         # Test human input operations
+        waiting_reply = asyncio.create_task(
+            task_lock.get_human_input(agent_name)
+        )
+        await asyncio.sleep(0)
         await task_lock.put_human_input(agent_name, "User response")
-        user_response = await task_lock.get_human_input(agent_name)
+        user_response = await waiting_reply
         assert user_response == "User response"
 
         # Test background task management

--- a/backend/tests/app/test_exception_handler_registration.py
+++ b/backend/tests/app/test_exception_handler_registration.py
@@ -1,0 +1,61 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from app import api
+from app.exception.exception import UserException
+from app.exception.handler import register_exception_handlers
+
+
+def test_user_exception_handler_is_registered_on_shared_api():
+    assert UserException in api.exception_handlers
+
+
+def test_user_exception_returns_api_error_instead_of_http_500():
+    test_api = FastAPI()
+    register_exception_handlers(test_api)
+
+    @test_api.get("/late-human-reply")
+    async def late_human_reply():
+        raise UserException(1, "No longer waiting for a human reply")
+
+    with TestClient(test_api) as client:
+        response = client.get("/late-human-reply")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "code": 1,
+        "text": "No longer waiting for a human reply",
+    }
+
+
+def test_validation_handler_works_without_eager_translation_import():
+    test_api = FastAPI()
+    register_exception_handlers(test_api)
+
+    class Payload(BaseModel):
+        count: int
+
+    @test_api.post("/validate")
+    async def validate(payload: Payload):
+        return payload
+
+    with TestClient(test_api) as client:
+        response = client.post("/validate", json={"count": "not-a-number"})
+
+    assert response.status_code == 200
+    assert response.json()["code"] == 100

--- a/src/components/ChatBox/index.tsx
+++ b/src/components/ChatBox/index.tsx
@@ -369,6 +369,7 @@ export default function ChatBox(): JSX.Element {
   const handleSendRef = useRef<
     ((messageStr?: string, taskId?: string) => Promise<void>) | null
   >(null);
+  const autoReplyAttemptRef = useRef<string | null>(null);
 
   const navigate = useNavigate();
 
@@ -386,7 +387,19 @@ export default function ChatBox(): JSX.Element {
   const [isPauseResumeLoading, setIsPauseResumeLoading] = useState(false);
 
   const activeTaskId = chatStore?.activeTaskId;
-  const activeAsk = chatStore?.tasks[activeTaskId as string]?.activeAsk;
+  const activeAskTask = chatStore?.tasks[activeTaskId as string];
+  const activeAsk = activeAskTask?.activeAsk;
+  const activeAskMessageId = activeAskTask?.messages.findLast(
+    (item) => item.step === AgentStep.ASK
+  )?.id;
+  const isInteractiveHumanReply =
+    activeAskTask?.type !== 'replay' &&
+    activeAskTask?.type !== 'share' &&
+    activeAskTask?.status !== ChatTaskStatus.FINISHED;
+  const activeHumanReplyKey =
+    activeTaskId && activeAsk && isInteractiveHumanReply
+      ? `${activeTaskId}:${activeAskMessageId || activeAsk}`
+      : null;
 
   useEffect(() => {
     if (!chatStore?.activeTaskId) return;
@@ -399,23 +412,24 @@ export default function ChatBox(): JSX.Element {
   }, [chatStore?.activeTaskId, chatStore]);
 
   useEffect(() => {
-    if (!chatStore) return;
-    const _activeAsk = activeAsk;
-    let timer: NodeJS.Timeout;
-    if (_activeAsk && _activeAsk !== '') {
-      const _taskId = chatStore.activeTaskId as string;
-      timer = setTimeout(() => {
-        if (handleSendRef.current) {
-          handleSendRef.current('skip', _taskId);
-        }
-      }, 30000); // 30 seconds
-      return () => clearTimeout(timer); // clear previous timer
+    if (!activeHumanReplyKey || !activeTaskId) {
+      autoReplyAttemptRef.current = null;
+      return;
     }
-    // if activeAsk is empty, also clear timer
-    return () => {
-      if (timer) clearTimeout(timer);
-    };
-  }, [activeAsk, chatStore, activeTaskId]);
+    if (message.trim() || autoReplyAttemptRef.current === activeHumanReplyKey) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      // A failed request must not create an endless 30-second retry loop for
+      // the same question. The prompt remains visible so the user can retry.
+      if (autoReplyAttemptRef.current === activeHumanReplyKey) return;
+      autoReplyAttemptRef.current = activeHumanReplyKey;
+      void handleSendRef.current?.('skip', activeTaskId);
+    }, 30000);
+
+    return () => window.clearTimeout(timer);
+  }, [activeHumanReplyKey, activeTaskId, message]);
 
   const getAllChatStoresMemoized = useMemo(() => {
     if (!projectStore.activeProjectId) return [];
@@ -725,6 +739,9 @@ export default function ChatBox(): JSX.Element {
     if (textareaRef.current) textareaRef.current.style.height = '60px';
     try {
       if (requiresHumanReply) {
+        if (activeHumanReplyKey) {
+          autoReplyAttemptRef.current = activeHumanReplyKey;
+        }
         chatStore.addMessages(_taskId, {
           id: generateUniqueId(),
           role: 'user',

--- a/src/lib/fileInfo.ts
+++ b/src/lib/fileInfo.ts
@@ -21,6 +21,11 @@ export function getFileExtension(value?: string): string {
   return lastSegment.split('.').pop()?.toLowerCase() || '';
 }
 
+/** Remove the link-only sandbox scheme before passing a local path to Electron. */
+export function normalizeFileInfoPath(path: string): string {
+  return path.replace(/^sandbox:(?=(?:[A-Za-z]:)?[\\/])/i, '');
+}
+
 /**
  * Build a minimal {@link FileInfo} from a file path (and optional display name),
  * inferring `type` from the extension and `isRemote` from an http(s) prefix.
@@ -28,11 +33,13 @@ export function getFileExtension(value?: string): string {
  * a path/name is available.
  */
 export function fileInfoFromPath(path: string, name?: string): FileInfo {
-  const cleanName = name || path.split(/[\\/]/).pop() || path;
+  const normalizedPath = normalizeFileInfoPath(path);
+  const cleanName =
+    name || normalizedPath.split(/[\\/]/).pop() || normalizedPath;
   return {
     name: cleanName,
-    path,
-    type: getFileExtension(cleanName) || getFileExtension(path),
-    isRemote: /^https?:\/\//i.test(path),
+    path: normalizedPath,
+    type: getFileExtension(cleanName) || getFileExtension(normalizedPath),
+    isRemote: /^https?:\/\//i.test(normalizedPath),
   };
 }

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -1262,6 +1262,8 @@ const chatStore = (initial?: Partial<ChatStore>) =>
             // Never resurrect a task as pending / awaiting confirmation
             // from a cached snapshot — those are in-flight flags only.
             isPending: false,
+            activeAsk: '',
+            askList: [],
             autoConfirmDeadline: null,
             streamingDecomposeText: '',
             // File handles can't round-trip through JSON, so cached
@@ -3677,6 +3679,8 @@ const chatStore = (initial?: Partial<ChatStore>) =>
               setTaskAssigning(currentTaskId, taskAssigning);
 
               // Complete the current task with error status
+              setActiveAsk(currentTaskId, '');
+              setActiveAskList(currentTaskId, []);
               setStatus(currentTaskId, ChatTaskStatus.FINISHED);
               setIsPending(currentTaskId, false);
 
@@ -3874,6 +3878,8 @@ const chatStore = (initial?: Partial<ChatStore>) =>
 
             addMessages(currentTaskId, endUiMessage);
             setIsPending(currentTaskId, false);
+            setActiveAsk(currentTaskId, '');
+            setActiveAskList(currentTaskId, []);
             setStatus(currentTaskId, ChatTaskStatus.FINISHED);
             setUpdateCount();
 
@@ -4174,28 +4180,61 @@ const chatStore = (initial?: Partial<ChatStore>) =>
             return;
           }
           if (agentMessages.step === AgentStep.SYNC) return;
-          if (agentMessages.step === AgentStep.ASK) {
-            if (tasks[currentTaskId].activeAsk != '') {
-              const newMessage: Message = {
+          if (agentMessages.step === AgentStep.HUMAN_REPLY) {
+            const reply =
+              agentMessages.data?.reply ||
+              agentMessages.data?.content ||
+              (typeof agentMessages.data === 'string'
+                ? agentMessages.data
+                : '');
+            if (reply) {
+              addMessages(currentTaskId, {
                 id: generateUniqueId(),
-                role: 'agent',
-                agent_name: agentMessages.data.agent || '',
-                content:
-                  agentMessages.data?.content ||
-                  agentMessages.data?.notice ||
-                  agentMessages.data?.answer ||
-                  agentMessages.data?.question ||
-                  (agentMessages.data as string) ||
-                  '',
-                step: agentMessages.step,
-                isConfirm: false,
-              };
+                role: 'user',
+                content: reply,
+              });
+            }
+
+            const [nextAsk, ...remainingAsks] = tasks[currentTaskId].askList;
+            setActiveAskList(currentTaskId, remainingAsks);
+            if (nextAsk) {
+              setActiveAsk(currentTaskId, nextAsk.agent_name || '');
+              addMessages(currentTaskId, nextAsk);
+            } else {
+              setActiveAsk(currentTaskId, '');
+            }
+            setIsPending(currentTaskId, false);
+            return;
+          }
+          if (agentMessages.step === AgentStep.ASK) {
+            const newMessage: Message = {
+              id: generateUniqueId(),
+              role: 'agent',
+              agent_name: agentMessages.data.agent || '',
+              content:
+                agentMessages.data?.content ||
+                agentMessages.data?.notice ||
+                agentMessages.data?.answer ||
+                agentMessages.data?.question ||
+                (agentMessages.data as string) ||
+                '',
+              step: agentMessages.step,
+              isConfirm: false,
+            };
+
+            if (tasks[currentTaskId].activeAsk != '') {
               let activeAskList = tasks[currentTaskId].askList;
               setActiveAskList(currentTaskId, [...activeAskList, newMessage]);
               return;
             }
+            // Playback ASK state is read-only: ChatBox excludes replay/share
+            // tasks from live input timers. Keeping the state here lets a
+            // recorded HUMAN_REPLY promote queued historical questions in
+            // the same order as the original run.
             setActiveAsk(currentTaskId, agentMessages.data.agent || '');
             setIsPending(currentTaskId, false);
+            addMessages(currentTaskId, newMessage);
+            return;
           }
           const newMessage: Message = {
             id: generateUniqueId(),

--- a/src/types/chatbox.d.ts
+++ b/src/types/chatbox.d.ts
@@ -142,6 +142,7 @@ declare global {
       state?: string;
       message?: string;
       question?: string;
+      reply?: string;
       agent?: string;
       file_path?: string;
       process_task_id?: string;

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -40,6 +40,7 @@ export const AgentStep = {
   REMOVE_TASK: 'remove_task',
   NOTICE: 'notice',
   ASK: 'ask',
+  HUMAN_REPLY: 'human_reply',
   SYNC: 'sync',
   NOTICE_CARD: 'notice_card',
   FAILED: 'failed',

--- a/test/unit/components/ChatBox.test.tsx
+++ b/test/unit/components/ChatBox.test.tsx
@@ -13,7 +13,7 @@
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
 // Comprehensive unit tests for ChatBox component
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -737,6 +737,109 @@ describe('ChatBox Component', async () => {
         const apiCalled = (_mockFetchPost as any).mock.calls.length > 0;
         expect(storeCalled || apiCalled).toBe(true);
       });
+    });
+
+    it('should auto-skip a failed human reply only once per question', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const timeoutSpy = vi.spyOn(window, 'setTimeout');
+      _mockFetchPost.mockRejectedValue(new Error('Backend unavailable'));
+
+      const activeAskTask = {
+        ...defaultChatStoreState.tasks['test-task-id'],
+        activeAsk: 'test-agent',
+        hasMessages: true,
+        messages: [
+          {
+            id: 'ask-1',
+            role: 'agent',
+            content: 'Please clarify',
+            step: 'ask',
+          },
+        ],
+      };
+      mockUseChatStoreAdapter.mockReturnValue({
+        projectStore: defaultProjectStoreState as any,
+        chatStore: {
+          ...defaultChatStoreState,
+          tasks: { 'test-task-id': activeAskTask },
+        } as any,
+      });
+
+      const rendered = renderChatBox();
+      const autoReplyTimer = timeoutSpy.mock.calls.find(
+        ([, delay]) => delay === 30000
+      );
+      expect(autoReplyTimer).toBeDefined();
+      await act(async () => {
+        (autoReplyTimer![0] as TimerHandler)();
+        await Promise.resolve();
+      });
+
+      expect(_mockFetchPost).toHaveBeenCalledTimes(1);
+      expect(_mockFetchPost).toHaveBeenCalledWith(
+        '/chat/test-project-id/human-reply',
+        { agent: 'test-agent', reply: 'skip' }
+      );
+
+      // Store snapshots change as messages/pending state update. Re-rendering
+      // the same prompt must not arm another automatic reply timer.
+      mockUseChatStoreAdapter.mockReturnValue({
+        projectStore: defaultProjectStoreState as any,
+        chatStore: {
+          ...defaultChatStoreState,
+          tasks: { 'test-task-id': { ...activeAskTask } },
+        } as any,
+      });
+      rendered.rerender(
+        <BrowserRouter>
+          <ChatBox />
+        </BrowserRouter>
+      );
+      await act(async () => {
+        (autoReplyTimer![0] as TimerHandler)();
+        await Promise.resolve();
+      });
+
+      expect(_mockFetchPost).toHaveBeenCalledTimes(1);
+      expect(
+        timeoutSpy.mock.calls.filter(([, delay]) => delay === 30000)
+      ).toHaveLength(1);
+      timeoutSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not auto-skip a question while replaying history', () => {
+      const timeoutSpy = vi.spyOn(window, 'setTimeout');
+      const replayTask = {
+        ...defaultChatStoreState.tasks['test-task-id'],
+        type: 'replay',
+        activeAsk: 'test-agent',
+        hasMessages: true,
+        messages: [
+          {
+            id: 'historical-ask-1',
+            role: 'agent',
+            content: 'Historical question',
+            step: 'ask',
+          },
+        ],
+      };
+      mockUseChatStoreAdapter.mockReturnValue({
+        projectStore: defaultProjectStoreState as any,
+        chatStore: {
+          ...defaultChatStoreState,
+          tasks: { 'test-task-id': replayTask },
+        } as any,
+      });
+
+      renderChatBox();
+
+      expect(
+        timeoutSpy.mock.calls.filter(([, delay]) => delay === 30000)
+      ).toHaveLength(0);
+      timeoutSpy.mockRestore();
     });
   });
 

--- a/test/unit/electron/main/filePath.test.ts
+++ b/test/unit/electron/main/filePath.test.ts
@@ -15,6 +15,21 @@
 import { normalizeLegacySandboxPath } from '../../../../electron/main/utils/filePath';
 
 describe('normalizeLegacySandboxPath', () => {
+  it('removes sandbox schemes from absolute local paths', () => {
+    expect(
+      normalizeLegacySandboxPath(
+        'sandbox:/Users/test/project/simple_greeting.py',
+        'darwin'
+      )
+    ).toBe('/Users/test/project/simple_greeting.py');
+    expect(
+      normalizeLegacySandboxPath(
+        'sandbox:C:\\Users\\test\\project\\report.csv',
+        'win32'
+      )
+    ).toBe('C:\\Users\\test\\project\\report.csv');
+  });
+
   it('repairs x-prefixed POSIX paths on non-Windows platforms', () => {
     expect(
       normalizeLegacySandboxPath('x:/Users/test/report.csv', 'darwin')
@@ -37,5 +52,8 @@ describe('normalizeLegacySandboxPath', () => {
     expect(
       normalizeLegacySandboxPath('https://example.com/report.csv', 'darwin')
     ).toBe('https://example.com/report.csv');
+    expect(
+      normalizeLegacySandboxPath('sandbox:relative/report.csv', 'darwin')
+    ).toBe('sandbox:relative/report.csv');
   });
 });

--- a/test/unit/lib/fileInfo.test.ts
+++ b/test/unit/lib/fileInfo.test.ts
@@ -12,19 +12,26 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-export function normalizeLegacySandboxPath(
-  filePath: string,
-  platform: NodeJS.Platform = process.platform
-): string {
-  const withoutSandboxScheme = filePath.replace(
-    /^sandbox:(?=(?:[A-Za-z]:)?[\\/])/i,
-    ''
-  );
-  const hadSandboxScheme = withoutSandboxScheme !== filePath;
+import { fileInfoFromPath } from '@/lib/fileInfo';
+import { describe, expect, it } from 'vitest';
 
-  if (platform === 'win32') return withoutSandboxScheme;
+describe('fileInfoFromPath', () => {
+  it('turns sandbox file links into local file paths', () => {
+    expect(
+      fileInfoFromPath('sandbox:/Users/test/project/simple_greeting.py')
+    ).toEqual({
+      name: 'simple_greeting.py',
+      path: '/Users/test/project/simple_greeting.py',
+      type: 'py',
+      isRemote: false,
+    });
+  });
 
-  const normalized = withoutSandboxScheme.replace(/\\/g, '/');
-  if (/^x:\//i.test(normalized)) return normalized.slice(2);
-  return hadSandboxScheme ? normalized : filePath;
-}
+  it('preserves remote URLs', () => {
+    expect(fileInfoFromPath('https://example.com/report.csv')).toMatchObject({
+      path: 'https://example.com/report.csv',
+      type: 'csv',
+      isRemote: true,
+    });
+  });
+});

--- a/test/unit/store/chatStore.test.ts
+++ b/test/unit/store/chatStore.test.ts
@@ -191,6 +191,35 @@ describe('ChatStore - Core Functionality', () => {
     });
   });
 
+  describe('Cached task hydration', () => {
+    it('does not resurrect a stale human-reply wait', () => {
+      const { result } = renderHook(() => useChatStore());
+      const taskId = result.current.getState().create();
+      const cachedTask = {
+        ...result.current.getState().tasks[taskId],
+        activeAsk: 'Agents.single_agent',
+        askList: [
+          {
+            id: 'queued-ask',
+            role: 'agent',
+            content: 'Old question',
+            step: 'ask',
+          },
+        ],
+        isPending: true,
+      } as any;
+
+      act(() => {
+        result.current.getState().hydrateTask(taskId, cachedTask);
+      });
+
+      const hydrated = result.current.getState().tasks[taskId];
+      expect(hydrated.activeAsk).toBe('');
+      expect(hydrated.askList).toEqual([]);
+      expect(hydrated.isPending).toBe(false);
+    });
+  });
+
   describe('END message resolution', () => {
     it('keeps non-empty END payload ahead of prior agent summaries', () => {
       expect(
@@ -1169,6 +1198,10 @@ describe('ChatStore - Core Functionality', () => {
     const replayProjectState = () => ({
       activeProjectId: 'proj-replay',
       getHistoryId: () => null,
+      getProjectById: () => ({
+        id: 'proj-replay',
+        mode: 'single',
+      }),
     });
 
     beforeEach(() => {
@@ -1198,6 +1231,93 @@ describe('ChatStore - Core Functionality', () => {
       expect(result.current.getState().tasks['replay-1']).toBeDefined();
       expect(result.current.getState().activeTaskId).toBe('replay-1');
       expect(fetchEventSource).toHaveBeenCalled();
+    });
+
+    it('replays a recorded human reply without leaving an active wait', async () => {
+      vi.mocked(fetchEventSource).mockImplementation(async (_url, opts) => {
+        for (const event of [
+          {
+            step: 'ask',
+            data: {
+              agent: 'Agents.single_agent',
+              question: 'What kind of script?',
+            },
+          },
+          {
+            step: 'human_reply',
+            data: {
+              agent: 'Agents.single_agent',
+              reply: 'A simple script is enough',
+            },
+          },
+          { step: 'end', data: 'Created the script' },
+        ]) {
+          opts.onmessage?.({ data: JSON.stringify(event) } as any);
+        }
+        return Promise.resolve();
+      });
+      const { result } = renderHook(() => useChatStore());
+      const taskId = result.current.getState().create();
+      result.current.getState().addMessages(taskId, {
+        id: generateUniqueId(),
+        role: 'user',
+        content: 'Create a script',
+      });
+
+      await act(async () => {
+        await result.current
+          .getState()
+          .startTask(taskId, 'replay', undefined, 0);
+      });
+
+      const task = result.current.getState().tasks[taskId];
+      expect(task.messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: 'agent',
+            step: 'ask',
+            content: 'What kind of script?',
+          }),
+          expect.objectContaining({
+            role: 'user',
+            content: 'A simple script is enough',
+          }),
+        ])
+      );
+      expect(task.activeAsk).toBe('');
+      expect(task.askList).toEqual([]);
+      expect(task.status).toBe(ChatTaskStatus.FINISHED);
+    });
+
+    it('clears legacy replay ASK state when the task ends', async () => {
+      vi.mocked(fetchEventSource).mockImplementation(async (_url, opts) => {
+        opts.onmessage?.({
+          data: JSON.stringify({
+            step: 'ask',
+            data: {
+              agent: 'Agents.single_agent',
+              question: 'Historical question',
+            },
+          }),
+        } as any);
+        opts.onmessage?.({
+          data: JSON.stringify({ step: 'end', data: 'Finished' }),
+        } as any);
+        return Promise.resolve();
+      });
+      const { result } = renderHook(() => useChatStore());
+      const taskId = result.current.getState().create();
+
+      await act(async () => {
+        await result.current
+          .getState()
+          .startTask(taskId, 'replay', undefined, 0);
+      });
+
+      const task = result.current.getState().tasks[taskId];
+      expect(task.activeAsk).toBe('');
+      expect(task.askList).toEqual([]);
+      expect(task.status).toBe(ChatTaskStatus.FINISHED);
     });
 
     it('replay SSE: AbortError does not throw', async () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

# Pull Request

## Related Issue

Closes #

## Description

Two fixes:

- **Persist human replies.** Replies were consumed by the live agent but never recorded. `/chat/{id}/human-reply` now writes a `human_reply` conversation entry, notifies the memory service, and syncs the reply to cloud playback via a new `sync_step_event`. `chatStore`/`ChatBox` render persisted replies in history/replay.
- **Normalize preview file paths.** Strip the link-only `sandbox:` scheme (including `sandbox:C:\...`) in both the renderer and Electron main before paths reach the OS; Windows is no longer skipped by legacy-path normalization.

## Testing Evidence (REQUIRED)

- [x] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
