### PR TITLE
fix: harden session terminal transport and lifecycle

### DIFF
--- a/backend/app/controller/workspace_controller.py
+++ b/backend/app/controller/workspace_controller.py
@@ -225,6 +225,104 @@ async def workspace_current(
     }
 
 
+@router.get("/workspace/effective-directory")
+async def workspace_effective_directory(
+    space_id: str = Query(..., description="Space ID"),
+    project_id: str = Query(..., description="Project ID"),
+    email: str = Query(..., description="User email"),
+    user_id: str | None = Query(None, description="Canonical user ID"),
+    task_id: str | None = Query(None, description="Run/task ID"),
+    workdir_mode: str | None = Query(
+        None, description="Project working-directory mode"
+    ),
+) -> dict[str, Any]:
+    """Return the Brain-authoritative directory for a Project terminal."""
+    resolver = get_workspace_resolver()
+
+    if task_id:
+        snapshot = resolver.store.get_snapshot(email, task_id, user_id)
+        if (
+            snapshot is not None
+            and snapshot.project_id == project_id
+            and snapshot.space_id == space_id
+        ):
+            working_directory = Path(snapshot.working_directory).expanduser()
+            if working_directory.is_dir():
+                return {
+                    "space_id": space_id,
+                    "project_id": project_id,
+                    "task_id": task_id,
+                    "working_directory": str(working_directory),
+                    "source": "task_snapshot",
+                    "workdir_mode": snapshot.workdir_mode,
+                }
+
+    task_lock = get_task_lock_if_exists(project_id)
+    if (
+        task_lock is not None
+        and task_lock.working_directory
+        and (
+            task_lock.project_id is None or task_lock.project_id == project_id
+        )
+        and (task_lock.space_id is None or task_lock.space_id == space_id)
+        and (task_id is None or task_lock.current_task_id == task_id)
+    ):
+        working_directory = Path(task_lock.working_directory).expanduser()
+        if working_directory.is_dir():
+            return {
+                "space_id": space_id,
+                "project_id": project_id,
+                "task_id": task_lock.current_task_id,
+                "working_directory": str(working_directory),
+                "source": "active_run",
+                "workdir_mode": task_lock.workdir_mode,
+            }
+
+    latest_snapshot = resolver.store.get_latest_project_snapshot(
+        email, project_id, space_id, user_id
+    )
+    if latest_snapshot is not None:
+        working_directory = Path(
+            latest_snapshot.working_directory
+        ).expanduser()
+        if working_directory.is_dir():
+            return {
+                "space_id": space_id,
+                "project_id": project_id,
+                "task_id": latest_snapshot.task_id,
+                "working_directory": str(working_directory),
+                "source": "task_snapshot",
+                "workdir_mode": latest_snapshot.workdir_mode,
+            }
+
+    fallback_workdir_mode = (
+        latest_snapshot.workdir_mode
+        if latest_snapshot is not None
+        else workdir_mode
+    )
+    if fallback_workdir_mode in {None, "direct-write"}:
+        binding = resolver.store.get_binding(email, space_id, user_id)
+        if binding is not None:
+            working_directory = Path(binding.workspace_root).expanduser()
+            if working_directory.is_dir():
+                return {
+                    "space_id": space_id,
+                    "project_id": project_id,
+                    "task_id": None,
+                    "working_directory": str(working_directory),
+                    "source": "binding",
+                    "workdir_mode": fallback_workdir_mode,
+                }
+
+    raise HTTPException(
+        status_code=404,
+        detail={
+            "code": "effective_workspace_unavailable",
+            "message": "No Brain-resolved working directory is available for this Project.",
+        },
+    )
+
+
 @router.post("/workspace/scratch")
 async def workspace_scratch(
     payload: WorkspaceScratchRequest, request: Request

--- a/backend/app/utils/workspace_resolver.py
+++ b/backend/app/utils/workspace_resolver.py
@@ -364,23 +364,63 @@ class WorkspaceStore:
                     )
         return list(bindings_by_space.values())
 
+    @staticmethod
+    def _read_snapshot(path: Path) -> TaskSnapshot | None:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if "space_id" not in data:
+                data["space_id"] = data.get("project_id", "")
+            data.setdefault("user_id", None)
+            data.setdefault("workdir_mode", None)
+            data.setdefault("base_snapshot_id", None)
+            return TaskSnapshot(**data)
+        except Exception:
+            logger.warning("Failed to read task snapshot: %s", path)
+            return None
+
     def get_snapshot(
         self, email: str, task_id: str, user_id: str | int | None = None
     ) -> TaskSnapshot | None:
         for path in self._task_paths(email, task_id, user_id):
             if not path.exists():
                 continue
-            try:
-                data = json.loads(path.read_text(encoding="utf-8"))
-                if "space_id" not in data:
-                    data["space_id"] = data.get("project_id", "")
-                data.setdefault("user_id", None)
-                data.setdefault("workdir_mode", None)
-                data.setdefault("base_snapshot_id", None)
-                return TaskSnapshot(**data)
-            except Exception:
-                logger.warning("Failed to read task snapshot: %s", path)
+            snapshot = self._read_snapshot(path)
+            if snapshot is not None:
+                return snapshot
         return None
+
+    def get_latest_project_snapshot(
+        self,
+        email: str,
+        project_id: str,
+        space_id: str,
+        user_id: str | int | None = None,
+    ) -> TaskSnapshot | None:
+        """Return the newest persisted Run directory for one Project."""
+        latest: TaskSnapshot | None = None
+        for root in self._state_roots(email, user_id):
+            tasks_dir = root / "tasks"
+            if not tasks_dir.exists():
+                continue
+            for path in tasks_dir.glob("*.json"):
+                snapshot = self._read_snapshot(path)
+                if (
+                    snapshot is None
+                    or snapshot.project_id != project_id
+                    or snapshot.space_id != space_id
+                    or (
+                        user_id is not None
+                        and snapshot.user_id is not None
+                        and str(snapshot.user_id) != str(user_id)
+                    )
+                ):
+                    continue
+                if (
+                    latest is None
+                    or snapshot.task_start_time > latest.task_start_time
+                ):
+                    latest = snapshot
+        return latest
 
     def save_snapshot(self, email: str, snapshot: TaskSnapshot) -> None:
         self._atomic_write(

--- a/backend/tests/app/controller/test_workspace_controller_effective_directory.py
+++ b/backend/tests/app/controller/test_workspace_controller_effective_directory.py
@@ -1,0 +1,217 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.controller import workspace_controller
+
+
+def workspace_store(*, snapshot=None, latest_snapshot=None, binding=None):
+    return SimpleNamespace(
+        get_snapshot=lambda *_args: snapshot,
+        get_latest_project_snapshot=lambda *_args: latest_snapshot,
+        get_binding=lambda *_args: binding,
+    )
+
+
+@pytest.mark.asyncio
+async def test_effective_directory_returns_matching_task_snapshot(
+    monkeypatch, tmp_path
+):
+    working_directory = tmp_path / "project-workdir"
+    working_directory.mkdir()
+    snapshot = SimpleNamespace(
+        project_id="project-1",
+        space_id="space-1",
+        working_directory=str(working_directory),
+        workdir_mode="copy",
+    )
+    resolver = SimpleNamespace(store=workspace_store(snapshot=snapshot))
+    monkeypatch.setattr(
+        workspace_controller, "get_workspace_resolver", lambda: resolver
+    )
+    monkeypatch.setattr(
+        workspace_controller, "get_task_lock_if_exists", lambda _id: None
+    )
+
+    result = await workspace_controller.workspace_effective_directory(
+        space_id="space-1",
+        project_id="project-1",
+        email="user@example.com",
+        user_id="7",
+        task_id="task-1",
+    )
+
+    assert result["working_directory"] == str(working_directory)
+    assert result["source"] == "task_snapshot"
+    assert result["workdir_mode"] == "copy"
+
+
+@pytest.mark.asyncio
+async def test_effective_directory_falls_back_to_matching_active_run(
+    monkeypatch, tmp_path
+):
+    working_directory = tmp_path / "active-run"
+    working_directory.mkdir()
+    resolver = SimpleNamespace(store=workspace_store())
+    task_lock = SimpleNamespace(
+        project_id="project-1",
+        space_id="space-1",
+        current_task_id="task-1",
+        working_directory=str(working_directory),
+        workdir_mode="direct-write",
+    )
+    monkeypatch.setattr(
+        workspace_controller, "get_workspace_resolver", lambda: resolver
+    )
+    monkeypatch.setattr(
+        workspace_controller,
+        "get_task_lock_if_exists",
+        lambda _id: task_lock,
+    )
+
+    result = await workspace_controller.workspace_effective_directory(
+        space_id="space-1",
+        project_id="project-1",
+        email="user@example.com",
+        task_id="task-1",
+    )
+
+    assert result["working_directory"] == str(working_directory)
+    assert result["source"] == "active_run"
+
+
+@pytest.mark.asyncio
+async def test_effective_directory_rejects_cross_project_snapshot(
+    monkeypatch, tmp_path
+):
+    working_directory = tmp_path / "other-project"
+    working_directory.mkdir()
+    snapshot = SimpleNamespace(
+        project_id="project-other",
+        space_id="space-1",
+        working_directory=str(working_directory),
+        workdir_mode="copy",
+    )
+    resolver = SimpleNamespace(store=workspace_store(snapshot=snapshot))
+    monkeypatch.setattr(
+        workspace_controller, "get_workspace_resolver", lambda: resolver
+    )
+    monkeypatch.setattr(
+        workspace_controller, "get_task_lock_if_exists", lambda _id: None
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await workspace_controller.workspace_effective_directory(
+            space_id="space-1",
+            project_id="project-1",
+            email="user@example.com",
+            task_id="task-1",
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail["code"] == "effective_workspace_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_effective_directory_uses_latest_project_snapshot_when_idle(
+    monkeypatch, tmp_path
+):
+    working_directory = tmp_path / "latest-project-workdir"
+    working_directory.mkdir()
+    latest_snapshot = SimpleNamespace(
+        task_id="task-latest",
+        project_id="project-1",
+        space_id="space-1",
+        working_directory=str(working_directory),
+        workdir_mode="copy",
+    )
+    resolver = SimpleNamespace(
+        store=workspace_store(latest_snapshot=latest_snapshot)
+    )
+    monkeypatch.setattr(
+        workspace_controller, "get_workspace_resolver", lambda: resolver
+    )
+    monkeypatch.setattr(
+        workspace_controller, "get_task_lock_if_exists", lambda _id: None
+    )
+
+    result = await workspace_controller.workspace_effective_directory(
+        space_id="space-1",
+        project_id="project-1",
+        email="user@example.com",
+    )
+
+    assert result["task_id"] == "task-latest"
+    assert result["working_directory"] == str(working_directory)
+    assert result["source"] == "task_snapshot"
+    assert result["workdir_mode"] == "copy"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("workdir_mode", [None, "direct-write"])
+async def test_effective_directory_uses_binding_for_direct_write_idle_project(
+    monkeypatch, tmp_path, workdir_mode
+):
+    workspace_root = tmp_path / "bound-space"
+    workspace_root.mkdir()
+    binding = SimpleNamespace(workspace_root=str(workspace_root))
+    resolver = SimpleNamespace(store=workspace_store(binding=binding))
+    monkeypatch.setattr(
+        workspace_controller, "get_workspace_resolver", lambda: resolver
+    )
+    monkeypatch.setattr(
+        workspace_controller, "get_task_lock_if_exists", lambda _id: None
+    )
+
+    result = await workspace_controller.workspace_effective_directory(
+        space_id="space-1",
+        project_id="project-1",
+        email="user@example.com",
+        workdir_mode=workdir_mode,
+    )
+
+    assert result["working_directory"] == str(workspace_root)
+    assert result["source"] == "binding"
+    assert result["workdir_mode"] == workdir_mode
+
+
+@pytest.mark.asyncio
+async def test_effective_directory_does_not_use_binding_for_copy_project(
+    monkeypatch, tmp_path
+):
+    workspace_root = tmp_path / "bound-space"
+    workspace_root.mkdir()
+    binding = SimpleNamespace(workspace_root=str(workspace_root))
+    resolver = SimpleNamespace(store=workspace_store(binding=binding))
+    monkeypatch.setattr(
+        workspace_controller, "get_workspace_resolver", lambda: resolver
+    )
+    monkeypatch.setattr(
+        workspace_controller, "get_task_lock_if_exists", lambda _id: None
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await workspace_controller.workspace_effective_directory(
+            space_id="space-1",
+            project_id="project-1",
+            email="user@example.com",
+            workdir_mode="copy",
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail["code"] == "effective_workspace_unavailable"

--- a/backend/tests/app/utils/test_workspace_store_snapshots.py
+++ b/backend/tests/app/utils/test_workspace_store_snapshots.py
@@ -1,0 +1,64 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from app.utils.workspace_resolver import TaskSnapshot, WorkspaceStore
+
+
+def task_snapshot(task_id: str, task_start_time: float) -> TaskSnapshot:
+    return TaskSnapshot(
+        task_id=task_id,
+        project_id="project-1",
+        space_id="space-1",
+        user_id="7",
+        working_directory=f"/work/{task_id}",
+        task_output_root=f"/output/{task_id}",
+        task_start_time=task_start_time,
+        binding_source="space_local_brain",
+        created_at="2026-07-31T00:00:00Z",
+        workdir_mode="copy",
+    )
+
+
+def test_get_latest_project_snapshot_uses_persisted_start_time(
+    monkeypatch, tmp_path
+):
+    store = WorkspaceStore()
+    monkeypatch.setattr(store, "_state_roots", lambda *_args: (tmp_path,))
+    store.save_snapshot("user@example.com", task_snapshot("task-old", 10))
+    store.save_snapshot("user@example.com", task_snapshot("task-new", 20))
+    store.save_snapshot(
+        "user@example.com",
+        TaskSnapshot(
+            **{
+                **task_snapshot("task-other", 30).__dict__,
+                "project_id": "project-other",
+            }
+        ),
+    )
+    store.save_snapshot(
+        "user@example.com",
+        TaskSnapshot(
+            **{
+                **task_snapshot("task-other-user", 40).__dict__,
+                "user_id": "99",
+            }
+        ),
+    )
+
+    latest = store.get_latest_project_snapshot(
+        "user@example.com", "project-1", "space-1", "7"
+    )
+
+    assert latest is not None
+    assert latest.task_id == "task-new"

--- a/electron/main/terminal.ts
+++ b/electron/main/terminal.ts
@@ -31,10 +31,7 @@ interface TerminalCreateResult {
 }
 
 interface TerminalSession {
-  /**
-   * The renderer currently attached to this shell. This must remain mutable:
-   * restored tabs reuse their persisted shell id from a new WebContents.
-   */
+  /** Live renderer that owns this shell; a destroyed owner may be replaced. */
   sender: WebContents;
   /** Set after node-pty loads and the synchronous spawn completes. */
   pty: IPty | null;
@@ -42,9 +39,15 @@ interface TerminalSession {
   disposed: boolean;
   /** Shared by concurrent creates so only one PTY can be spawned per id. */
   creation: Promise<TerminalCreateResult>;
+  /** Short batching window prevents high-volume commands flooding IPC. */
+  outputChunks: string[];
+  outputCodeUnits: number;
+  outputTimer: ReturnType<typeof setTimeout> | null;
 }
 
 const sessions = new Map<string, TerminalSession>();
+const OUTPUT_BATCH_DELAY_MS = 16;
+const OUTPUT_BATCH_MAX_CODE_UNITS = 64 * 1024;
 
 /**
  * node-pty is a native module; load it lazily so a missing/broken binary
@@ -70,13 +73,71 @@ function defaultShell(): { file: string; args: string[] } {
 }
 
 /**
- * Do not leak credentials held by the Electron main process into an
- * interactive shell where a plain `env` would print them. Keep ordinary
- * desktop environment variables so the shell still inherits PATH, locale,
- * proxy configuration, and toolchain settings.
+ * Explicit environment contract for the local convenience shell.
+ *
+ * Proxy variables are intentionally excluded: proxy URLs commonly embed
+ * credentials, so inheriting them would recreate the secret-leak problem this
+ * allowlist prevents. The login shell may still load user-configured proxy
+ * values from its own profile, where they are owned by the user rather than
+ * the Electron main-process environment.
  */
-const SENSITIVE_ENV_NAME =
-  /(?:^|_)(?:API_KEY|TOKEN|PASSWORD|PASSWD|SECRET|PRIVATE_KEY)(?:$|_)/i;
+const SAFE_ENV_NAMES = new Set(
+  [
+    'HOME',
+    'USER',
+    'LOGNAME',
+    'SHELL',
+    'PATH',
+    'LANG',
+    'TERM',
+    'COLORTERM',
+    'TMPDIR',
+    'TMP',
+    'TEMP',
+    'SSH_AUTH_SOCK',
+    'TERM_PROGRAM',
+    'TERM_PROGRAM_VERSION',
+    'NO_COLOR',
+    'CLICOLOR',
+    'CLICOLOR_FORCE',
+    // Windows process/shell discovery.
+    'SYSTEMROOT',
+    'WINDIR',
+    'COMSPEC',
+    'PATHEXT',
+    'USERPROFILE',
+    'HOMEDRIVE',
+    'HOMEPATH',
+    'APPDATA',
+    'LOCALAPPDATA',
+    'PROGRAMDATA',
+    'PROGRAMFILES',
+    'PROGRAMFILES(X86)',
+    'PROGRAMW6432',
+    // Non-secret toolchain locations that a GUI-launched shell may need.
+    'NVM_DIR',
+    'VOLTA_HOME',
+    'PNPM_HOME',
+    'BUN_INSTALL',
+    'CARGO_HOME',
+    'RUSTUP_HOME',
+    'GOPATH',
+    'GOROOT',
+    'JAVA_HOME',
+    'PYENV_ROOT',
+    'CONDA_PREFIX',
+    'VIRTUAL_ENV',
+  ].map((name) => name.toUpperCase())
+);
+
+function isSafeTerminalEnvironmentName(name: string): boolean {
+  const upper = name.toUpperCase();
+  return (
+    SAFE_ENV_NAMES.has(upper) ||
+    upper.startsWith('LC_') ||
+    upper.startsWith('XDG_')
+  );
+}
 
 export function terminalEnvironment(
   environment: NodeJS.ProcessEnv = process.env
@@ -84,9 +145,69 @@ export function terminalEnvironment(
   return Object.fromEntries(
     Object.entries(environment).filter(
       (entry): entry is [string, string] =>
-        entry[1] !== undefined && !SENSITIVE_ENV_NAME.test(entry[0])
+        entry[1] !== undefined && isSafeTerminalEnvironmentName(entry[0])
     )
   );
+}
+
+function flushTerminalOutput(id: string, session: TerminalSession) {
+  if (session.outputTimer) {
+    clearTimeout(session.outputTimer);
+    session.outputTimer = null;
+  }
+  if (sessions.get(id) !== session || session.outputChunks.length === 0) {
+    session.outputChunks = [];
+    session.outputCodeUnits = 0;
+    return;
+  }
+  const data = session.outputChunks.join('');
+  session.outputChunks = [];
+  session.outputCodeUnits = 0;
+  const sender = session.sender;
+  if (!sender.isDestroyed()) {
+    sender.send('terminal-data', { id, data });
+  }
+}
+
+function queueTerminalOutput(
+  id: string,
+  session: TerminalSession,
+  data: string
+) {
+  session.outputChunks.push(data);
+  session.outputCodeUnits += data.length;
+  if (session.outputCodeUnits >= OUTPUT_BATCH_MAX_CODE_UNITS) {
+    flushTerminalOutput(id, session);
+    return;
+  }
+  if (!session.outputTimer) {
+    session.outputTimer = setTimeout(
+      () => flushTerminalOutput(id, session),
+      OUTPUT_BATCH_DELAY_MS
+    );
+  }
+}
+
+function terminalOwnedBy(
+  session: TerminalSession,
+  sender: WebContents
+): boolean {
+  if (session.sender === sender) return true;
+  // macOS keeps the app and its PTYs alive after the last window closes. A
+  // Dock reopen creates a new WebContents, so a restored tab must be able to
+  // adopt an orphaned session. A second live renderer is still rejected.
+  if (session.sender.isDestroyed()) {
+    session.sender = sender;
+    return true;
+  }
+  return false;
+}
+
+function dropQueuedOutput(session: TerminalSession) {
+  if (session.outputTimer) clearTimeout(session.outputTimer);
+  session.outputTimer = null;
+  session.outputChunks = [];
+  session.outputCodeUnits = 0;
 }
 
 export interface TerminalCreateOptions {
@@ -94,13 +215,14 @@ export interface TerminalCreateOptions {
   cwd?: string;
   cols?: number;
   rows?: number;
+  allowHomeFallback?: boolean;
 }
 
 async function createTerminalSession(
   session: TerminalSession,
   options: TerminalCreateOptions
 ): Promise<TerminalCreateResult> {
-  const { id, cwd, cols, rows } = options;
+  const { id, cwd, cols, rows, allowHomeFallback = true } = options;
   const pty = await loadNodePty();
   if (!pty) {
     if (sessions.get(id) === session) sessions.delete(id);
@@ -113,7 +235,26 @@ async function createTerminalSession(
   }
 
   const { file, args } = defaultShell();
-  const workingDir = cwd && fs.existsSync(cwd) ? cwd : os.homedir();
+  let workingDir: string;
+  try {
+    if (cwd && fs.statSync(cwd).isDirectory()) {
+      workingDir = cwd;
+    } else if (allowHomeFallback) {
+      workingDir = os.homedir();
+    } else {
+      throw new Error('Project working directory is unavailable');
+    }
+  } catch {
+    if (allowHomeFallback) {
+      workingDir = os.homedir();
+    } else {
+      if (sessions.get(id) === session) sessions.delete(id);
+      return {
+        success: false,
+        error: 'Project working directory is unavailable',
+      };
+    }
+  }
   try {
     const terminal = pty.spawn(file, args, {
       name: 'xterm-256color',
@@ -125,15 +266,13 @@ async function createTerminalSession(
     session.pty = terminal;
     terminal.onData((data) => {
       if (sessions.get(id) !== session) return;
-      const sender = session.sender;
-      if (!sender.isDestroyed()) {
-        sender.send('terminal-data', { id, data });
-      }
+      queueTerminalOutput(id, session, data);
     });
     terminal.onExit(({ exitCode }) => {
       // A disposed/restarted PTY can report its exit after a replacement with
       // the same id is already live. Do not mark that replacement as exited.
       if (sessions.get(id) !== session) return;
+      flushTerminalOutput(id, session);
       sessions.delete(id);
       const sender = session.sender;
       if (!sender.isDestroyed()) {
@@ -156,13 +295,17 @@ export function registerTerminalIpcHandlers() {
   ipcMain.handle(
     'terminal-create',
     async (event, options: TerminalCreateOptions) => {
-      const { id, cwd, cols, rows } = options ?? {};
+      const { id, cwd, cols, rows, allowHomeFallback } = options ?? {};
       if (!id) return { success: false, error: 'Missing terminal id' };
 
       const existing = sessions.get(id);
       if (existing) {
-        // A restored renderer becomes the owner of all subsequent output.
-        existing.sender = event.sender;
+        if (!terminalOwnedBy(existing, event.sender)) {
+          return {
+            success: false,
+            error: 'Terminal session is owned by another renderer',
+          };
+        }
         const result = await existing.creation;
         return result.success ? { ...result, existing: true } : result;
       }
@@ -173,6 +316,9 @@ export function registerTerminalIpcHandlers() {
         sender: event.sender,
         pty: null,
         disposed: false,
+        outputChunks: [],
+        outputCodeUnits: 0,
+        outputTimer: null,
         creation: Promise.resolve({
           success: false,
           error: 'Terminal creation has not started',
@@ -184,6 +330,7 @@ export function registerTerminalIpcHandlers() {
         cwd,
         cols,
         rows,
+        allowHomeFallback,
       });
       return session.creation;
     }
@@ -191,15 +338,19 @@ export function registerTerminalIpcHandlers() {
 
   ipcMain.on(
     'terminal-input',
-    (_event, payload: { id: string; data: string }) => {
-      sessions.get(payload?.id)?.pty?.write(payload.data);
+    (event, payload: { id: string; data: string }) => {
+      const session = sessions.get(payload?.id);
+      if (!session || !terminalOwnedBy(session, event.sender)) return;
+      session.pty?.write(payload.data);
     }
   );
 
   ipcMain.on(
     'terminal-resize',
-    (_event, payload: { id: string; cols: number; rows: number }) => {
-      const terminal = sessions.get(payload?.id)?.pty;
+    (event, payload: { id: string; cols: number; rows: number }) => {
+      const session = sessions.get(payload?.id);
+      if (!session || !terminalOwnedBy(session, event.sender)) return;
+      const terminal = session.pty;
       if (!terminal) return;
       const cols = Math.max(2, Math.floor(payload.cols || 0));
       const rows = Math.max(1, Math.floor(payload.rows || 0));
@@ -211,11 +362,18 @@ export function registerTerminalIpcHandlers() {
     }
   );
 
-  ipcMain.handle('terminal-dispose', (_event, id: string) => {
+  ipcMain.handle('terminal-dispose', (event, id: string) => {
     const session = sessions.get(id);
     if (!session) return { success: true };
+    if (!terminalOwnedBy(session, event.sender)) {
+      return {
+        success: false,
+        error: 'Terminal session is owned by another renderer',
+      };
+    }
     sessions.delete(id);
     session.disposed = true;
+    dropQueuedOutput(session);
     try {
       session.pty?.kill();
     } catch (error) {
@@ -229,6 +387,7 @@ export function registerTerminalIpcHandlers() {
 export function disposeAllTerminals() {
   for (const [id, session] of sessions) {
     session.disposed = true;
+    dropQueuedOutput(session);
     try {
       session.pty?.kill();
     } catch (error) {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -203,6 +203,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     cwd?: string;
     cols?: number;
     rows?: number;
+    allowHomeFallback?: boolean;
   }) => ipcRenderer.invoke('terminal-create', options),
   terminalInput: (id: string, data: string) =>
     ipcRenderer.send('terminal-input', { id, data }),

--- a/src/components/Session/PreviewPanel/tabKinds.tsx
+++ b/src/components/Session/PreviewPanel/tabKinds.tsx
@@ -12,7 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-import type { PreviewTabKind, SessionPreviewTab } from '@/store/pageTabStore';
+import type {
+  PreviewTabDestinationKind,
+  SessionPreviewTab,
+} from '@/store/pageTabStore';
 import {
   ClipboardCheck,
   FileText,
@@ -24,7 +27,7 @@ import {
 } from 'lucide-react';
 
 export interface PreviewKindMeta {
-  kind: PreviewTabKind;
+  kind: PreviewTabDestinationKind;
   icon: LucideIcon;
   /** i18n key + fallback used for the tab title and chooser row label. */
   labelKey: string;
@@ -64,10 +67,19 @@ export const PREVIEW_TAB_KINDS: PreviewKindMeta[] = [
     kind: 'terminal',
     icon: SquareTerminal,
     labelKey: 'layout.preview-kind-terminal',
-    defaultLabel: 'Terminal',
+    defaultLabel: 'Project terminal',
     descriptionKey: 'layout.preview-kind-terminal-desc',
     defaultDescription:
-      'Open a local terminal that starts in this project’s folder.',
+      'Open the project terminal in the Brain-resolved working directory.',
+  },
+  {
+    kind: 'local-terminal',
+    icon: SquareTerminal,
+    labelKey: 'layout.preview-kind-local-terminal',
+    defaultLabel: 'Local shell',
+    descriptionKey: 'layout.preview-kind-local-terminal-desc',
+    defaultDescription:
+      'Open your desktop login shell independently of the project runtime.',
   },
 ];
 

--- a/src/components/Session/PreviewPanel/tabs/ChooserTab.tsx
+++ b/src/components/Session/PreviewPanel/tabs/ChooserTab.tsx
@@ -12,8 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import { useHost } from '@/host';
 import { cn } from '@/lib/utils';
-import type { PreviewTabKind } from '@/store/pageTabStore';
+import type { PreviewTabDestinationKind } from '@/store/pageTabStore';
 import { ChevronRight, SquareTerminal } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -23,7 +24,7 @@ import { useSessionTerminalSources } from './terminal/useSessionTerminalSources'
 
 export interface ChooserTabProps {
   /** Open the given content kind (replaces this chooser tab in place). */
-  onChoose: (kind: PreviewTabKind) => void;
+  onChoose: (kind: PreviewTabDestinationKind) => void;
   /** Open one of the project's agent terminal streams (servers / scripts). */
   onChooseAgentStream?: (source: TerminalSource) => void;
 }
@@ -36,6 +37,7 @@ export interface ChooserTabProps {
  */
 export function ChooserTab({ onChoose, onChooseAgentStream }: ChooserTabProps) {
   const { t } = useTranslation();
+  const host = useHost();
   const sources = useSessionTerminalSources({ trackOutput: false });
   // Newest first, with still-running streams (servers, watchers) on top.
   const projectStreams = useMemo(() => {
@@ -55,7 +57,9 @@ export function ChooserTab({ onChoose, onChooseAgentStream }: ChooserTabProps) {
           })}
         </p>
         <div className="flex flex-col gap-1.5">
-          {PREVIEW_TAB_KINDS.map(
+          {PREVIEW_TAB_KINDS.filter(
+            ({ kind }) => kind !== 'local-terminal' || host?.electronAPI
+          ).map(
             ({
               kind,
               icon: Icon,

--- a/src/components/Session/PreviewPanel/tabs/terminal/ShellTerminal.tsx
+++ b/src/components/Session/PreviewPanel/tabs/terminal/ShellTerminal.tsx
@@ -13,7 +13,6 @@
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
 import { Button } from '@/components/ui/button';
-import { useHost } from '@/host';
 import {
   ensureShellSession,
   getShellBuffer,
@@ -25,6 +24,7 @@ import {
   writeToShell,
   type ShellSessionState,
 } from '@/lib/shellSessions';
+import type { TerminalTransport } from '@/lib/terminalTransport';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Terminal } from '@xterm/xterm';
@@ -46,24 +46,28 @@ export interface ShellTerminalProps {
   shellId: string;
   /** Directory the shell starts in; falls back to the home directory. */
   cwd?: string;
+  /** Whether this explicitly local surface may fall back to the user's home. */
+  allowHomeFallback?: boolean;
+  /** Host-independent PTY transport selected by the surface router. */
+  transport: TerminalTransport;
   /** Called with the URL when a link in the output is clicked. */
   onOpenLink?: (url: string) => void;
 }
 
 /**
- * A real interactive terminal — xterm in front, a main-process PTY running
- * the user's login shell behind. Feels like the desktop terminal: native
- * prompt, arrow keys, colors, Ctrl+C, full-screen programs. Scrollback is
- * replayed from the session registry when the tab remounts.
+ * A real interactive terminal — xterm in front, a selected PTY transport
+ * behind. The Electron adapter feels like the desktop terminal; a Brain
+ * adapter can provide the same interaction remotely. Scrollback is replayed
+ * from the session registry when the tab remounts.
  */
 export function ShellTerminal({
   shellId,
   cwd,
+  allowHomeFallback = false,
+  transport,
   onOpenLink,
 }: ShellTerminalProps) {
   const { t } = useTranslation();
-  const host = useHost();
-  const electronAPI = host?.electronAPI;
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const [session, setSession] = useState<ShellSessionState>(() =>
@@ -78,8 +82,7 @@ export function ShellTerminal({
 
   useEffect(() => {
     const container = containerRef.current;
-    const api = electronAPI;
-    if (!container || !api?.terminalCreate) return;
+    if (!container) return;
 
     const terminal = new Terminal({
       cursorBlink: true,
@@ -129,14 +132,14 @@ export function ShellTerminal({
     );
 
     const inputDisposable = terminal.onData((data) =>
-      writeToShell(api, shellId, data)
+      writeToShell(transport, shellId, data)
     );
 
     const safeFit = () => {
       if (!container.clientWidth || !container.clientHeight) return;
       try {
         fitAddon.fit();
-        resizeShell(api, shellId, terminal.cols, terminal.rows);
+        resizeShell(transport, shellId, terminal.cols, terminal.rows);
       } catch {
         // Ignore: the next resize will refit.
       }
@@ -146,9 +149,10 @@ export function ShellTerminal({
     // container resizes (panel drag, window resize, side panel fold).
     let frame = requestAnimationFrame(() => {
       safeFit();
-      void ensureShellSession(api, {
+      void ensureShellSession(transport, {
         id: shellId,
         cwd,
+        allowHomeFallback,
         cols: terminal.cols,
         rows: terminal.rows,
       }).then(setSession);
@@ -171,11 +175,10 @@ export function ShellTerminal({
     };
     // cwd only matters at spawn time; a change never restarts a live shell.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shellId, runId, electronAPI]);
+  }, [shellId, runId, transport]);
 
   const handleRestart = async () => {
-    if (!electronAPI) return;
-    const disposed = await resetShellSession(electronAPI, shellId);
+    const disposed = await resetShellSession(transport, shellId);
     if (!disposed) return;
     setSession(getShellSessionState(shellId));
     setRunId((id) => id + 1);

--- a/src/components/Session/PreviewPanel/tabs/terminal/TerminalTab.tsx
+++ b/src/components/Session/PreviewPanel/tabs/terminal/TerminalTab.tsx
@@ -15,12 +15,18 @@
 import { Button } from '@/components/ui/button';
 import { TooltipSimple } from '@/components/ui/tooltip';
 import { useHost } from '@/host';
+import { createElectronTerminalTransport } from '@/lib/terminalTransport';
 import { cn } from '@/lib/utils';
+import {
+  fetchWorkspaceCapabilities,
+  fetchWorkspaceEffectiveDirectory,
+} from '@/service/workspaceApi';
 import { useAuthStore } from '@/store/authStore';
 import { usePageTabStore, type SessionTerminalTab } from '@/store/pageTabStore';
+import { useProjectRuntimeStore } from '@/store/projectRuntimeStore';
 import { useSpaceStore } from '@/store/spaceStore';
 import { Check, Copy, SquareTerminal } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ShellTerminal } from './ShellTerminal';
 import type { TerminalSource } from './terminalSources';
@@ -32,15 +38,19 @@ export interface TerminalTabProps {
 }
 
 /**
- * Terminal surface router. A plain terminal tab is a real interactive local
- * shell (a main-process PTY running the user's login shell). A tab opened
- * from the chooser's project section shows that agent stream read-only.
+ * Terminal surface router. Project terminals use a Brain-authoritative cwd;
+ * explicitly local shells retain the Desktop login-shell experience. A tab
+ * opened from the chooser's project section shows that agent stream read-only.
  */
 export function TerminalTab({ tab }: TerminalTabProps) {
   if (tab.agentSourceId) {
     return <AgentStreamTerminal sourceId={tab.agentSourceId} />;
   }
-  return <LocalShellTerminal tab={tab} />;
+  return (tab.surface ?? 'project') === 'local' ? (
+    <LocalShellTerminal tab={tab} />
+  ) : (
+    <ProjectShellTerminal tab={tab} />
+  );
 }
 
 /** One-line label for a stream: agent name, then the subtask it ran for. */
@@ -50,82 +60,232 @@ export function terminalSourceLabel(source: TerminalSource): string {
     : source.agentName;
 }
 
-/** Interactive local shell, started in the project's working folder. */
-function LocalShellTerminal({ tab }: { tab: SessionTerminalTab }) {
+function TerminalUnavailable({ message }: { message: string }) {
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col items-center justify-center gap-2 px-6 text-center">
+      <SquareTerminal
+        className="h-8 w-8 text-ds-icon-neutral-muted-default"
+        aria-hidden
+      />
+      <p className="max-w-[420px] text-sm text-ds-text-neutral-muted-default">
+        {message}
+      </p>
+    </div>
+  );
+}
+
+function useProjectActiveTaskId(projectId: string | null): string | null {
+  const chatStore = useProjectRuntimeStore((state) => {
+    if (!projectId) return null;
+    const project = state.projects[projectId];
+    if (!project) return null;
+    return project.activeChatId
+      ? (project.chatStores[project.activeChatId] ?? null)
+      : (Object.values(project.chatStores)[0] ?? null);
+  });
+  const [taskId, setTaskId] = useState<string | null>(
+    () => chatStore?.getState().activeTaskId ?? null
+  );
+  useEffect(() => {
+    const update = () => setTaskId(chatStore?.getState().activeTaskId ?? null);
+    update();
+    return chatStore?.subscribe(update);
+  }, [chatStore]);
+  return taskId;
+}
+
+/** Interactive Project terminal, rooted at the Brain-resolved run directory. */
+function ProjectShellTerminal({ tab }: { tab: SessionTerminalTab }) {
   const { t } = useTranslation();
   const host = useHost();
+  const electronTransport = useMemo(
+    () => createElectronTerminalTransport(host?.electronAPI),
+    [host?.electronAPI]
+  );
+  const [transportState, setTransportState] = useState<{
+    loading: boolean;
+    transport: ReturnType<typeof createElectronTerminalTransport>;
+  }>({ loading: true, transport: null });
+  useEffect(() => {
+    let cancelled = false;
+    fetchWorkspaceCapabilities()
+      .then((capabilities) => {
+        if (cancelled) return;
+        const canUseLocalProjectTransport =
+          capabilities.terminal === true && capabilities.deployment === 'local';
+        setTransportState({
+          loading: false,
+          transport: canUseLocalProjectTransport ? electronTransport : null,
+        });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTransportState({ loading: false, transport: null });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [electronTransport]);
+  const transport = transportState.transport;
   const openBrowserPreview = usePageTabStore(
     (state) => state.openBrowserPreview
   );
   const projectId = usePageTabStore((state) => state.sessionPreviewProjectId);
   const email = useAuthStore((state) => state.email);
   const userId = useAuthStore((state) => state.user_id);
-  const isDesktop = Boolean(host?.electronAPI?.terminalCreate);
-
-  // A folder-backed Space works directly in the user's chosen local folder,
-  // so the shell must open there — not in the generated per-project output
-  // folder used by legacy/blank Spaces.
-  const spaceRootPath = useSpaceStore((state) => {
-    const spaceId =
-      (projectId ? state.getProjectMeta(projectId)?.spaceId : null) ??
-      state.activeSpaceId;
-    return (spaceId ? state.spaces[spaceId]?.rootPath : null) ?? null;
+  const indexedSpaceId = useSpaceStore((state) =>
+    projectId ? (state.projectIdIndex[projectId] ?? null) : null
+  );
+  const runtimeSpaceId = useProjectRuntimeStore((state) =>
+    projectId ? (state.projects[projectId]?.spaceId ?? null) : null
+  );
+  const indexedWorkdirMode = useSpaceStore((state) => {
+    if (!projectId) return null;
+    const indexedProjectSpaceId = state.projectIdIndex[projectId];
+    return indexedProjectSpaceId
+      ? (state.projectsBySpaceId[indexedProjectSpaceId]?.[projectId]
+          ?.workdirMode ?? null)
+      : null;
   });
+  const runtimeWorkdirMode = useProjectRuntimeStore((state) =>
+    projectId ? (state.projects[projectId]?.workdirMode ?? null) : null
+  );
+  const spaceId = indexedSpaceId ?? runtimeSpaceId;
+  const workdirMode = indexedWorkdirMode ?? runtimeWorkdirMode;
+  const taskId = useProjectActiveTaskId(projectId);
+  const [resolution, setResolution] = useState<{
+    cwd: string | null;
+    loading: boolean;
+    error: string | null;
+  }>({ cwd: null, loading: true, error: null });
+  const missingContextMessage = t('layout.terminal-project-context-missing', {
+    defaultValue: 'The Project workspace context is unavailable.',
+  });
+  const unavailableWorkspaceMessage = t(
+    'layout.terminal-project-workspace-unavailable',
+    {
+      defaultValue:
+        'No Brain-resolved working directory is available for this Project.',
+    }
+  );
 
-  // Resolve the working folder before spawning so the shell opens there
-  // (falls back to the home directory when unavailable).
-  const [cwd, setCwd] = useState<string | undefined>(undefined);
-  const [cwdResolved, setCwdResolved] = useState(false);
   useEffect(() => {
     let cancelled = false;
-    if (spaceRootPath) {
-      setCwd(spaceRootPath);
-      setCwdResolved(true);
+    if (!transport) return;
+    if (!projectId || !spaceId || !email) {
+      setResolution({
+        cwd: null,
+        loading: false,
+        error: missingContextMessage,
+      });
       return;
     }
-    const api = host?.electronAPI;
-    if (!api?.getProjectFolderPath || !email || !projectId) {
-      setCwdResolved(true);
-      return;
-    }
-    api
-      .getProjectFolderPath(email, projectId, userId)
-      .then((folderPath: string) => {
+    setResolution({ cwd: null, loading: true, error: null });
+    fetchWorkspaceEffectiveDirectory(
+      spaceId,
+      projectId,
+      email,
+      userId,
+      taskId,
+      workdirMode
+    )
+      .then((result) => {
         if (cancelled) return;
-        setCwd(folderPath || undefined);
-        setCwdResolved(true);
+        if (!result.working_directory) {
+          throw new Error('Brain returned an empty working directory');
+        }
+        setResolution({
+          cwd: result.working_directory,
+          loading: false,
+          error: null,
+        });
       })
-      .catch(() => {
-        if (!cancelled) setCwdResolved(true);
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setResolution({
+          cwd: null,
+          loading: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : unavailableWorkspaceMessage,
+        });
       });
     return () => {
       cancelled = true;
     };
-  }, [host, email, userId, projectId, spaceRootPath]);
+  }, [
+    email,
+    missingContextMessage,
+    projectId,
+    spaceId,
+    taskId,
+    unavailableWorkspaceMessage,
+    transport,
+    userId,
+    workdirMode,
+  ]);
 
-  if (!isDesktop) {
+  if (transportState.loading) {
+    return <div className="h-full w-full" />;
+  }
+  if (!transport) {
     return (
-      <div className="flex h-full min-h-0 w-full flex-col items-center justify-center gap-2 px-6 text-center">
-        <SquareTerminal
-          className="h-8 w-8 text-ds-icon-neutral-muted-default"
-          aria-hidden
-        />
-        <p className="max-w-[360px] text-sm text-ds-text-neutral-muted-default">
-          {t('layout.terminal-desktop-only', {
-            defaultValue: 'The terminal is available in the desktop app.',
-          })}
-        </p>
-      </div>
+      <TerminalUnavailable
+        message={t('layout.terminal-brain-transport-unavailable', {
+          defaultValue:
+            'This client does not yet have a compatible terminal transport for the connected Brain.',
+        })}
+      />
     );
   }
-  if (!cwdResolved) {
-    // One frame at most; avoids spawning in $HOME then "jumping" folders.
+  if (resolution.loading) {
     return <div className="h-full w-full" />;
+  }
+  if (!resolution.cwd || resolution.error) {
+    return (
+      <TerminalUnavailable
+        message={resolution.error ?? unavailableWorkspaceMessage}
+      />
+    );
   }
   return (
     <ShellTerminal
       shellId={tab.shellId ?? `session-shell:fallback:${tab.id}`}
-      cwd={cwd}
+      cwd={resolution.cwd}
+      allowHomeFallback={false}
+      transport={transport}
+      onOpenLink={openBrowserPreview}
+    />
+  );
+}
+
+/** Explicit Desktop-local login shell; it is not the Project workspace shell. */
+function LocalShellTerminal({ tab }: { tab: SessionTerminalTab }) {
+  const { t } = useTranslation();
+  const host = useHost();
+  const transport = useMemo(
+    () => createElectronTerminalTransport(host?.electronAPI),
+    [host?.electronAPI]
+  );
+  const openBrowserPreview = usePageTabStore(
+    (state) => state.openBrowserPreview
+  );
+  if (!transport) {
+    return (
+      <TerminalUnavailable
+        message={t('layout.terminal-local-desktop-only', {
+          defaultValue: 'The local shell is available in the desktop app.',
+        })}
+      />
+    );
+  }
+  return (
+    <ShellTerminal
+      shellId={tab.shellId ?? `local-shell:fallback:${tab.id}`}
+      allowHomeFallback
+      transport={transport}
       onOpenLink={openBrowserPreview}
     />
   );

--- a/src/lib/shellSessions.ts
+++ b/src/lib/shellSessions.ts
@@ -12,23 +12,18 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import type {
+  TerminalCreateOptions,
+  TerminalTransport,
+} from '@/lib/terminalTransport';
+
 /**
- * Renderer-side registry for interactive shell sessions (main-process PTYs).
+ * Renderer-side registry for interactive shell sessions (transport-owned PTYs).
  * The PTY outlives the xterm UI — switching preview tabs unmounts the
  * terminal component — so this module owns the IPC listeners and a rolling
  * output buffer per shell, letting a remounted terminal replay its scrollback
  * and re-attach to the live stream.
  */
-
-type TerminalHostApi = Pick<
-  Window['electronAPI'],
-  | 'terminalCreate'
-  | 'terminalInput'
-  | 'terminalResize'
-  | 'terminalDispose'
-  | 'onTerminalData'
-  | 'onTerminalExit'
->;
 
 export interface ShellSessionState {
   /** The PTY was spawned (or confirmed alive) at least once. */
@@ -39,6 +34,7 @@ export interface ShellSessionState {
 }
 
 interface ShellSessionEntry extends ShellSessionState {
+  transport: TerminalTransport | null;
   buffer: string[];
   bufferCodeUnits: number;
   dataListeners: Set<(chunk: string) => void>;
@@ -50,7 +46,7 @@ interface ShellSessionEntry extends ShellSessionState {
 const MAX_BUFFER_CODE_UNITS = 1_000_000;
 
 const sessions = new Map<string, ShellSessionEntry>();
-let ipcBound = false;
+const boundTransports = new WeakSet<TerminalTransport>();
 
 function entryFor(id: string): ShellSessionEntry {
   let entry = sessions.get(id);
@@ -60,6 +56,7 @@ function entryFor(id: string): ShellSessionEntry {
       exited: false,
       exitCode: null,
       error: null,
+      transport: null,
       buffer: [],
       bufferCodeUnits: 0,
       dataListeners: new Set(),
@@ -88,16 +85,16 @@ function notifyState(entry: ShellSessionEntry) {
 }
 
 /** Attach the global IPC listeners once; they dispatch by shell id. */
-function bindIpc(api: TerminalHostApi) {
-  if (ipcBound) return;
-  ipcBound = true;
-  api.onTerminalData(({ id, data }: { id: string; data: string }) => {
+function bindTransport(transport: TerminalTransport) {
+  if (boundTransports.has(transport)) return;
+  boundTransports.add(transport);
+  transport.onData(({ id, data }) => {
     const entry = sessions.get(id);
     if (!entry) return;
     appendToBuffer(entry, data);
     entry.dataListeners.forEach((listener) => listener(data));
   });
-  api.onTerminalExit(({ id, exitCode }: { id: string; exitCode: number }) => {
+  transport.onExit(({ id, exitCode }) => {
     const entry = sessions.get(id);
     if (!entry) return;
     entry.exited = true;
@@ -106,29 +103,25 @@ function bindIpc(api: TerminalHostApi) {
   });
 }
 
-export interface EnsureShellOptions {
-  id: string;
-  cwd?: string;
-  cols?: number;
-  rows?: number;
-}
+export type EnsureShellOptions = TerminalCreateOptions;
 
 /**
  * Spawn the shell if it isn't already running. Safe to call on every mount:
  * the main process keeps one PTY per id and reports `existing` when alive.
  */
 export async function ensureShellSession(
-  api: TerminalHostApi,
+  transport: TerminalTransport,
   options: EnsureShellOptions
 ): Promise<ShellSessionState> {
-  bindIpc(api);
+  bindTransport(transport);
   const entry = entryFor(options.id);
+  entry.transport = transport;
   if (entry.created && !entry.exited) return snapshot(entry);
   if (entry.createPromise) return entry.createPromise;
 
-  const createPromise = api
-    .terminalCreate(options)
-    .then((result: Awaited<ReturnType<TerminalHostApi['terminalCreate']>>) => {
+  const createPromise = transport
+    .create(options)
+    .then((result) => {
       // The tab/project may have been disposed while IPC was in flight.
       if (sessions.get(options.id) !== entry) return snapshot(entry);
       if (result.success) {
@@ -161,11 +154,12 @@ export async function ensureShellSession(
 
 /** Kill the PTY and drop all local state (tab closed). */
 export function disposeShellSession(
-  api: TerminalHostApi | undefined,
+  fallbackTransport: TerminalTransport | null | undefined,
   id: string
 ) {
+  const transport = sessions.get(id)?.transport ?? fallbackTransport;
   sessions.delete(id);
-  void api?.terminalDispose(id);
+  void transport?.dispose(id);
 }
 
 /**
@@ -174,11 +168,12 @@ export function disposeShellSession(
  * to the old shell with blank scrollback.
  */
 export async function resetShellSession(
-  api: TerminalHostApi,
+  transport: TerminalTransport,
   id: string
 ): Promise<boolean> {
   try {
-    await api.terminalDispose(id);
+    const result = await transport.dispose(id);
+    if (!result.success) return false;
   } catch {
     return false;
   }
@@ -188,23 +183,28 @@ export async function resetShellSession(
   entry.exited = false;
   entry.exitCode = null;
   entry.error = null;
+  entry.transport = transport;
   entry.buffer = [];
   entry.bufferCodeUnits = 0;
   notifyState(entry);
   return true;
 }
 
-export function writeToShell(api: TerminalHostApi, id: string, data: string) {
-  api.terminalInput(id, data);
+export function writeToShell(
+  transport: TerminalTransport,
+  id: string,
+  data: string
+) {
+  transport.input(id, data);
 }
 
 export function resizeShell(
-  api: TerminalHostApi,
+  transport: TerminalTransport,
   id: string,
   cols: number,
   rows: number
 ) {
-  api.terminalResize(id, cols, rows);
+  transport.resize(id, cols, rows);
 }
 
 /** Buffered output for scrollback replay on remount. */

--- a/src/lib/terminalTransport.ts
+++ b/src/lib/terminalTransport.ts
@@ -1,0 +1,63 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+export interface TerminalCreateOptions {
+  id: string;
+  cwd?: string;
+  cols?: number;
+  rows?: number;
+  /** Project terminals must fail instead of silently opening outside cwd. */
+  allowHomeFallback?: boolean;
+}
+
+export interface TerminalCreateResult {
+  success: boolean;
+  existing?: boolean;
+  error?: string;
+}
+
+export interface TerminalTransport {
+  readonly kind: 'electron-local' | 'brain';
+  create(options: TerminalCreateOptions): Promise<TerminalCreateResult>;
+  input(id: string, data: string): void;
+  resize(id: string, cols: number, rows: number): void;
+  dispose(id: string): Promise<{ success: boolean; error?: string }>;
+  onData(callback: (payload: { id: string; data: string }) => void): () => void;
+  onExit(
+    callback: (payload: { id: string; exitCode: number }) => void
+  ): () => void;
+}
+
+const electronTransports = new WeakMap<object, TerminalTransport>();
+
+/** Adapter for the Desktop-local PTY. A Brain adapter can implement the same contract. */
+export function createElectronTerminalTransport(
+  api: Window['electronAPI'] | null | undefined
+): TerminalTransport | null {
+  if (!api?.terminalCreate) return null;
+  const key = api as object;
+  const cached = electronTransports.get(key);
+  if (cached) return cached;
+  const transport: TerminalTransport = {
+    kind: 'electron-local',
+    create: (options) => api.terminalCreate(options),
+    input: (id, data) => api.terminalInput(id, data),
+    resize: (id, cols, rows) => api.terminalResize(id, cols, rows),
+    dispose: (id) => api.terminalDispose(id),
+    onData: (callback) => api.onTerminalData(callback),
+    onExit: (callback) => api.onTerminalExit(callback),
+  };
+  electronTransports.set(key, transport);
+  return transport;
+}

--- a/src/service/workspaceApi.ts
+++ b/src/service/workspaceApi.ts
@@ -79,6 +79,15 @@ export interface WorkspaceProjectRefreshPayload {
   serverRefreshConfirmed: true;
 }
 
+export interface WorkspaceEffectiveDirectory {
+  space_id: string;
+  project_id: string;
+  task_id?: string | null;
+  working_directory: string;
+  source: 'task_snapshot' | 'active_run' | 'binding';
+  workdir_mode?: string | null;
+}
+
 export const fetchWorkspaceCapabilities =
   async (): Promise<WorkspaceCapabilities> =>
     fetchGet('/workspace/capabilities');
@@ -92,6 +101,23 @@ export const fetchWorkspaceCurrent = async (
     space_id: spaceId,
     email,
     ...(userId === undefined || userId === null ? {} : { user_id: userId }),
+  });
+
+export const fetchWorkspaceEffectiveDirectory = async (
+  spaceId: string,
+  projectId: string,
+  email: string,
+  userId?: string | number | null,
+  taskId?: string | null,
+  workdirMode?: string | null
+): Promise<WorkspaceEffectiveDirectory> =>
+  fetchGet('/workspace/effective-directory', {
+    space_id: spaceId,
+    project_id: projectId,
+    email,
+    ...(userId === undefined || userId === null ? {} : { user_id: userId }),
+    ...(taskId ? { task_id: taskId } : {}),
+    ...(workdirMode ? { workdir_mode: workdirMode } : {}),
   });
 
 export const bindWorkspaceToSpace = async (

--- a/src/store/pageTabStore.ts
+++ b/src/store/pageTabStore.ts
@@ -15,6 +15,7 @@
 import { createHost } from '@/host';
 import { canonicalizeBrowserUrl, normalizeBrowserUrl } from '@/lib/browserUrl';
 import { disposeShellSession } from '@/lib/shellSessions';
+import { createElectronTerminalTransport } from '@/lib/terminalTransport';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
@@ -82,6 +83,8 @@ export interface SessionTerminalTab {
    * Project-scoped so the shell survives tab switches within an app run.
    */
   shellId?: string;
+  /** Interactive terminal surface; old persisted tabs default to project. */
+  surface?: 'project' | 'local';
   /**
    * When set, the tab shows this agent terminal stream (read-only) instead of
    * a local shell. Ids come from `collectTerminalSources`.
@@ -109,6 +112,8 @@ export type SessionPreviewTab =
  * it is the picker itself, not a destination.
  */
 export type PreviewTabKind = Exclude<SessionPreviewTab['type'], 'chooser'>;
+/** Chooser destinations may map more than one surface to a terminal tab. */
+export type PreviewTabDestinationKind = PreviewTabKind | 'local-terminal';
 
 export interface PreviewBrowserViewport {
   x: number;
@@ -207,7 +212,7 @@ function browserTabTitleForUrl(url: string): string {
 
 /** Build a fresh tab of the requested kind. Browser tabs need the project id. */
 function createPreviewTabOfKind(
-  kind: PreviewTabKind,
+  kind: PreviewTabDestinationKind,
   projectId: string | null
 ): SessionPreviewTab {
   switch (kind) {
@@ -226,10 +231,21 @@ function createPreviewTabOfKind(
       return {
         id,
         type: 'terminal',
-        title: 'Terminal',
+        title: 'Project terminal',
         // Stable per-tab PTY id: the shell keeps running while the user
         // switches preview tabs, and dies when the tab is closed.
         shellId: `session-shell:${projectId ?? 'global'}:${id}`,
+        surface: 'project',
+      };
+    }
+    case 'local-terminal': {
+      const id = nextSessionPreviewTabId('terminal');
+      return {
+        id,
+        type: 'terminal',
+        title: 'Local shell',
+        shellId: `local-shell:${projectId ?? 'global'}:${id}`,
+        surface: 'local',
       };
     }
     case 'canvas':
@@ -282,9 +298,10 @@ function sanitizeSessionPreviewForPersist(
 
 function disposePreviewShellTabs(tabs: SessionPreviewTab[]) {
   const api = createHost().electronAPI ?? undefined;
+  const transport = createElectronTerminalTransport(api);
   for (const tab of tabs) {
     if (tab.type === 'terminal' && tab.shellId) {
-      disposeShellSession(api, tab.shellId);
+      disposeShellSession(transport, tab.shellId);
     }
   }
 }
@@ -422,7 +439,10 @@ interface PageTabState {
    * Turn a tab (typically the chooser) into the chosen content kind, in place.
    * Falls back to appending if the target tab no longer exists.
    */
-  choosePreviewTabType: (tabId: string, kind: PreviewTabKind) => void;
+  choosePreviewTabType: (
+    tabId: string,
+    kind: PreviewTabDestinationKind
+  ) => void;
   /** Open a file in a deduplicated file tab (reuses a blank starter tab). */
   openFilePreview: (file?: FileInfo | null) => void;
   /**
@@ -465,6 +485,11 @@ interface PageTabState {
    * interactive shell it owned, even when no preview component is mounted.
    */
   removeSessionPreviewProject: (projectId: string) => void;
+  /**
+   * Authentication-boundary cleanup. Keep only previews owned by Projects
+   * retained for the next user and terminate every removed interactive shell.
+   */
+  retainSessionPreviewProjects: (projectIds: string[]) => void;
 }
 
 type SetPageTabState = (
@@ -950,6 +975,36 @@ export const usePageTabStore = create<PageTabState>()(
                   previewBrowserViewport: null,
                 }
               : {}),
+          };
+        });
+      },
+      retainSessionPreviewProjects: (projectIds) => {
+        const retained = new Set(projectIds);
+        const current = get();
+        for (const [projectId, slice] of Object.entries(
+          current.sessionPreviewByProject
+        )) {
+          if (!retained.has(projectId)) {
+            disposePreviewShellTabs(slice.tabs);
+          }
+        }
+        set((state) => {
+          const sessionPreviewByProject = Object.fromEntries(
+            Object.entries(state.sessionPreviewByProject).filter(
+              ([projectId]) => retained.has(projectId)
+            )
+          );
+          const scopedProjectRetained =
+            state.sessionPreviewProjectId !== null &&
+            retained.has(state.sessionPreviewProjectId);
+          return {
+            sessionPreviewByProject,
+            ...(scopedProjectRetained
+              ? {}
+              : {
+                  sessionPreviewProjectId: null,
+                  previewBrowserViewport: null,
+                }),
           };
         });
       },

--- a/src/store/projectStore.test.ts
+++ b/src/store/projectStore.test.ts
@@ -50,7 +50,12 @@ describe('projectStore runtime shape', () => {
     });
     globalThis.electronAPI = {
       ...globalThis.electronAPI,
+      terminalCreate: vi.fn().mockResolvedValue({ success: true }),
+      terminalInput: vi.fn(),
+      terminalResize: vi.fn(),
       terminalDispose: vi.fn().mockResolvedValue({ success: true }),
+      onTerminalData: vi.fn(() => () => {}),
+      onTerminalExit: vi.fn(() => () => {}),
     };
     usePageTabStore.setState({
       sessionPreviewProjectId: null,
@@ -219,9 +224,34 @@ describe('projectStore runtime shape', () => {
       false
     );
     expect(useSpaceStore.getState().getProjectMeta(projectId)).toBeDefined();
+    expect(
+      usePageTabStore.getState().sessionPreviewByProject[projectId]
+    ).toBeUndefined();
     expect(hasActiveSSEConnectionMock).toHaveBeenCalledWith(
       expect.arrayContaining(['task_finished'])
     );
+  });
+
+  it('keeps preview state when replacing only the project runtime', () => {
+    const projectId = useProjectStore
+      .getState()
+      .createProject('Reloaded Project', undefined, 'project_reload');
+    const pageTabs = usePageTabStore.getState();
+    pageTabs.setSessionPreviewProject(projectId);
+    pageTabs.toggleSessionPreview();
+    pageTabs.choosePreviewTabType(
+      getSessionPreviewSlice(usePageTabStore.getState()).activeTabId!,
+      'terminal'
+    );
+
+    useProjectStore.getState()._evictProjectRuntime(projectId);
+
+    expect(useProjectStore.getState().projects[projectId]).toBeUndefined();
+    expect(useSpaceStore.getState().getProjectMeta(projectId)).toBeDefined();
+    expect(
+      usePageTabStore.getState().sessionPreviewByProject[projectId]
+    ).toBeDefined();
+    expect(globalThis.electronAPI.terminalDispose).not.toHaveBeenCalled();
   });
 
   it('merges missing history into a background remote Project without stealing focus', async () => {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -122,10 +122,7 @@ export enum ProjectType {
 
 export type ProjectMode = 'single-agent' | 'workforce';
 export type ProjectWorkdirMode =
-  | 'worktree'
-  | 'copy'
-  | 'direct-write'
-  | 'artifact-only';
+  'worktree' | 'copy' | 'direct-write' | 'artifact-only';
 
 interface TaskQueue {
   task_id: string;
@@ -1169,7 +1166,8 @@ const projectStore = create<ProjectStore>()((set, get) => ({
     projectId?: string,
     historyId?: string
   ) => {
-    const { projects, removeProject, createProject, createChatStore } = get();
+    const { projects, _evictProjectRuntime, createProject, createChatStore } =
+      get();
 
     let replayProjectId: string;
 
@@ -1191,7 +1189,7 @@ const projectStore = create<ProjectStore>()((set, get) => ({
     if (projectId) {
       if (projects[projectId]) {
         console.log(`[ProjectStore] Overwriting existing project ${projectId}`);
-        removeProject(projectId);
+        _evictProjectRuntime(projectId);
       }
       // Create project with the specific naming
       replayProjectId = createProject(
@@ -1274,7 +1272,8 @@ const projectStore = create<ProjectStore>()((set, get) => ({
     taskQuestionsById?: Record<string, string>,
     serverUpdatedAt?: number | null
   ) => {
-    const { projects, removeProject, createProject, createChatStore } = get();
+    const { projects, _evictProjectRuntime, createProject, createChatStore } =
+      get();
     const existingProject = projects[projectId];
     const existingMeta = useSpaceStore.getState().getProjectMeta(projectId);
     const projectNameCandidate = (projectName ?? '').trim();
@@ -1296,7 +1295,7 @@ const projectStore = create<ProjectStore>()((set, get) => ({
       console.log(
         `[ProjectStore] Overwriting existing project ${projectId} for load`
       );
-      removeProject(projectId);
+      _evictProjectRuntime(projectId);
     }
 
     const loadProjectId = createProject(

--- a/src/store/spaceStore.test.ts
+++ b/src/store/spaceStore.test.ts
@@ -100,7 +100,12 @@ describe('spaceStore user scoping', () => {
     };
     globalThis.electronAPI = {
       ...globalThis.electronAPI,
+      terminalCreate: vi.fn().mockResolvedValue({ success: true }),
+      terminalInput: vi.fn(),
+      terminalResize: vi.fn(),
       terminalDispose: vi.fn().mockResolvedValue({ success: true }),
+      onTerminalData: vi.fn(() => () => {}),
+      onTerminalExit: vi.fn(() => () => {}),
     };
     usePageTabStore.setState({
       sessionPreviewProjectId: null,
@@ -203,6 +208,20 @@ describe('spaceStore user scoping', () => {
   });
 
   it('removes spaces and project metadata from the previous signed-in user', () => {
+    const pageTabs = usePageTabStore.getState();
+    pageTabs.setSessionPreviewProject('project_old');
+    pageTabs.toggleSessionPreview();
+    pageTabs.choosePreviewTabType(
+      getSessionPreviewSlice(usePageTabStore.getState()).activeTabId!,
+      'terminal'
+    );
+    const removedTerminal = getSessionPreviewSlice(usePageTabStore.getState())
+      .tabs[0];
+    const removedShellId =
+      removedTerminal.type === 'terminal' ? removedTerminal.shellId : undefined;
+    pageTabs.setSessionPreviewProject('project_new');
+    pageTabs.toggleSessionPreview();
+
     useSpaceStore.getState().resetForUser(2);
 
     const state = useSpaceStore.getState();
@@ -214,6 +233,15 @@ describe('spaceStore user scoping', () => {
       space_new_blank: 'project_new',
     });
     expect(state.projectsSyncedAt).toEqual({ space_new_blank: 200 });
+    expect(globalThis.electronAPI.terminalDispose).toHaveBeenCalledWith(
+      removedShellId
+    );
+    expect(
+      usePageTabStore.getState().sessionPreviewByProject.project_old
+    ).toBeUndefined();
+    expect(
+      usePageTabStore.getState().sessionPreviewByProject.project_new
+    ).toBeDefined();
   });
 
   it('hydrates new accounts with one blank space and hides empty legacy rows', async () => {

--- a/src/store/spaceStore.ts
+++ b/src/store/spaceStore.ts
@@ -520,7 +520,8 @@ export const useSpaceStore = create<SpaceStore>()(
       projectIdIndex: {},
       projectsSyncedAt: {},
 
-      resetForUser: (userId) =>
+      resetForUser: (userId) => {
+        let retainedProjectIds: string[] = [];
         set((state) => {
           const nextSpaces: Record<string, Space> = {};
           for (const [spaceId, space] of Object.entries(state.spaces)) {
@@ -561,6 +562,7 @@ export const useSpaceStore = create<SpaceStore>()(
           }
 
           const localLegacyId = legacySpaceIdForUser(DEFAULT_LOCAL_USER_ID);
+          retainedProjectIds = Object.keys(nextProjectIdIndex);
           return {
             storageEnvironmentKey: getAuthEnvironmentKey(),
             spaces: nextSpaces,
@@ -574,7 +576,11 @@ export const useSpaceStore = create<SpaceStore>()(
             projectIdIndex: nextProjectIdIndex,
             projectsSyncedAt: nextProjectsSyncedAt,
           };
-        }),
+        });
+        usePageTabStore
+          .getState()
+          .retainSessionPreviewProjects(retainedProjectIds);
+      },
 
       hydrateFromServer: async (userId) => {
         try {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -240,10 +240,13 @@ interface ElectronAPI {
     cwd?: string;
     cols?: number;
     rows?: number;
+    allowHomeFallback?: boolean;
   }) => Promise<{ success: boolean; existing?: boolean; error?: string }>;
   terminalInput: (id: string, data: string) => void;
   terminalResize: (id: string, cols: number, rows: number) => void;
-  terminalDispose: (id: string) => Promise<{ success: boolean }>;
+  terminalDispose: (
+    id: string
+  ) => Promise<{ success: boolean; error?: string }>;
   onTerminalData: (
     callback: (payload: { id: string; data: string }) => void
   ) => () => void;

--- a/test/unit/components/Session/TerminalTab.test.tsx
+++ b/test/unit/components/Session/TerminalTab.test.tsx
@@ -35,11 +35,23 @@ vi.mock('@/components/Session/PreviewPanel/tabs/terminal/XtermViewer', () => ({
 vi.mock(
   '@/components/Session/PreviewPanel/tabs/terminal/ShellTerminal',
   () => ({
-    ShellTerminal: ({ shellId, cwd }: { shellId: string; cwd?: string }) => (
+    ShellTerminal: ({
+      shellId,
+      cwd,
+      allowHomeFallback,
+      transport,
+    }: {
+      shellId: string;
+      cwd?: string;
+      allowHomeFallback?: boolean;
+      transport: { kind: string };
+    }) => (
       <div
         data-testid="shell-terminal"
         data-shell-id={shellId}
         data-cwd={cwd}
+        data-home-fallback={String(Boolean(allowHomeFallback))}
+        data-transport={transport.kind}
       />
     ),
   })
@@ -64,38 +76,78 @@ vi.mock('@/store/authStore', () => ({
   },
 }));
 
-// The real space store drags the API client into the module graph; the tab
-// only resolves the active Space's local root folder from it.
-let mockSpaceRootPath: string | null = null;
 vi.mock('@/store/spaceStore', () => ({
   useSpaceStore: (selector: (state: unknown) => unknown) =>
     selector({
-      activeSpaceId: 'space-1',
-      spaces: { 'space-1': { rootPath: mockSpaceRootPath } },
-      getProjectMeta: () => null,
+      projectIdIndex: { 'project-1': 'space-1' },
+      projectsBySpaceId: {
+        'space-1': {
+          'project-1': { workdirMode: 'direct-write' },
+        },
+      },
     }),
+}));
+
+vi.mock('@/store/projectRuntimeStore', () => ({
+  useProjectRuntimeStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      projects: {
+        'project-1': {
+          spaceId: 'space-1',
+          activeChatId: null,
+          chatStores: {},
+        },
+      },
+    }),
+}));
+
+const { fetchWorkspaceCapabilitiesMock, fetchWorkspaceEffectiveDirectoryMock } =
+  vi.hoisted(() => ({
+    fetchWorkspaceCapabilitiesMock: vi.fn(),
+    fetchWorkspaceEffectiveDirectoryMock: vi.fn(),
+  }));
+vi.mock('@/service/workspaceApi', () => ({
+  fetchWorkspaceCapabilities: fetchWorkspaceCapabilitiesMock,
+  fetchWorkspaceEffectiveDirectory: fetchWorkspaceEffectiveDirectoryMock,
 }));
 
 beforeEach(() => {
   mockSources = [];
-  mockSpaceRootPath = null;
-  desktopHost.electronAPI.getProjectFolderPath.mockClear();
+  fetchWorkspaceCapabilitiesMock.mockReset();
+  fetchWorkspaceCapabilitiesMock.mockResolvedValue({
+    terminal: true,
+    deployment: 'local',
+  });
+  fetchWorkspaceEffectiveDirectoryMock.mockReset();
+  fetchWorkspaceEffectiveDirectoryMock.mockResolvedValue({
+    space_id: 'space-1',
+    project_id: 'project-1',
+    working_directory: '/brain/project-workdir',
+    source: 'active_run',
+  });
 });
 
 const desktopHost = {
   ipcRenderer: null,
   electronAPI: {
     terminalCreate: vi.fn(),
-    getProjectFolderPath: vi.fn().mockResolvedValue('/tmp/project'),
+    terminalInput: vi.fn(),
+    terminalResize: vi.fn(),
+    terminalDispose: vi.fn(),
+    onTerminalData: vi.fn(),
+    onTerminalExit: vi.fn(),
   },
 };
 
-function shellTab(): SessionTerminalTab {
+function shellTab(
+  surface: 'project' | 'local' = 'project'
+): SessionTerminalTab {
   return {
     id: 'tab-1',
     type: 'terminal',
-    title: 'Terminal',
+    title: surface === 'project' ? 'Project terminal' : 'Local shell',
     shellId: 'session-shell:project-1:tab-1',
+    surface,
   };
 }
 
@@ -126,42 +178,82 @@ function renderTab(tab: SessionTerminalTab, host: unknown = desktopHost) {
 }
 
 describe('TerminalTab', () => {
-  it('renders an interactive local shell for a plain terminal tab', async () => {
+  it('renders a Project shell through the selected transport', async () => {
+    usePageTabStore.setState({ sessionPreviewProjectId: 'project-1' });
     renderTab(shellTab());
     expect(await screen.findByTestId('shell-terminal')).toHaveAttribute(
       'data-shell-id',
       'session-shell:project-1:tab-1'
     );
-  });
-
-  it('opens the shell in the Space root folder when the Space is folder-backed', async () => {
-    mockSpaceRootPath = '/Users/me/my-local-folder';
-    renderTab(shellTab());
-    expect(await screen.findByTestId('shell-terminal')).toHaveAttribute(
-      'data-cwd',
-      '/Users/me/my-local-folder'
+    expect(screen.getByTestId('shell-terminal')).toHaveAttribute(
+      'data-transport',
+      'electron-local'
     );
-    expect(desktopHost.electronAPI.getProjectFolderPath).not.toHaveBeenCalled();
   });
 
-  it('falls back to the generated project folder for non-folder Spaces', async () => {
+  it('opens the Project shell only in the Brain-resolved effective directory', async () => {
     usePageTabStore.setState({ sessionPreviewProjectId: 'project-1' });
     renderTab(shellTab());
     expect(await screen.findByTestId('shell-terminal')).toHaveAttribute(
       'data-cwd',
-      '/tmp/project'
+      '/brain/project-workdir'
     );
-    expect(desktopHost.electronAPI.getProjectFolderPath).toHaveBeenCalledWith(
-      'test@example.com',
+    expect(screen.getByTestId('shell-terminal')).toHaveAttribute(
+      'data-home-fallback',
+      'false'
+    );
+    expect(fetchWorkspaceEffectiveDirectoryMock).toHaveBeenCalledWith(
+      'space-1',
       'project-1',
-      7
+      'test@example.com',
+      7,
+      null,
+      'direct-write'
     );
   });
 
-  it('tells web users the shell needs the desktop app', () => {
+  it('keeps the explicit local shell independent from Project cwd resolution', async () => {
+    renderTab(shellTab('local'));
+    expect(await screen.findByTestId('shell-terminal')).toHaveAttribute(
+      'data-home-fallback',
+      'true'
+    );
+    expect(screen.getByTestId('shell-terminal')).not.toHaveAttribute(
+      'data-cwd'
+    );
+    expect(fetchWorkspaceEffectiveDirectoryMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing compatible transport without claiming terminal is desktop-only', async () => {
     renderTab(shellTab(), { ipcRenderer: null, electronAPI: null });
     expect(
-      screen.getByText('layout.terminal-desktop-only')
+      await screen.findByText('layout.terminal-brain-transport-unavailable')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('shell-terminal')).not.toBeInTheDocument();
+  });
+
+  it('does not use the Electron PTY for a Project on a remote Brain', async () => {
+    fetchWorkspaceCapabilitiesMock.mockResolvedValue({
+      terminal: true,
+      deployment: 'remote_cluster',
+    });
+    renderTab(shellTab());
+
+    expect(
+      await screen.findByText('layout.terminal-brain-transport-unavailable')
+    ).toBeInTheDocument();
+    expect(fetchWorkspaceEffectiveDirectoryMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('shell-terminal')).not.toBeInTheDocument();
+  });
+
+  it('shows the Brain workspace error instead of falling back to a local path', async () => {
+    usePageTabStore.setState({ sessionPreviewProjectId: 'project-1' });
+    fetchWorkspaceEffectiveDirectoryMock.mockRejectedValue(
+      new Error('effective workspace unavailable')
+    );
+    renderTab(shellTab());
+    expect(
+      await screen.findByText('effective workspace unavailable')
     ).toBeInTheDocument();
     expect(screen.queryByTestId('shell-terminal')).not.toBeInTheDocument();
   });

--- a/test/unit/electron/main/terminal.test.ts
+++ b/test/unit/electron/main/terminal.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   handles: new Map<string, (...args: any[]) => any>(),
@@ -88,6 +88,7 @@ function createHandler() {
 
 describe('terminal IPC lifecycle', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     disposeAllTerminals();
     mocks.handles.clear();
     mocks.listeners.clear();
@@ -95,7 +96,12 @@ describe('terminal IPC lifecycle', () => {
     registerTerminalIpcHandlers();
   });
 
-  it('refreshes the output sender when a persisted shell id is reattached', async () => {
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('rejects reattachment of a persisted shell id by another renderer', async () => {
     const pty = fakePty();
     mocks.spawn.mockReturnValue(pty);
     const originalSender = sender();
@@ -110,23 +116,56 @@ describe('terminal IPC lifecycle', () => {
       { id: 'session-shell:project:tab' }
     );
     pty.emitData('ready');
+    vi.runOnlyPendingTimers();
 
-    expect(result).toMatchObject({ success: true, existing: true });
-    expect(originalSender.send).not.toHaveBeenCalled();
-    expect(reopenedSender.send).toHaveBeenCalledWith('terminal-data', {
+    expect(result).toMatchObject({ success: false });
+    expect(originalSender.send).toHaveBeenCalledWith('terminal-data', {
       id: 'session-shell:project:tab',
       data: 'ready',
     });
+    expect(reopenedSender.send).not.toHaveBeenCalled();
+  });
+
+  it('allows a restored renderer to adopt a shell whose owner was destroyed', async () => {
+    const pty = fakePty();
+    mocks.spawn.mockReturnValue(pty);
+    const closedWindowSender = sender();
+    const reopenedWindowSender = sender();
+
+    await createHandler()(
+      { sender: closedWindowSender },
+      { id: 'session-shell:project:restored-tab' }
+    );
+    closedWindowSender.isDestroyed.mockReturnValue(true);
+    const result = await createHandler()(
+      { sender: reopenedWindowSender },
+      { id: 'session-shell:project:restored-tab' }
+    );
+    pty.emitData('restored');
+    vi.runOnlyPendingTimers();
+
+    expect(result).toMatchObject({ success: true, existing: true });
+    expect(closedWindowSender.send).not.toHaveBeenCalled();
+    expect(reopenedWindowSender.send).toHaveBeenCalledWith('terminal-data', {
+      id: 'session-shell:project:restored-tab',
+      data: 'restored',
+    });
+
+    const disposed = await mocks.handles.get('terminal-dispose')!(
+      { sender: reopenedWindowSender },
+      'session-shell:project:restored-tab'
+    );
+    expect(disposed).toEqual({ success: true });
+    expect(pty.kill).toHaveBeenCalledTimes(1);
   });
 
   it('shares one spawn across concurrent creates for the same id', async () => {
     mocks.spawn.mockReturnValue(fakePty());
-    const firstSender = sender();
-    const secondSender = sender();
+    const owner = sender();
 
     const [first, second] = await Promise.all([
-      createHandler()({ sender: firstSender }, { id: 'shared-shell' }),
-      createHandler()({ sender: secondSender }, { id: 'shared-shell' }),
+      createHandler()({ sender: owner }, { id: 'shared-shell' }),
+      createHandler()({ sender: owner }, { id: 'shared-shell' }),
     ]);
 
     expect(mocks.spawn).toHaveBeenCalledTimes(1);
@@ -142,12 +181,92 @@ describe('terminal IPC lifecycle', () => {
         OPENAI_API_KEY: 'secret',
         GH_TOKEN: 'secret',
         AWS_SECRET_ACCESS_KEY: 'secret',
+        AWS_ACCESS_KEY_ID: 'secret',
+        DATABASE_URL: 'postgres://secret',
+        REDIS_URL: 'redis://secret',
+        GITHUB_PAT: 'secret',
+        NPM_AUTH: 'secret',
+        SESSION_COOKIE: 'secret',
         CODEX_RESOLVER_SECRET: 'secret',
+        HTTP_PROXY: 'http://user:password@proxy.example',
+        HTTPS_PROXY: 'http://user:password@proxy.example',
+        ALL_PROXY: 'socks5://user:password@proxy.example',
+        NO_PROXY: 'localhost,127.0.0.1',
+        XDG_CONFIG_HOME: '/tmp/xdg',
       })
     ).toEqual({
       PATH: '/usr/bin',
       LANG: 'en_GB.UTF-8',
+      XDG_CONFIG_HOME: '/tmp/xdg',
     });
+  });
+
+  it('batches sustained output before crossing the renderer IPC boundary', async () => {
+    const pty = fakePty();
+    mocks.spawn.mockReturnValue(pty);
+    const outputSender = sender();
+    await createHandler()({ sender: outputSender }, { id: 'batched-shell' });
+
+    pty.emitData('one');
+    pty.emitData('two');
+    expect(outputSender.send).not.toHaveBeenCalled();
+
+    vi.runOnlyPendingTimers();
+    expect(outputSender.send).toHaveBeenCalledTimes(1);
+    expect(outputSender.send).toHaveBeenCalledWith('terminal-data', {
+      id: 'batched-shell',
+      data: 'onetwo',
+    });
+  });
+
+  it('rejects input, resize, and disposal from a non-owning renderer', async () => {
+    const pty = fakePty();
+    mocks.spawn.mockReturnValue(pty);
+    const owner = sender();
+    const stranger = sender();
+    await createHandler()({ sender: owner }, { id: 'owned-shell' });
+
+    mocks.listeners.get('terminal-input')!(
+      { sender: stranger },
+      { id: 'owned-shell', data: 'unsafe' }
+    );
+    mocks.listeners.get('terminal-resize')!(
+      { sender: stranger },
+      { id: 'owned-shell', cols: 100, rows: 40 }
+    );
+    const rejected = await mocks.handles.get('terminal-dispose')!(
+      { sender: stranger },
+      'owned-shell'
+    );
+
+    expect(pty.write).not.toHaveBeenCalled();
+    expect(pty.resize).not.toHaveBeenCalled();
+    expect(pty.kill).not.toHaveBeenCalled();
+    expect(rejected).toMatchObject({ success: false });
+
+    mocks.listeners.get('terminal-input')!(
+      { sender: owner },
+      { id: 'owned-shell', data: 'safe' }
+    );
+    expect(pty.write).toHaveBeenCalledWith('safe');
+  });
+
+  it('fails a Project terminal instead of silently falling back to home', async () => {
+    mocks.spawn.mockReturnValue(fakePty());
+    const result = await createHandler()(
+      { sender: sender() },
+      {
+        id: 'strict-project-shell',
+        cwd: '/definitely/missing/eigent-project-directory',
+        allowHomeFallback: false,
+      }
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Project working directory is unavailable',
+    });
+    expect(mocks.spawn).not.toHaveBeenCalled();
   });
 
   it('ignores a disposed PTY exit after a replacement shell starts', async () => {
@@ -164,6 +283,7 @@ describe('terminal IPC lifecycle', () => {
     await createHandler()({ sender: outputSender }, { id: 'restart-shell' });
     oldPty.emitData('stale output');
     oldPty.emitExit(0);
+    vi.runOnlyPendingTimers();
 
     expect(outputSender.send).not.toHaveBeenCalledWith('terminal-data', {
       id: 'restart-shell',
@@ -174,6 +294,7 @@ describe('terminal IPC lifecycle', () => {
       expect.anything()
     );
     replacementPty.emitData('replacement-ready');
+    vi.runOnlyPendingTimers();
     expect(outputSender.send).toHaveBeenCalledWith('terminal-data', {
       id: 'restart-shell',
       data: 'replacement-ready',

--- a/test/unit/store/pageTabStore.preview.test.ts
+++ b/test/unit/store/pageTabStore.preview.test.ts
@@ -24,7 +24,12 @@ describe('pageTabStore session preview', () => {
   beforeEach(() => {
     window.electronAPI = {
       ...window.electronAPI,
+      terminalCreate: vi.fn().mockResolvedValue({ success: true }),
+      terminalInput: vi.fn(),
+      terminalResize: vi.fn(),
       terminalDispose: vi.fn().mockResolvedValue({ success: true }),
+      onTerminalData: vi.fn(() => () => {}),
+      onTerminalExit: vi.fn(() => () => {}),
     };
     usePageTabStore.setState({
       sessionPreviewProjectId: null,
@@ -96,6 +101,23 @@ describe('pageTabStore session preview', () => {
       'session-shell:project-a:'
     );
     expect(terminal.type === 'terminal' && terminal.agentSourceId).toBeFalsy();
+    expect(terminal.type === 'terminal' && terminal.surface).toBe('project');
+  });
+
+  it('creates an explicitly local shell as a distinct chooser destination', () => {
+    const store = usePageTabStore.getState();
+    store.toggleSessionPreview();
+    store.choosePreviewTabType(slice().activeTabId!, 'local-terminal');
+
+    expect(slice().tabs[0]).toMatchObject({
+      type: 'terminal',
+      title: 'Local shell',
+      surface: 'local',
+    });
+    const tab = slice().tabs[0];
+    expect(tab.type === 'terminal' && tab.shellId).toContain(
+      'local-shell:project-a:'
+    );
   });
 
   it('opens agent streams in terminal tabs, converting the chooser in place', () => {
@@ -295,5 +317,33 @@ describe('pageTabStore session preview', () => {
       'project-b'
     );
     expect(slice().open).toBe(true);
+  });
+
+  it("retains only the next user's project previews at an auth boundary", () => {
+    const store = usePageTabStore.getState();
+    store.toggleSessionPreview();
+    store.choosePreviewTabType(slice().activeTabId!, 'terminal');
+    const removedTerminal = slice().tabs[0];
+    const removedShellId =
+      removedTerminal.type === 'terminal' ? removedTerminal.shellId : undefined;
+
+    store.setSessionPreviewProject('project-b');
+    store.toggleSessionPreview();
+    store.choosePreviewTabType(slice().activeTabId!, 'terminal');
+
+    store.retainSessionPreviewProjects(['project-b']);
+
+    expect(window.electronAPI.terminalDispose).toHaveBeenCalledWith(
+      removedShellId
+    );
+    expect(
+      usePageTabStore.getState().sessionPreviewByProject['project-a']
+    ).toBeUndefined();
+    expect(
+      usePageTabStore.getState().sessionPreviewByProject['project-b']
+    ).toBeDefined();
+    expect(usePageTabStore.getState().sessionPreviewProjectId).toBe(
+      'project-b'
+    );
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

# Pull Request

## Related Issue

Relates to #1319.

Follow-up to #1761 after the in-session preview panel was merged into `main`.

## Description

Fixes several terminal issues found after #1761:

- Project terminals could start in an incorrect or fallback directory. They now use the project directory resolved by the backend and show an error when it is unavailable.
- Terminal sessions could be destroyed while reloading project history or retained after logout. Session cleanup now follows the project and user lifecycle.
- Restored terminals could not reconnect after closing and reopening the main window on macOS.
- Interactive shells inherited more environment variables than necessary. The inherited environment is now restricted to an explicit allowlist.
- High-volume terminal output emitted excessive IPC events. Output is now batched before being sent to the renderer.
- The terminal chooser now distinguishes project terminals from the local desktop shell.

## Testing Evidence (REQUIRED)

- [x] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
