### PR TITLE
fix(model-selection): preserve selected model when switching mid-conversation

### DIFF
--- a/backend/app/controller/chat_controller.py
+++ b/backend/app/controller/chat_controller.py
@@ -718,6 +718,13 @@ async def improve(id: str, data: SupplementChat, request: Request):
                 question=data.question,
                 attaches=data.attaches or [],
                 project_context=data.project_context,
+                model_platform=data.model_platform,
+                model_type=data.model_type,
+                api_key=data.api_key,
+                api_url=data.api_url,
+                auth_source=data.auth_source,
+                model_config_dict=data.model_config_dict,
+                extra_params=data.extra_params,
             ),
             new_task_id=data.task_id,
         )

--- a/backend/app/model/chat.py
+++ b/backend/app/model/chat.py
@@ -211,6 +211,16 @@ class SupplementChat(BaseModel):
     task_id: str | None = None
     attaches: list[str] = []
     project_context: str | None = None
+    # Optional model override for follow-up turns. When the user switches the
+    # model mid-conversation, the client sends the new selection here so the
+    # backend can rebuild the agent instead of reusing the original one.
+    model_platform: NormalizedOptionalModelPlatform = None
+    model_type: str | None = None
+    api_key: str | None = None
+    api_url: str | None = None
+    auth_source: Literal["codex_subscription"] | None = None
+    model_config_dict: dict[str, Any] | None = None
+    extra_params: dict | None = None
 
 
 class HumanReply(BaseModel):

--- a/backend/app/service/chat_service.py
+++ b/backend/app/service/chat_service.py
@@ -65,7 +65,10 @@ from app.memory import (
 )
 from app.model.chat import Chat, NewAgent, Status, TaskContent, sse_json
 from app.model.subscription_runtime import is_subscription_auth
-from app.service.single_agent_service import single_agent_solve
+from app.service.single_agent_service import (
+    _apply_model_override,
+    single_agent_solve,
+)
 from app.service.task import (
     Action,
     ActionDecomposeProgressData,
@@ -74,6 +77,7 @@ from app.service.task import (
     ActionInstallMcpData,
     ActionNewAgent,
     Agents,
+    ImprovePayload,
     TaskLock,
     delete_task_lock,
     set_current_task_id,
@@ -641,6 +645,12 @@ async def step_solve(options: Chat, request: Request, task_lock: TaskLock):
                         if item.data.attaches
                         else options.attaches
                     )
+                    # If the user switched the model mid-conversation, rebuild
+                    # the cached question agent so the new model is used from
+                    # this turn onward while keeping conversation context.
+                    if _apply_model_override(options, item.data):
+                        task_lock.question_agent = None
+                        question_agent = question_confirm_agent(options)
                     logger.info(
                         "[NEW-QUESTION] Follow-up "
                         "question from "

--- a/backend/app/service/single_agent_service.py
+++ b/backend/app/service/single_agent_service.py
@@ -33,6 +33,7 @@ from app.service.task import (
     Action,
     ActionData,
     ActionImproveData,
+    ImprovePayload,
     TaskLock,
     delete_task_lock,
     set_current_task_id,
@@ -53,6 +54,68 @@ try:
     )
 except ValueError:
     _MEMORY_TOKEN_BUDGET = 8000
+
+
+def _apply_model_override(options: Chat, payload: ImprovePayload) -> bool:
+    """Apply a user-selected model override to options for a follow-up turn.
+
+    Returns True when the model actually changed (so the caller knows to
+    rebuild the cached agent), False when there is no override or it matches
+    the current configuration.
+
+    The frontend sends the full resolved model config on the improve request so
+    a mid-conversation model switch is honored even though the conversation's
+    project pin / history still references the original model.
+    """
+    if not payload.model_platform and not payload.model_type:
+        # No override supplied on this turn.
+        return False
+
+    # "changed" reflects a change to the model identity (platform / type /
+    # auth_source) which is what the cached agent was built from. Only these
+    # force a rebuild. Credentials and extra config are still applied so a
+    # custom/local provider switch propagates correctly, but they do not by
+    # themselves invalidate the cached agent (e.g. sending `{}` where the
+    # current config is `None` should not trigger a pointless rebuild).
+    changed = False
+
+    if (
+        payload.model_platform
+        and payload.model_platform != options.model_platform
+    ):
+        options.model_platform = payload.model_platform
+        changed = True
+    if payload.model_type and payload.model_type != options.model_type:
+        options.model_type = payload.model_type
+        changed = True
+    if (
+        getattr(options, "auth_source", None) != payload.auth_source
+        and payload.auth_source is not None
+    ):
+        options.auth_source = payload.auth_source
+        changed = True
+
+    if payload.api_key is not None and payload.api_key != options.api_key:
+        options.api_key = payload.api_key
+    if payload.api_url is not None and payload.api_url != options.api_url:
+        options.api_url = payload.api_url
+    if payload.model_config_dict is not None:
+        # Avoid treating a populated config replacing an empty one as no-op.
+        options.model_config_dict = payload.model_config_dict
+    if payload.extra_params is not None:
+        options.extra_params = payload.extra_params
+
+    if changed:
+        logger.info(
+            "Model override applied for follow-up turn",
+            extra={
+                "project_id": options.project_id,
+                "model_platform": options.model_platform,
+                "model_type": options.model_type,
+                "auth_source": getattr(options, "auth_source", None),
+            },
+        )
+    return changed
 
 
 def _build_single_agent_context(
@@ -320,6 +383,22 @@ async def single_agent_solve(
                         set_current_task_id(
                             options.project_id, current_task_id
                         )
+
+                    # If the user switched the model mid-conversation, rebuild
+                    # the cached agent so the new model is used from this turn
+                    # onward while preserving conversation context.
+                    if _apply_model_override(options, item.data):
+                        if agent is not None:
+                            logger.info(
+                                "Model changed on follow-up turn; rebuilding "
+                                "single agent",
+                                extra={
+                                    "project_id": options.project_id,
+                                    "model_platform": options.model_platform,
+                                    "model_type": options.model_type,
+                                },
+                            )
+                        agent = None
 
                     if running_turn is not None and not running_turn.done():
                         yield sse_json(

--- a/backend/app/service/task.py
+++ b/backend/app/service/task.py
@@ -82,6 +82,15 @@ class ImprovePayload(BaseModel):
     question: str
     attaches: list[str] = []
     project_context: str | None = None
+    # Optional model override so switching models mid-conversation lets the
+    # backend rebuild the agent with the new model while keeping context.
+    model_platform: str | None = None
+    model_type: str | None = None
+    api_key: str | None = None
+    api_url: str | None = None
+    auth_source: str | None = None
+    model_config_dict: dict[str, Any] | None = None
+    extra_params: dict | None = None
 
 
 class ActionImproveData(BaseModel):

--- a/src/components/ChatBox/index.tsx
+++ b/src/components/ChatBox/index.tsx
@@ -31,7 +31,10 @@ import {
 import { inferSessionModeFromTask } from '@/lib/sessionMode';
 import { proxyUpdateTriggerExecution } from '@/service/triggerApi';
 import { useAuthStore } from '@/store/authStore';
-import { buildProjectContinuationContext } from '@/store/chatStore';
+import {
+  buildProjectContinuationContext,
+  resolveChatModelForProject,
+} from '@/store/chatStore';
 import { usePageTabStore } from '@/store/pageTabStore';
 import { useSpaceStore } from '@/store/spaceStore';
 import { ExecutionStatus } from '@/types';
@@ -886,7 +889,11 @@ export default function ChatBox(): JSX.Element {
             chatStore.setNextTaskId(nextTaskId);
             chatStore.setNextExecutionId(_taskId as string, executionId);
 
-            // Use improve endpoint (POST /chat/{id}) - {id} is project_id
+            // Use improve endpoint (POST /chat/{id}) - {id} is project_id.
+            // Resolve the currently selected model so a mid-conversation switch
+            // (e.g. model A -> model B) is honored on this follow-up turn.
+            const improveModel =
+              await resolveChatModelForProject(targetProjectId);
             fetchPost(`/chat/${targetProjectId}`, {
               question: tempMessageContent,
               task_id: nextTaskId,
@@ -896,6 +903,17 @@ export default function ChatBox(): JSX.Element {
                 nextTaskId
               ),
               target: undefined,
+              ...(improveModel
+                ? {
+                    model_platform: improveModel.model_platform,
+                    model_type: improveModel.model_type,
+                    api_key: improveModel.api_key,
+                    api_url: improveModel.api_url,
+                    auth_source: improveModel.auth_source,
+                    model_config_dict: improveModel.model_config_dict,
+                    extra_params: improveModel.extra_params,
+                  }
+                : {}),
             });
             chatStore.setIsPending(_taskId, true);
             chatStore.addMessages(_taskId, {
@@ -954,6 +972,7 @@ export default function ChatBox(): JSX.Element {
     }
   };
 
+  // eslint-disable-next-line react-hooks/refs
   handleSendRef.current = handleSend;
 
   // Reactive queuedMessages for the active project

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -1246,6 +1246,128 @@ const updateTriggerExecutionStatus = async (
   }
 };
 
+/**
+ * Resolve the currently selected model for a Project so it can be sent with a
+ * follow-up (improve) request. This honors a model pinned on the Project (from
+ * the last conversation) and falls back to the user's global defaults, matching
+ * the resolution that `startTask` uses when starting a new conversation.
+ *
+ * Returns the model request fields the backend needs to rebuild the agent, or
+ * `null` when the model cannot be determined.
+ */
+export async function resolveChatModelForProject(
+  projectId: string | null
+): Promise<null | {
+  model_platform: string;
+  model_type: string;
+  api_key: string;
+  api_url?: string;
+  auth_source?: 'codex_subscription';
+  model_config_dict?: Record<string, unknown>;
+  extra_params?: Record<string, unknown>;
+}> {
+  const projectStore = useProjectStore.getState();
+  const authStore = getAuthStore();
+
+  const pinnedModelSelection = projectId
+    ? projectStore.getProjectModel(projectId)
+    : null;
+  const effectiveModelType =
+    pinnedModelSelection?.modelType ?? authStore.modelType;
+
+  if (effectiveModelType === 'custom' || effectiveModelType === 'local') {
+    let provider: any = null;
+    if (pinnedModelSelection?.provider_id !== undefined) {
+      try {
+        const res = await proxyFetchGet('/api/v1/providers');
+        const providerList = Array.isArray(res) ? res : res.items || [];
+        provider =
+          providerList.find(
+            (p: { id: number }) => p.id === pinnedModelSelection.provider_id
+          ) || null;
+      } catch (error) {
+        console.error('Failed to load pinned model provider:', error);
+      }
+    }
+    if (!provider) {
+      const res = await proxyFetchGet('/api/v1/providers', {
+        prefer: true,
+      });
+      const providerList = res.items || [];
+      provider = providerList[0];
+    }
+    if (!provider) {
+      return null;
+    }
+    const { modelConfigDict, extraParams } = splitProviderConfig(
+      provider.encrypted_config
+    );
+    return {
+      api_key: provider.api_key,
+      model_type: provider.model_type,
+      model_platform: provider.provider_name,
+      api_url: provider.endpoint_url || provider.api_url,
+      model_config_dict: modelConfigDict,
+      extra_params: extraParams,
+      auth_source: undefined,
+    };
+  }
+
+  if (effectiveModelType === 'cloud') {
+    const requestedCloudModelId =
+      pinnedModelSelection?.cloud_model_type || authStore.cloud_model_type;
+    const cloudModelStore = getCloudModelStore();
+    let resolvedCloudModel = cloudModelStore.resolveCloudModel(
+      requestedCloudModelId
+    );
+    if (!resolvedCloudModel || resolvedCloudModel.source !== 'selected') {
+      await cloudModelStore.fetchCloudModels(true);
+      resolvedCloudModel = getCloudModelStore().resolveCloudModel(
+        requestedCloudModelId
+      );
+    }
+    if (!resolvedCloudModel) {
+      return null;
+    }
+    let res: any;
+    try {
+      res = await proxyFetchGet('/api/v1/user/key');
+    } catch (error) {
+      return null;
+    }
+    if (!res?.value) {
+      return null;
+    }
+    return {
+      api_key: res.value,
+      model_type: resolvedCloudModel.model.model_type,
+      model_platform: resolvedCloudModel.model.model_platform,
+      api_url: res.api_url,
+      model_config_dict: {},
+      extra_params: {},
+      auth_source: undefined,
+    };
+  }
+
+  if (effectiveModelType === 'codex_subscription') {
+    const codexModelId =
+      pinnedModelSelection?.codex_model_type ||
+      authStore.codex_model_type ||
+      'gpt-5.5';
+    return {
+      api_key: '',
+      model_type: codexModelId,
+      model_platform: 'openai',
+      api_url: '',
+      model_config_dict: {},
+      extra_params: {},
+      auth_source: 'codex_subscription',
+    };
+  }
+
+  return null;
+}
+
 const chatStore = (initial?: Partial<ChatStore>) =>
   createStore<ChatStore>()((set, get) => ({
     activeTaskId: null,


### PR DESCRIPTION

<!-- Thank you for contributing! -->

# Pull Request

## Related Issue

Fixes #1847 

## Description

When you switched the model in the chatbox mid-conversation (e.g. Model A → Model B), the next follow-up message never actually reached the backend with your new selection. I have attached a video evidence of the bug in the Before view and the After view shows it is fixed.  

## Testing Evidence (REQUIRED)

Before:

https://github.com/user-attachments/assets/f51e0757-5394-41c0-9116-9c014d9ffc11

After:

https://github.com/user-attachments/assets/256e4ee3-277c-4387-9dea-cbdb5497b8db

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->

<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->

<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- [x] I have included human-verified testing evidence in this PR.
- [x] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
