### PR TITLE
fix: allow local Brain to bind folders outside home directory

### DIFF
--- a/backend/app/hands/environment_hands.py
+++ b/backend/app/hands/environment_hands.py
@@ -46,19 +46,8 @@ class EnvironmentHands(IHands):
     def can_access_filesystem(self, path: str) -> bool:
         if self._caps.filesystem_scope == "full":
             try:
-                resolved = Path(path).expanduser().resolve()
-                home = Path.home()
-                workspace = self.workspace_root.resolve()
-                try:
-                    resolved.relative_to(home)
-                    return True
-                except ValueError:
-                    pass
-                try:
-                    resolved.relative_to(workspace)
-                    return True
-                except ValueError:
-                    return False
+                Path(path).expanduser().resolve()
+                return True
             except (OSError, RuntimeError):
                 return False
         if self._caps.filesystem_scope == "workspace_only":

--- a/backend/tests/app/hands/test_capabilities.py
+++ b/backend/tests/app/hands/test_capabilities.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+from pathlib import Path
+
 import pytest
 
 from app.hands import capabilities
@@ -66,3 +68,39 @@ def test_detect_capabilities_uses_terminal_shell_probe(monkeypatch):
 
     assert caps.has_terminal is True
     assert hands.can_execute_terminal() is True
+
+
+@pytest.mark.unit
+def test_environment_hands_full_scope_allows_path_outside_workspace(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    # Use the filesystem root so this path is outside both the configured
+    # workspace and the user's home directory on Windows and POSIX runners.
+    outside = Path(tmp_path.anchor) / "eigent-full-scope-test"
+
+    caps = capabilities.BrainCapabilities(
+        filesystem_scope="full",
+        workspace_root=workspace,
+    )
+    hands = EnvironmentHands(caps)
+
+    assert hands.can_access_filesystem(str(outside)) is True
+
+
+@pytest.mark.unit
+def test_environment_hands_workspace_only_stays_restricted(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    inside = workspace / "project"
+    inside.mkdir()
+    outside = Path(tmp_path.anchor) / "eigent-workspace-only-test"
+
+    caps = capabilities.BrainCapabilities(
+        filesystem_scope="workspace_only",
+        workspace_root=workspace,
+    )
+    hands = EnvironmentHands(caps)
+
+    assert hands.can_access_filesystem(str(inside)) is True
+    assert hands.can_access_filesystem(str(outside)) is False


### PR DESCRIPTION
## Summary

Fix local workspace binding for folders that live outside the user's home directory or `EIGENT_WORKSPACE`.

Local desktop deployments are detected with `filesystem_scope="full"`, but `EnvironmentHands.can_access_filesystem()` was still restricting that scope to the home directory and configured workspace root. On Windows this rejects valid folders on another drive (for example `D:\...`) and surfaces as:

> That folder is not available to this Brain.

The change makes `full` mean unrestricted filesystem capability as declared by `BrainCapabilities`, while leaving `workspace_only` unchanged for sandbox/container deployments.

## Changes

- allow any resolvable path when `filesystem_scope == "full"`
- keep `workspace_only` restricted to the configured workspace root
- add regression coverage for both behaviors

Path existence and directory validation remain in the workspace binding endpoint, so this only fixes the capability check; it does not bypass normal bind-path validation.

## Validation

Validated on Windows with a local Brain by binding a folder outside the user profile / workspace root, including a folder on `D:`. The previous code rejects that path; this change allows it while the `workspace_only` regression test still rejects paths outside its workspace.

Fixes #1766