### PR TITLE
Read theme from authStore instead of next-themes

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-import { useTheme } from 'next-themes';
+import { useAuthStore } from '@/store/authStore';
 import { createPortal } from 'react-dom';
 import { Toaster as Sonner } from 'sonner';
 
@@ -48,13 +48,13 @@ const FOLD_AT_THREE_CSS = `
 `;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = 'system' } = useTheme();
+  const appearance = useAuthStore((state) => state.appearance);
 
   const toaster = (
     <>
       <style>{FOLD_AT_THREE_CSS}</style>
       <Sonner
-        theme={theme as ToasterProps['theme']}
+        theme={appearance}
         className="toaster group"
         toastOptions={{
           classNames: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

# Pull Request

## Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

Fixes #1845 

## Description

The toast component `src/components/ui/sonner.tsx` read its theme from next-themes's `useTheme() (const { theme = 'system' } = useTheme())`, which did not reflect the app's actually-resolved theme. That's why the toast box rendered with colors that didn't match the device theme.

So I changed the Toaster to read the resolved appearance from the app's theme store instead.

## Testing Evidence (REQUIRED)

Before: 

<img width="1728" height="1117" alt="Screenshot 2026-08-13 at 15 07 25" src="https://github.com/user-attachments/assets/c1cd77bf-53dd-4f9f-ae9f-2eee0281c7d5" />

After:

<img width="1728" height="1117" alt="Screenshot 2026-08-13 at 14 53 06" src="https://github.com/user-attachments/assets/5a6ac315-6a0d-4a6e-9f97-fce779643296" />

- [x] I have included human-verified testing evidence in this PR.
- [x] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

## Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
