### PR TITLE
feat: make the Files page a usable project workspace

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -56,10 +56,17 @@ import {
 import {
   authorizeLocalFilePath,
   authorizeLocalPreviewPath,
-  isExecutableExternalOpenPath,
   isMainRendererSender,
 } from './localFileSecurity';
 import { filePathFromLocalFileUrl } from './localFileUrl';
+import {
+  authorizeWorkspaceLocalNode,
+  openWorkspaceLocalFile,
+  rememberBoundedPathGrant,
+  revealAuthorizedLocalNode,
+  revealUserVisibleLocalNode,
+  revealWorkspaceLocalNode,
+} from './localPathActions';
 import { setRoundedCorners } from './native/macos-window';
 import { registerReviewChangesIpcHandlers } from './reviewChanges';
 import {
@@ -118,6 +125,25 @@ let use_external_cdp = false;
 let proxyUrl: string | null = null;
 const LEGACY_DESKTOP_INSTANCE_STORAGE_KEY = 'eigent_desktop_instance_id';
 const activeLocalFileRoots = new Set<string>();
+
+/**
+ * Real paths the user picked in a native file dialog this session.
+ *
+ * Chat attachments are chosen from anywhere on disk, so they are legitimately
+ * outside every Space root. The dialog itself is the user's authorization, and
+ * recording the exact picked path lets those attachments stay revealable
+ * without granting the renderer free rein over the file system.
+ */
+const userSelectedLocalPaths = new Set<string>();
+const USER_SELECTED_PATH_LIMIT = 512;
+
+function rememberUserSelectedLocalPath(realPath: string): void {
+  rememberBoundedPathGrant(
+    userSelectedLocalPaths,
+    realPath,
+    USER_SELECTED_PATH_LIMIT
+  );
+}
 
 function resolveDesktopInstanceId(legacyRendererId?: string | null): string {
   if (!desktopInstanceId) {
@@ -210,7 +236,8 @@ type BackendStartOptions = {
 };
 
 type BackendStartResult =
-  { success: true; port: number } | { success: false; error: string };
+  | { success: true; port: number }
+  | { success: false; error: string };
 
 function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -1179,6 +1206,12 @@ function registerIpcHandlers() {
     'set-local-file-preview-roots',
     async (event, roots: unknown) => {
       assertMainRendererSender(event);
+      // TODO(security): replace this renderer-declared, process-global root set
+      // with main-authoritative, per-surface capabilities. A compromised main
+      // renderer can currently register a broad existing directory (including
+      // a filesystem root), and the replace semantics let concurrent preview
+      // surfaces clear one another's grants. This check is bug containment,
+      // not a renderer-compromise boundary.
       if (!Array.isArray(roots) || roots.length > 4) {
         throw new Error('Invalid local file preview roots');
       }
@@ -1757,6 +1790,7 @@ function registerIpcHandlers() {
 
   // ==================== file operation handler ====================
   ipcMain.handle('select-file', async (event, options = {}) => {
+    assertMainRendererSender(event);
     const result = await dialog.showOpenDialog(win!, {
       properties: ['openFile', 'multiSelections'],
       ...options,
@@ -1767,6 +1801,15 @@ function registerIpcHandlers() {
         filePath,
         fileName: filePath.split(/[/\\]/).pop() || '',
       }));
+
+      // Picking a file here is the user's own grant to reveal it later, even
+      // though attachments routinely live outside every Space root.
+      await Promise.all(
+        result.filePaths.map(async (filePath) => {
+          const realPath = await fsp.realpath(filePath).catch(() => null);
+          if (realPath) rememberUserSelectedLocalPath(realPath);
+        })
+      );
 
       return {
         success: true,
@@ -1843,15 +1886,19 @@ function registerIpcHandlers() {
   ipcMain.handle(
     'process-dropped-files',
     async (event, fileData: Array<{ name: string; path?: string }>) => {
+      assertMainRendererSender(event);
       try {
         // In Electron with contextIsolation, we need to get file paths differently
         // The renderer will send us file metadata, and we'll use webUtils if needed
         const files = fileData
           .filter((f) => f.path) // Only process files with valid paths
-          .map((f) => ({
-            filePath: fs.realpathSync(f.path!),
-            fileName: f.name,
-          }));
+          .map((f) => {
+            const filePath = fs.realpathSync(f.path!);
+            // Drag-and-drop is an explicit user gesture equivalent to picking
+            // the exact path in the native file dialog.
+            rememberUserSelectedLocalPath(filePath);
+            return { filePath, fileName: f.name };
+          });
 
         if (files.length === 0) {
           return {
@@ -1878,7 +1925,8 @@ function registerIpcHandlers() {
   // path-based attachment flow; pasted File objects carry no filesystem path.
   ipcMain.handle(
     'save-pasted-file',
-    async (_event, fileName: string, data: ArrayBuffer) => {
+    async (event, fileName: string, data: ArrayBuffer) => {
+      assertMainRendererSender(event);
       try {
         const pastedDir = path.join(app.getPath('temp'), 'eigent-pasted');
         await fsp.mkdir(pastedDir, { recursive: true });
@@ -1891,7 +1939,10 @@ function registerIpcHandlers() {
         const unique = crypto.randomUUID();
         const filePath = path.join(pastedDir, `${stamp}-${unique}-${safeName}`);
         await fsp.writeFile(filePath, Buffer.from(new Uint8Array(data)));
-        return { success: true, filePath, fileName: safeName };
+        const realPath = await fsp.realpath(filePath);
+        // The paste gesture created this exact attachment on the user's behalf.
+        rememberUserSelectedLocalPath(realPath);
+        return { success: true, filePath: realPath, fileName: safeName };
       } catch (error: any) {
         log.error('Failed to save pasted file:', error);
         return { success: false, error: error.message };
@@ -1899,45 +1950,38 @@ function registerIpcHandlers() {
     }
   );
 
-  ipcMain.handle('reveal-in-folder', async (event, filePath: string) => {
+  ipcMain.handle('reveal-in-folder', async (event, targetPath: string) => {
+    assertMainRendererSender(event);
     try {
-      const stats = await fs.promises
-        .stat(filePath.replace(/\/$/, ''))
-        .catch(() => null);
-      if (stats && stats.isDirectory()) {
-        shell.openPath(filePath);
-      } else {
-        shell.showItemInFolder(filePath);
-      }
-    } catch (e) {
-      log.error('reveal in folder failed', e);
+      // Same containment rules as 'reveal-local-path'; this channel additionally
+      // serves chat attachments, which the user picked outside the workspace.
+      return await revealUserVisibleLocalNode(
+        targetPath,
+        [...activeLocalFileRoots],
+        userSelectedLocalPaths,
+        shell
+      );
+    } catch (error) {
+      log.error('Reveal in folder failed', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to reveal path',
+      };
     }
   });
 
-  ipcMain.handle('open-local-file', async (event, filePath: string) => {
+  ipcMain.handle('reveal-local-path', async (event, targetPath: string) => {
     assertMainRendererSender(event);
-    const authorization = await authorizeLocalFilePath(
-      filePath,
-      localFileAllowedRoots()
+    return revealWorkspaceLocalNode(
+      targetPath,
+      [...activeLocalFileRoots],
+      shell
     );
-    if (!authorization.allowed) {
-      return { success: false, error: 'File is outside the active workspace' };
-    }
-    const stats = await fsp.stat(authorization.filePath).catch(() => null);
-    if (!stats?.isFile()) {
-      return { success: false, error: 'File does not exist' };
-    }
-    if (isExecutableExternalOpenPath(authorization.filePath, stats.mode)) {
-      shell.showItemInFolder(authorization.filePath);
-      return {
-        success: false,
-        error: 'Executable files cannot be opened from an agent result',
-      };
-    }
-    const error = await shell.openPath(authorization.filePath);
-    return error
-      ? { success: false, error }
-      : { success: true, error: undefined };
+  });
+
+  ipcMain.handle('open-local-file', async (event, targetPath: string) => {
+    assertMainRendererSender(event);
+    return openWorkspaceLocalFile(targetPath, [...activeLocalFileRoots], shell);
   });
 
   // Skills: all operations via Brain REST API (backend). No IPC.
@@ -2047,7 +2091,20 @@ function registerIpcHandlers() {
 
   ipcMain.handle(
     'open-in-ide',
-    async (_event, folderPath: string, ide: string) => {
+    async (event, targetPath: string, ide: string) => {
+      assertMainRendererSender(event);
+      if (ide !== 'vscode' && ide !== 'cursor' && ide !== 'system') {
+        return { success: false, error: 'Unsupported editor' };
+      }
+
+      const node = await authorizeWorkspaceLocalNode(targetPath, [
+        ...activeLocalFileRoots,
+      ]);
+      if (!node.success) return node;
+      if (ide === 'system') {
+        return revealAuthorizedLocalNode(node, shell);
+      }
+
       const getIDECommand = (): string => {
         const platform = process.platform;
         const homeDir = homedir();
@@ -2062,9 +2119,7 @@ function registerIpcHandlers() {
             for (const p of vscodePaths) {
               if (existsSync(p)) return p;
             }
-            log.warn(
-              '[IDE] VS Code not found on macOS, using system file manager'
-            );
+            log.warn('[IDE] VS Code not found on macOS');
             return '';
           } else if (platform === 'win32') {
             // Windows: Check common VS Code paths
@@ -2075,26 +2130,14 @@ function registerIpcHandlers() {
                 'Local',
                 'Programs',
                 'Microsoft VS Code',
-                'bin',
-                'code.cmd'
-              ),
-              path.join(
-                homeDir,
-                'AppData',
-                'Local',
-                'Programs',
-                'Microsoft VS Code',
                 'Code.exe'
               ),
-              'C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd',
               'C:\\Program Files\\Microsoft VS Code\\Code.exe',
             ];
             for (const p of vscodePaths) {
               if (existsSync(p)) return p;
             }
-            log.warn(
-              '[IDE] VS Code not found on Windows, using system file manager'
-            );
+            log.warn('[IDE] VS Code not found on Windows');
             return '';
           }
           return 'code'; // Linux
@@ -2108,24 +2151,11 @@ function registerIpcHandlers() {
             for (const p of cursorPaths) {
               if (existsSync(p)) return p;
             }
-            log.warn(
-              '[IDE] Cursor not found on macOS, using system file manager'
-            );
+            log.warn('[IDE] Cursor not found on macOS');
             return '';
           } else if (platform === 'win32') {
             // Windows: Check common Cursor paths
             const cursorPaths = [
-              path.join(
-                homeDir,
-                'AppData',
-                'Local',
-                'Programs',
-                'Cursor',
-                'resources',
-                'app',
-                'bin',
-                'cursor.cmd'
-              ),
               path.join(
                 homeDir,
                 'AppData',
@@ -2139,9 +2169,7 @@ function registerIpcHandlers() {
             for (const p of cursorPaths) {
               if (existsSync(p)) return p;
             }
-            log.warn(
-              '[IDE] Cursor not found on Windows, using system file manager'
-            );
+            log.warn('[IDE] Cursor not found on Windows');
             return '';
           }
           return 'cursor'; // Linux
@@ -2151,37 +2179,24 @@ function registerIpcHandlers() {
 
       const cmd = getIDECommand();
       if (!cmd) {
-        // IDE not found or 'system' selected - open with system file manager
-        const errorMsg = await shell.openPath(folderPath);
-        if (errorMsg) {
-          log.error('[IDE] shell.openPath error:', errorMsg);
-          return { success: false, error: errorMsg };
-        }
-        return { success: true };
+        const editorName = ide === 'vscode' ? 'Visual Studio Code' : 'Cursor';
+        return { success: false, error: `${editorName} is not installed` };
       }
 
       return new Promise<{ success: boolean; error?: string }>((resolve) => {
-        // Use shell: true so .cmd/.bat wrappers work on Windows
-        const child = spawn(cmd, [folderPath], {
-          shell: true,
+        const child = spawn(cmd, [node.path], {
+          shell: false,
           stdio: 'ignore',
           detached: true,
         });
         child.unref();
 
-        child.on('error', (error) => {
-          log.warn(
-            `[IDE] ${cmd} not found, falling back to system file manager:`,
-            error.message
-          );
-          shell.openPath(folderPath).then((errorMsg) => {
-            resolve(
-              errorMsg ? { success: false, error: errorMsg } : { success: true }
-            );
-          });
+        child.once('error', (error) => {
+          log.warn(`[IDE] Failed to open ${node.path} with ${cmd}:`, error);
+          resolve({ success: false, error: error.message });
         });
 
-        child.on('spawn', () => {
+        child.once('spawn', () => {
           resolve({ success: true });
         });
       });

--- a/electron/main/localFileSecurity.ts
+++ b/electron/main/localFileSecurity.ts
@@ -142,12 +142,27 @@ export async function authorizeLocalPreviewPath(
   };
 }
 
+function hasExecutableExtension(candidatePath: string): boolean {
+  return EXECUTABLE_FILE_EXTENSIONS.has(
+    path.extname(candidatePath).toLowerCase()
+  );
+}
+
+/**
+ * Detect a directory the OS launches instead of browsing, such as a macOS
+ * `.app` bundle.
+ *
+ * Mode bits cannot make this call: every traversable directory carries the
+ * execute bit, so {@link isExecutableExternalOpenPath} would match all of
+ * them. Only the extension distinguishes a bundle from an ordinary folder.
+ */
+export function isExecutableBundlePath(directoryPath: string): boolean {
+  return hasExecutableExtension(directoryPath);
+}
+
 export function isExecutableExternalOpenPath(
   filePath: string,
   mode = 0
 ): boolean {
-  return (
-    EXECUTABLE_FILE_EXTENSIONS.has(path.extname(filePath).toLowerCase()) ||
-    (mode & 0o111) !== 0
-  );
+  return hasExecutableExtension(filePath) || (mode & 0o111) !== 0;
 }

--- a/electron/main/localPathActions.ts
+++ b/electron/main/localPathActions.ts
@@ -1,0 +1,194 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import fsp from 'node:fs/promises';
+import {
+  authorizeLocalFilePath,
+  isExecutableBundlePath,
+  isExecutableExternalOpenPath,
+} from './localFileSecurity';
+
+export type LocalPathActionResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export type AuthorizedLocalNode = {
+  success: true;
+  path: string;
+  kind: 'file' | 'directory';
+  mode: number;
+};
+
+type LocalNodeAuthorizationResult =
+  | AuthorizedLocalNode
+  | { success: false; error: string };
+
+export interface LocalPathShell {
+  openPath: (targetPath: string) => Promise<string>;
+  showItemInFolder: (targetPath: string) => void;
+}
+
+/** Remember an exact real path with bounded least-recently-used eviction. */
+export function rememberBoundedPathGrant(
+  grants: Set<string>,
+  realPath: string,
+  limit: number
+): void {
+  if (!Number.isSafeInteger(limit) || limit < 1) {
+    throw new Error('Path grant limit must be a positive safe integer');
+  }
+  grants.delete(realPath);
+  grants.add(realPath);
+  while (grants.size > limit) {
+    const oldest = grants.values().next().value;
+    if (oldest === undefined) break;
+    grants.delete(oldest);
+  }
+}
+
+function authorizationError(reason: 'invalid' | 'missing' | 'outside-roots') {
+  if (reason === 'invalid') return 'Invalid local path';
+  if (reason === 'missing') return 'Path does not exist';
+  return 'Path is outside the active workspace';
+}
+
+/** Classify an already-authorized real path as a revealable file or folder. */
+async function describeLocalNode(
+  realPath: string
+): Promise<LocalNodeAuthorizationResult> {
+  const stats = await fsp.stat(realPath).catch(() => null);
+  if (!stats) return { success: false, error: 'Path does not exist' };
+  if (!stats.isFile() && !stats.isDirectory()) {
+    return { success: false, error: 'Unsupported local path type' };
+  }
+
+  return {
+    success: true,
+    path: realPath,
+    kind: stats.isDirectory() ? 'directory' : 'file',
+    mode: stats.mode,
+  };
+}
+
+/** Resolve and authorize one existing file-system node inside an active Space. */
+export async function authorizeWorkspaceLocalNode(
+  targetPath: string,
+  workspaceRoots: Iterable<string>
+): Promise<LocalNodeAuthorizationResult> {
+  const authorization = await authorizeLocalFilePath(
+    targetPath,
+    workspaceRoots
+  );
+  if (!authorization.allowed) {
+    return {
+      success: false,
+      error: authorizationError(authorization.reason),
+    };
+  }
+
+  return describeLocalNode(authorization.filePath);
+}
+
+/**
+ * Authorize a node the renderer may reveal in the OS file manager.
+ *
+ * Two independent grants are accepted: containment in an active Space root,
+ * and an exact path the user themselves chose in the native file dialog. The
+ * second grant keeps chat attachments stored outside the workspace revealable
+ * without widening the workspace boundary for every other operation.
+ */
+export async function authorizeRevealableLocalNode(
+  targetPath: string,
+  workspaceRoots: Iterable<string>,
+  userSelectedPaths: ReadonlySet<string> = new Set()
+): Promise<LocalNodeAuthorizationResult> {
+  const workspaceNode = await authorizeWorkspaceLocalNode(
+    targetPath,
+    workspaceRoots
+  );
+  if (workspaceNode.success || userSelectedPaths.size === 0) {
+    return workspaceNode;
+  }
+
+  const realPath = await fsp.realpath(targetPath).catch(() => null);
+  if (!realPath || !userSelectedPaths.has(realPath)) return workspaceNode;
+
+  return describeLocalNode(realPath);
+}
+
+/** Open a folder itself, or reveal and highlight an exact file. */
+export async function revealAuthorizedLocalNode(
+  node: AuthorizedLocalNode,
+  targetShell: LocalPathShell
+): Promise<LocalPathActionResult> {
+  // A macOS `.app` is a directory, so `shell.openPath` would launch it rather
+  // than browse it. Bundles are highlighted in their parent folder instead,
+  // exactly like files -- revealing never executes agent-authored output.
+  if (node.kind === 'file' || isExecutableBundlePath(node.path)) {
+    targetShell.showItemInFolder(node.path);
+    return { success: true };
+  }
+
+  const error = await targetShell.openPath(node.path);
+  return error ? { success: false, error } : { success: true };
+}
+
+export async function revealWorkspaceLocalNode(
+  targetPath: string,
+  workspaceRoots: Iterable<string>,
+  targetShell: LocalPathShell
+): Promise<LocalPathActionResult> {
+  const node = await authorizeWorkspaceLocalNode(targetPath, workspaceRoots);
+  if (!node.success) return node;
+  return revealAuthorizedLocalNode(node, targetShell);
+}
+
+/** Reveal a Space file or a path the user picked in the native file dialog. */
+export async function revealUserVisibleLocalNode(
+  targetPath: string,
+  workspaceRoots: Iterable<string>,
+  userSelectedPaths: ReadonlySet<string>,
+  targetShell: LocalPathShell
+): Promise<LocalPathActionResult> {
+  const node = await authorizeRevealableLocalNode(
+    targetPath,
+    workspaceRoots,
+    userSelectedPaths
+  );
+  if (!node.success) return node;
+  return revealAuthorizedLocalNode(node, targetShell);
+}
+
+/** Open a non-executable workspace file with its OS-default application. */
+export async function openWorkspaceLocalFile(
+  targetPath: string,
+  workspaceRoots: Iterable<string>,
+  targetShell: LocalPathShell
+): Promise<LocalPathActionResult> {
+  const node = await authorizeWorkspaceLocalNode(targetPath, workspaceRoots);
+  if (!node.success) return node;
+  if (node.kind !== 'file') {
+    return { success: false, error: 'Path is not a file' };
+  }
+  if (isExecutableExternalOpenPath(node.path, node.mode)) {
+    targetShell.showItemInFolder(node.path);
+    return {
+      success: false,
+      error: 'Executable files cannot be opened from an agent result',
+    };
+  }
+
+  const error = await targetShell.openPath(node.path);
+  return error ? { success: false, error } : { success: true };
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -196,8 +196,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     projectId: string,
     userId?: string | number | null
   ) => ipcRenderer.invoke('get-project-folder-path', email, projectId, userId),
-  openInIDE: (folderPath: string, ide: string) =>
-    ipcRenderer.invoke('open-in-ide', folderPath, ide),
+  revealLocalPath: (targetPath: string) =>
+    ipcRenderer.invoke('reveal-local-path', targetPath),
+  openLocalFile: (targetPath: string) =>
+    ipcRenderer.invoke('open-local-file', targetPath),
+  openInIDE: (targetPath: string, ide: 'vscode' | 'cursor' | 'system') =>
+    ipcRenderer.invoke('open-in-ide', targetPath, ide),
   setBrowserPort: (port: number, isExternal?: boolean) =>
     ipcRenderer.invoke('set-browser-port', port, isExternal),
   getBrowserPort: () => ipcRenderer.invoke('get-browser-port'),

--- a/src/components/ChatBox/MessageItem/UserMessageCard.tsx
+++ b/src/components/ChatBox/MessageItem/UserMessageCard.tsx
@@ -106,6 +106,21 @@ export function UserMessageCard({
     }
   }, [content, t]);
 
+  const revealAttachment = useCallback(
+    async (filePath: string) => {
+      try {
+        const result = await ipcRenderer?.invoke('reveal-in-folder', filePath);
+        if (!result?.success) {
+          toast.error(result?.error || t('chat.failed-to-open-folder'));
+        }
+      } catch (error) {
+        console.error('Failed to reveal attachment:', error);
+        toast.error(t('chat.failed-to-open-folder'));
+      }
+    },
+    [ipcRenderer, t]
+  );
+
   // Popover handles outside clicks; no manual listener needed
   const openRemainingPopover = () => {
     if (hoverCloseTimerRef.current) {
@@ -181,10 +196,7 @@ export function UserMessageCard({
                           file.filePath
                             ? (e) => {
                                 e.stopPropagation();
-                                ipcRenderer?.invoke(
-                                  'reveal-in-folder',
-                                  file.filePath
-                                );
+                                void revealAttachment(file.filePath!);
                               }
                             : undefined
                         }
@@ -260,10 +272,7 @@ export function UserMessageCard({
                                   file.filePath
                                     ? (e) => {
                                         e.stopPropagation();
-                                        ipcRenderer?.invoke(
-                                          'reveal-in-folder',
-                                          file.filePath
-                                        );
+                                        void revealAttachment(file.filePath!);
                                         setIsRemainingOpen(false);
                                       }
                                     : undefined

--- a/src/components/Dispatch/index.tsx
+++ b/src/components/Dispatch/index.tsx
@@ -17,7 +17,7 @@ import telegramIcon from '@/assets/icon/telegram.svg';
 import whatsappIcon from '@/assets/icon/whatsapp.svg';
 import { isDesktop } from '@/client/platform';
 import ContentHeader from '@/components/Layout/ContentHeader';
-import { SESSION_SIDE_PANEL_CONTENT_WIDTH_CLASS } from '@/components/Session/SidePanel/layout';
+import { RIGHT_RAIL_CONTENT_WIDTH_CLASS } from '@/components/Layout/rightRail';
 import { Button } from '@/components/ui/button';
 import {
   createRemoteControlSession,
@@ -661,7 +661,7 @@ export function WorkspaceDispatch() {
               <motion.div
                 className={cn(
                   'flex shrink-0 flex-col gap-1 overflow-y-auto border-l border-ds-border-neutral-subtle-default p-3',
-                  SESSION_SIDE_PANEL_CONTENT_WIDTH_CLASS
+                  RIGHT_RAIL_CONTENT_WIDTH_CLASS
                 )}
                 initial={{ x: 40, opacity: 0 }}
                 animate={{ x: 0, opacity: 1 }}

--- a/src/components/Folder/FilePreview.tsx
+++ b/src/components/Folder/FilePreview.tsx
@@ -19,6 +19,7 @@ import { resolveArtifactAssetFile } from '@/service/artifactAssetApi';
 import { FileText, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { downloadFromUrl, downloadOpenedFile, FileViewerPanel } from './index';
 
 export interface FilePreviewProps {
@@ -149,11 +150,10 @@ export function FilePreview({
 
   const handleToggleSourceCode = useCallback(() => {
     if (!selectedFile) return;
-    loadFileContent(selectedFile, !isShowSourceCode);
     setIsShowSourceCode((prev) => !prev);
-  }, [selectedFile, isShowSourceCode, loadFileContent]);
+  }, [selectedFile]);
 
-  const handleRevealFile = useCallback(() => {
+  const handleRevealFile = useCallback(async () => {
     if (!selectedFile) return;
     if (selectedFile.isRemote) {
       if (selectedFile.preview?.kind === 'blocked') {
@@ -163,8 +163,19 @@ export function FilePreview({
       void downloadFromUrl(selectedFile.path, selectedFile.name);
       return;
     }
-    ipcRenderer?.invoke('reveal-in-folder', selectedFile.path);
-  }, [selectedFile, ipcRenderer]);
+    try {
+      const result = await ipcRenderer?.invoke(
+        'reveal-in-folder',
+        selectedFile.path
+      );
+      if (!result?.success) {
+        toast.error(result?.error || t('chat.failed-to-open-folder'));
+      }
+    } catch (error) {
+      console.error('Failed to reveal file:', error);
+      toast.error(t('chat.failed-to-open-folder'));
+    }
+  }, [selectedFile, ipcRenderer, t]);
 
   const handleDownloadFile = useCallback(() => {
     if (!selectedFile || selectedFile.isFolder) return;

--- a/src/components/Folder/index.tsx
+++ b/src/components/Folder/index.tsx
@@ -14,27 +14,24 @@
 
 import cursorIcon from '@/assets/icon/cursor.svg';
 import vsCodeIcon from '@/assets/icon/vs-code.svg';
-import {
-  CONTENT_HEADER_BORDER_CLASS,
-  CONTENT_HEADER_CLASS,
-} from '@/components/Layout/ContentHeader';
+import { RIGHT_RAIL_CONTENT_WIDTH_CLASS } from '@/components/Layout/rightRail';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
+import { TooltipSimple } from '@/components/ui/tooltip';
 import type { LucideIcon } from 'lucide-react';
 import {
   AlertTriangle,
   ChevronDown,
   ChevronRight,
   CodeXml,
-  Download,
+  ExternalLink,
+  Eye,
   File,
   FileArchive,
   FileCode,
@@ -44,15 +41,18 @@ import {
   FolderOpen,
   Image,
   Music,
+  PanelRight,
+  PanelRightClose,
   Search,
-  SquareTerminal,
   Table2,
   Video,
 } from 'lucide-react';
 import {
   createElement,
   Fragment,
+  useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -85,6 +85,11 @@ import {
 } from '@/lib/htmlSanitization';
 import { isLocalWorkspaceSpace } from '@/lib/spaceLabel';
 import { cn } from '@/lib/utils';
+import {
+  normalizeWorkspaceRelativePath,
+  resolveWorkspaceFilePath,
+} from '@/lib/workspaceRelativePath';
+import { resolveArtifactAssetFile } from '@/service/artifactAssetApi';
 import {
   formatFileSize,
   type FilePreviewPayload,
@@ -343,50 +348,41 @@ function filterFileTree(node: FileTreeNode, query: string): FileTreeNode {
   if (!q || !node.children?.length) {
     return node;
   }
+
+  const nodeMatches = (candidate: FileTreeNode) =>
+    [candidate.name, candidate.relativePath, candidate.path]
+      .filter(Boolean)
+      .some((value) => String(value).toLowerCase().includes(q));
+
   const filteredChildren: FileTreeNode[] = [];
   for (const child of node.children) {
     if (child.isFolder) {
+      if (nodeMatches(child)) {
+        filteredChildren.push(child);
+        continue;
+      }
       const filtered = filterFileTree(child, query);
       if (filtered.children?.length) {
         filteredChildren.push(filtered);
       }
-    } else if (child.name.toLowerCase().includes(q)) {
+    } else if (nodeMatches(child)) {
       filteredChildren.push(child);
     }
   }
   return { ...node, children: filteredChildren };
 }
 
-/** Keep folder hierarchy; only include file leaves whose `path` is in the set. */
-function filterTreeToAllowedLeafPaths(
-  node: FileTreeNode,
-  allowedLeafPaths: Set<string>
-): FileTreeNode | null {
-  if (!node.children?.length) return null;
-  const children: FileTreeNode[] = [];
-  for (const child of node.children) {
-    if (child.isFolder) {
-      const nested = filterTreeToAllowedLeafPaths(child, allowedLeafPaths);
-      if (nested?.children?.length) {
-        children.push(nested);
-      }
-    } else if (allowedLeafPaths.has(child.path)) {
-      children.push(child);
+function collectExpandableFolderPaths(node: FileTreeNode): Set<string> {
+  const paths = new Set<string>();
+  const visit = (candidate: FileTreeNode) => {
+    for (const child of candidate.children ?? []) {
+      if (!child.isFolder) continue;
+      if (child.children?.length) paths.add(child.path);
+      visit(child);
     }
-  }
-  if (!children.length) return null;
-  return { ...node, children };
-}
-
-function pathsFromFileList(res: unknown[] | null): Set<string> {
-  const s = new Set<string>();
-  for (const item of res || []) {
-    const p = (item as { path?: string; url?: string })?.path;
-    const u = (item as { url?: string })?.url;
-    if (p) s.add(p);
-    else if (u) s.add(u);
-  }
-  return s;
+  };
+  visit(node);
+  return paths;
 }
 
 export interface FileInfo {
@@ -450,7 +446,10 @@ export function buildFileTree(files: FileInfo[]): FileTreeNode {
   const folderMap = new Map<string, FileTreeNode>();
   folderMap.set('', root);
 
-  const ensureFolderNode = (segments: string[]): FileTreeNode => {
+  const ensureFolderNode = (
+    segments: string[],
+    source?: Pick<FileInfo, 'isRemote' | 'projectId'>
+  ): FileTreeNode => {
     let parentNode = root;
     let currentFolderPath = '';
 
@@ -467,9 +466,16 @@ export function buildFileTree(files: FileInfo[]): FileTreeNode {
           isFolder: true,
           children: [],
           relativePath: currentFolderPath,
+          isRemote: source?.isRemote,
+          projectId: source?.projectId,
         };
         parentNode.children!.push(folderNode);
         folderMap.set(currentFolderPath, folderNode);
+      }
+
+      if (source?.isRemote) folderNode.isRemote = true;
+      if (!folderNode.projectId && source?.projectId) {
+        folderNode.projectId = source.projectId;
       }
 
       parentNode = folderNode;
@@ -497,13 +503,13 @@ export function buildFileTree(files: FileInfo[]): FileTreeNode {
     if (!pathSegments.length) continue;
 
     if (file.isFolder) {
-      ensureFolderNode(pathSegments);
+      ensureFolderNode(pathSegments, file);
       continue;
     }
 
     const folderSegments = pathSegments.slice(0, -1);
     const fileName = pathSegments[pathSegments.length - 1] || file.name;
-    const parentNode = ensureFolderNode(folderSegments);
+    const parentNode = ensureFolderNode(folderSegments, file);
 
     parentNode.children!.push({
       name: fileName || file.name,
@@ -636,7 +642,11 @@ export const FileTree: React.FC<FileTreeProps> = ({
   if (!node.children || node.children.length === 0) return null;
 
   return (
-    <div className="min-w-0">
+    <div
+      className="min-w-0"
+      role={level === 0 ? 'tree' : 'group'}
+      aria-label={level === 0 ? 'Files' : undefined}
+    >
       {node.children.map((child) => {
         const isExpanded = expandedFolders.has(child.path);
         const hasNested = Boolean(
@@ -669,53 +679,76 @@ export const FileTree: React.FC<FileTreeProps> = ({
 
         return (
           <div key={child.path} className="min-w-0">
-            <button
-              type="button"
-              onClick={() => {
-                if (child.isFolder) {
-                  onToggleFolder(child.path);
-                } else {
-                  onSelectFile(fileInfo);
-                }
-              }}
-              className={`mb-1 flex w-full min-w-0 flex-row items-center justify-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-ds-bg-neutral-subtle-hover ${
-                isRowSelected
-                  ? 'bg-ds-bg-neutral-default-default text-ds-text-neutral-default-default'
-                  : 'bg-transparent text-ds-text-neutral-muted-default'
-              }`}
-            >
-              {child.isFolder ? (
-                <span className="inline-flex w-4 shrink-0 items-center justify-start">
+            {child.isFolder ? (
+              <div
+                role="treeitem"
+                aria-expanded={isExpanded}
+                aria-selected={isRowSelected}
+                className={cn(
+                  'mb-1 flex w-full min-w-0 items-center rounded-lg px-1 py-0.5 transition-colors hover:bg-ds-bg-neutral-subtle-hover',
+                  isRowSelected
+                    ? 'bg-ds-bg-neutral-default-default text-ds-text-neutral-default-default'
+                    : 'bg-transparent text-ds-text-neutral-muted-default'
+                )}
+              >
+                <button
+                  type="button"
+                  onClick={() => onToggleFolder(child.path)}
+                  aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${child.name}`}
+                  className="inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-inherit hover:bg-ds-bg-neutral-default-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ds-ring-brand-default-focus"
+                >
                   {isExpanded ? (
                     <ChevronDown className={rowIconClass} />
                   ) : (
                     <ChevronRight className={rowIconClass} />
                   )}
-                </span>
-              ) : (
-                createElement(
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onSelectFile(fileInfo)}
+                  className="flex h-7 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md border-0 bg-transparent px-1 text-left text-inherit focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ds-ring-brand-default-focus"
+                >
+                  <FolderIcon className={rowIconClass} aria-hidden />
+                  <span className="min-w-0 flex-1 truncate text-left text-body-sm font-medium leading-normal">
+                    {child.name}
+                  </span>
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                role="treeitem"
+                aria-selected={isRowSelected}
+                onClick={() => onSelectFile(fileInfo)}
+                className={cn(
+                  'mb-1 flex w-full min-w-0 cursor-pointer flex-row items-center justify-start gap-2 rounded-lg border-0 px-2 py-1.5 text-left transition-colors hover:bg-ds-bg-neutral-subtle-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ds-ring-brand-default-focus',
+                  isRowSelected
+                    ? 'bg-ds-bg-neutral-default-default text-ds-text-neutral-default-default'
+                    : 'bg-transparent text-ds-text-neutral-muted-default'
+                )}
+              >
+                {createElement(
                   child.icon ??
                     getLeafFileTreeIcon({
                       name: child.name,
                       path: child.path,
                       type: child.type,
                     }),
-                  { className: rowIconClass }
-                )
-              )}
-
-              <span className="min-w-0 flex-1 truncate text-left text-body-sm font-medium leading-normal">
-                {child.name}
-              </span>
-              {variant === 'review' && !child.isFolder && status ? (
-                <span
-                  className={`w-4 shrink-0 text-center text-label-xs font-bold ${status.className}`}
-                  aria-label={child.status}
-                >
-                  {status.letter}
+                  { className: rowIconClass, 'aria-hidden': true }
+                )}
+                <span className="min-w-0 flex-1 truncate text-left text-body-sm font-medium leading-normal">
+                  {child.name}
                 </span>
-              ) : null}
-            </button>
+                {variant === 'review' && status ? (
+                  <span
+                    className={`w-4 shrink-0 text-center text-label-xs font-bold ${status.className}`}
+                    aria-label={child.status}
+                  >
+                    {status.letter}
+                  </span>
+                ) : null}
+              </button>
+            )}
 
             {hasNested ? (
               <div className="ml-4 border-y-0 border-l border-r-0 border-solid border-ds-border-neutral-subtle-default pl-1">
@@ -934,6 +967,13 @@ export async function downloadOpenedFile(file: FileInfo): Promise<void> {
   await downloadFromUrl(file.path, filename);
 }
 
+export interface FileViewerOpenAction {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  onSelect: () => void;
+}
+
 interface FolderProps {
   data?: Agent;
   spaceId?: string;
@@ -963,6 +1003,7 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
   const host = useHost();
   const ipcRenderer = host?.ipcRenderer;
   const electronAPI = host?.electronAPI;
+  const isDesktopHost = Boolean(electronAPI && ipcRenderer);
   const { t } = useTranslation();
   const [selectedFile, setSelectedFile] = useState<FileInfo | null>(null);
   const [loading, setLoading] = useState(false);
@@ -995,74 +1036,59 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
   const fileListRef = useRef<FileInfo[]>([]);
   const hasFetchedRemote = useRef(false);
   const lastFetchKey = useRef<string>('');
-  const priorFilePathsSnapshotRef = useRef<Set<string>>(new Set());
   const previewRequestRef = useRef<AbortController | null>(null);
-  const [fileTreeScope, setFileTreeScope] = useState<'all' | 'new'>('all');
-  const [newFilePathsAccumulated, setNewFilePathsAccumulated] = useState<
-    Set<string>
-  >(() => new Set());
+  const fileTreeControlsId = useId();
   const [isFileSidebarOpen, setIsFileSidebarOpen] = useState(true);
   const hasNoFiles = fileGroups.every((group) => group.files.length === 0);
 
   const rememberSelectedFile = (file: FileInfo) => {
+    if (file.isFolder) return;
     if (spaceId) return;
     if (!chatStore?.activeTaskId) return;
     chatStore.setSelectedFile(chatStore.activeTaskId, file);
   };
 
-  const filteredFileTree = useMemo(
+  const activeTaskId = spaceId
+    ? undefined
+    : (chatStore?.activeTaskId ?? undefined);
+  const activeTask = activeTaskId ? chatStore?.tasks[activeTaskId] : undefined;
+  const sidebarFileTree = useMemo(
     () => filterFileTree(fileTree, fileSearchQuery),
-    [fileTree, fileSearchQuery]
+    [fileSearchQuery, fileTree]
+  );
+  const visibleExpandedFolders = useMemo(
+    () =>
+      fileSearchQuery.trim()
+        ? collectExpandableFolderPaths(sidebarFileTree)
+        : expandedFolders,
+    [expandedFolders, fileSearchQuery, sidebarFileTree]
   );
 
-  const sidebarFileTree = useMemo(() => {
-    if (fileTreeScope === 'all') return filteredFileTree;
-    if (newFilePathsAccumulated.size === 0) {
-      return {
-        name: 'root',
-        path: '',
-        children: [],
-        isFolder: true,
-      } satisfies FileTreeNode;
-    }
-    const filtered = filterTreeToAllowedLeafPaths(
-      filteredFileTree,
-      newFilePathsAccumulated
-    );
-    return (
-      filtered ?? {
-        name: 'root',
-        path: '',
-        children: [],
-        isFolder: true,
-      }
-    );
-  }, [filteredFileTree, fileTreeScope, newFilePathsAccumulated]);
-
   const selectedFileChange = (file: FileInfo, isShowSourceCode?: boolean) => {
-    if (file.type === 'zip') {
-      // if file is remote, don't call reveal-in-folder
-      if (file.isRemote) {
-        void downloadFromUrl(file.path, file.name);
-        return;
-      }
-      ipcRenderer?.invoke('reveal-in-folder', file.path);
-      return;
-    }
-    // Don't open folders in preview - they are handled by expand/collapse
-    if (file.isFolder) {
+    if (file.isFolder || getFileType(file) === 'zip') {
+      previewRequestRef.current?.abort();
+      setSelectedFile(file);
+      setLoading(false);
+      setIsShowSourceCode(false);
+      rememberSelectedFile(file);
       return;
     }
     previewRequestRef.current?.abort();
     const controller = new AbortController();
     previewRequestRef.current = controller;
     setSelectedFile(file);
+    if (!isSameFileIdentity(selectedFile, file)) {
+      setIsShowSourceCode(Boolean(isShowSourceCode));
+    }
     setLoading(true);
-    void loadFilePreview(file, {
-      ipcRenderer,
-      showSource: isShowSourceCode,
-      signal: controller.signal,
-    })
+    void resolveArtifactAssetFile(file)
+      .then((resolvedFile) =>
+        loadFilePreview(resolvedFile, {
+          ipcRenderer,
+          showSource: isShowSourceCode,
+          signal: controller.signal,
+        })
+      )
       .then((loadedFile) => {
         if (controller.signal.aborted) return;
         setSelectedFile(loadedFile);
@@ -1086,9 +1112,7 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
   );
 
   const isShowSourceCodeChange = () => {
-    // all files can reload content
-    selectedFileChange(selectedFile!, !isShowSourceCode);
-    setIsShowSourceCode(!isShowSourceCode);
+    setIsShowSourceCode((current) => !current);
   };
 
   const toggleFolder = (folderPath: string) => {
@@ -1103,10 +1127,6 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
     });
   };
 
-  const activeTaskId = spaceId
-    ? undefined
-    : (chatStore?.activeTaskId ?? undefined);
-  const activeTask = activeTaskId ? chatStore?.tasks[activeTaskId] : undefined;
   const projectedFileRevision = useMemo(
     () => getSidePanelOutputFilesRevision(activeTask),
     [activeTask]
@@ -1165,9 +1185,6 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
     setFileGroups([{ folder: 'Reports', files: [] }]);
     fileListRef.current = [];
     setExpandedFolders(new Set());
-    priorFilePathsSnapshotRef.current = new Set();
-    setNewFilePathsAccumulated(new Set());
-    setFileTreeScope('all');
   }, [fileContextResetKey]);
 
   useEffect(() => {
@@ -1181,12 +1198,11 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
         setWorkingFolderPath(activeSpace.rootPath);
         return;
       }
+      setWorkingFolderPath(null);
       if (!authStore.email || !activeProjectId) {
-        setWorkingFolderPath(null);
         return;
       }
       if (typeof electronAPI?.getProjectFolderPath !== 'function') {
-        setWorkingFolderPath(null);
         return;
       }
       try {
@@ -1319,7 +1335,8 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
                 const url = item.url?.startsWith('http')
                   ? item.url
                   : `${baseURL}${item.url || ''}`;
-                const relativePath = item.relativePath || filename;
+                const relativePath =
+                  item.relativePath || item.relative_path || filename;
                 return {
                   name: filename,
                   type: filename.split('.').pop() || '',
@@ -1375,27 +1392,6 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
         : visibleFiles;
       fileListRef.current = nextVisibleFiles;
       const tree = buildFileTree(nextVisibleFiles);
-      if (nextVisibleFiles && Array.isArray(nextVisibleFiles)) {
-        const currentPaths = pathsFromFileList(nextVisibleFiles);
-        const prior = priorFilePathsSnapshotRef.current;
-        const isFirstPopulate = prior.size === 0 && currentPaths.size > 0;
-        if (isFirstPopulate) {
-          priorFilePathsSnapshotRef.current = new Set(currentPaths);
-        } else {
-          const added = new Set<string>();
-          for (const p of currentPaths) {
-            if (!prior.has(p)) added.add(p);
-          }
-          priorFilePathsSnapshotRef.current = new Set(currentPaths);
-          if (added.size > 0) {
-            setNewFilePathsAccumulated((prev) => {
-              const next = new Set(prev);
-              for (const p of added) next.add(p);
-              return next;
-            });
-          }
-        }
-      }
       setFileTree(tree);
       // Keep the old structure for compatibility
       setFileGroups((prev) => {
@@ -1406,7 +1402,6 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
             chatStoreSelectedFile
           );
           if (file) {
-            setFileTreeScope('all');
             setIsFileSidebarOpen(true);
             expandFoldersForFile(file as FileInfo);
             if (!isSameFileIdentity(selectedFile, file)) {
@@ -1496,18 +1491,17 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
     if (chatStoreSelectedFile && fileGroups[0]?.files) {
       const file = findMatchingFile(fileGroups[0].files, chatStoreSelectedFile);
       if (file) {
-        setFileTreeScope('all');
         setIsFileSidebarOpen(true);
         expandFoldersForFile(file as FileInfo);
         if (!isSameFileIdentity(selectedFile, file)) {
-          selectedFileChange(file as FileInfo, isShowSourceCode);
+          selectedFileChange(file as FileInfo);
         }
       }
     } else if (!chatStoreSelectedFile && selectedFile) {
       setSelectedFile(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedFilePath, fileGroups, isShowSourceCode, activeTaskId]);
+  }, [activeTaskId, fileGroups, selectedFilePath]);
 
   const fileBreadcrumbSegments = useMemo(() => {
     if (!selectedFile) return [];
@@ -1523,313 +1517,298 @@ export default function Folder({ data: _data, spaceId }: FolderProps) {
     });
   }, [selectedFile, useBrainWorkspaceFiles, workingFolderPath, t]);
 
-  if (!chatStore && !activeSpace) {
-    return <div>Loading...</div>;
-  }
+  const selectedTargetIsRemote = Boolean(
+    selectedFile?.isRemote || /^https?:\/\//i.test(selectedFile?.path || '')
+  );
+  const selectedLocalWorkspaceRoot = isDesktopHost
+    ? isLocalWorkspaceSpace(activeSpace)
+      ? activeSpace?.rootPath?.trim() || ''
+      : !selectedTargetIsRemote
+        ? workingFolderPath?.trim() || ''
+        : ''
+    : '';
+  const selectedBrowserTargetUrl =
+    !isDesktopHost && /^https?:\/\//i.test(selectedFile?.path || '')
+      ? selectedFile?.path || ''
+      : '';
+  const selectedLocalTargetPath = useMemo(() => {
+    if (!isDesktopHost || !selectedFile) return '';
+    const selectedPath = selectedFile.path?.trim() || '';
+    const isAbsoluteLocalPath = /^(?:\/|\\\\|[a-z]:[\\/])/i.test(selectedPath);
+    if (isAbsoluteLocalPath && !/^https?:\/\//i.test(selectedPath)) {
+      return selectedPath;
+    }
 
-  const _handleBack = () => {
-    if (!chatStore?.activeTaskId) return;
-    chatStore.setActiveWorkspace(chatStore.activeTaskId as string, 'workflow');
-  };
+    // Local Space file lists can be fetched through Brain and therefore carry
+    // an HTTP preview URL. On desktop, the Space root + relative path remains
+    // the authoritative exact node to reveal or pass to an editor.
+    const relativeTargetPath = normalizeWorkspaceRelativePath(
+      selectedFile.relativePath?.trim() ||
+        (!/^https?:\/\//i.test(selectedPath) ? selectedPath : '')
+    );
+    if (selectedLocalWorkspaceRoot && relativeTargetPath) {
+      return resolveWorkspaceFilePath(
+        selectedLocalWorkspaceRoot,
+        relativeTargetPath
+      );
+    }
 
-  const handleOpenInIDE = async (ide: 'vscode' | 'cursor' | 'system') => {
-    try {
-      if (!authStore.email) return;
-      if (!electronAPI) return;
-      let folderPath = activeSpace?.rootPath || '';
-      if (
-        !folderPath &&
-        activeProjectId &&
-        typeof electronAPI.getProjectFolderPath === 'function'
-      ) {
-        folderPath = await electronAPI.getProjectFolderPath(
-          authStore.email,
-          activeProjectId,
-          authStore.user_id
-        );
-      }
-      if (!folderPath) return;
+    return '';
+  }, [isDesktopHost, selectedFile, selectedLocalWorkspaceRoot]);
 
-      if (ide === 'system' && selectedFile && !selectedFile.isFolder) {
-        const p = selectedFile.path?.trim() ?? '';
-        const isLocalFsPath =
-          p.length > 0 && !selectedFile.isRemote && !/^https?:\/\//i.test(p);
-        if (isLocalFsPath && ipcRenderer?.invoke) {
-          await ipcRenderer.invoke('reveal-in-folder', p);
-          authStore.setPreferredIDE(ide);
+  const handleLocalFileAction = useCallback(
+    async (action: 'reveal' | 'cursor' | 'vscode') => {
+      if (!electronAPI || !selectedLocalTargetPath) return;
+      try {
+        if (selectedLocalWorkspaceRoot && ipcRenderer?.invoke) {
+          await ipcRenderer.invoke('set-local-file-preview-roots', [
+            selectedLocalWorkspaceRoot,
+          ]);
+        }
+        const result =
+          action === 'reveal'
+            ? await electronAPI.revealLocalPath(selectedLocalTargetPath)
+            : await electronAPI.openInIDE(selectedLocalTargetPath, action);
+        if (!result.success) {
+          toast.error(result.error || t('chat.failed-to-open-folder'));
           return;
         }
+        if (action === 'cursor' || action === 'vscode') {
+          authStore.setPreferredIDE(action);
+        }
+      } catch (error) {
+        console.error('Failed to open selected file target:', error);
+        toast.error(t('chat.failed-to-open-folder'));
       }
+    },
+    [
+      authStore,
+      electronAPI,
+      ipcRenderer,
+      selectedLocalTargetPath,
+      selectedLocalWorkspaceRoot,
+      t,
+    ]
+  );
 
-      const result = await electronAPI.openInIDE(folderPath, ide);
-      if (!result.success) {
-        toast.error(result.error || t('chat.failed-to-open-folder'));
-      } else {
-        authStore.setPreferredIDE(ide);
+  const openInActions = useMemo<FileViewerOpenAction[]>(() => {
+    if (!selectedFile) return [];
+    if (!isDesktopHost) {
+      if (selectedFile.isFolder || !selectedBrowserTargetUrl) return [];
+      return [
+        {
+          id: 'browser',
+          label: t('folder.open-in-browser', {
+            defaultValue: 'Open in browser',
+          }),
+          icon: <ExternalLink className="size-4" aria-hidden />,
+          onSelect: () =>
+            window.open(
+              selectedBrowserTargetUrl,
+              '_blank',
+              'noopener,noreferrer'
+            ),
+        },
+      ];
+    }
+    if (!selectedLocalTargetPath) return [];
+
+    const platform = electronAPI.getPlatform?.();
+    const fileManagerLabel =
+      platform === 'darwin'
+        ? selectedFile.isFolder
+          ? 'Open in Finder'
+          : 'Show in Finder'
+        : platform === 'win32'
+          ? selectedFile.isFolder
+            ? 'Open in File Explorer'
+            : 'Show in File Explorer'
+          : selectedFile.isFolder
+            ? 'Open in file manager'
+            : 'Show in folder';
+    return [
+      {
+        id: 'file-manager',
+        label: fileManagerLabel,
+        icon: <FolderOpen className="size-4" aria-hidden />,
+        onSelect: () => void handleLocalFileAction('reveal'),
+      },
+      {
+        id: 'cursor',
+        label: t('chat.open-in-cursor'),
+        icon: <img src={cursorIcon} alt="" className="size-4" aria-hidden />,
+        onSelect: () => void handleLocalFileAction('cursor'),
+      },
+      {
+        id: 'vscode',
+        label: t('chat.open-in-vscode'),
+        icon: <img src={vsCodeIcon} alt="" className="size-4" aria-hidden />,
+        onSelect: () => void handleLocalFileAction('vscode'),
+      },
+    ];
+  }, [
+    electronAPI,
+    handleLocalFileAction,
+    isDesktopHost,
+    selectedFile,
+    selectedBrowserTargetUrl,
+    selectedLocalTargetPath,
+    t,
+  ]);
+
+  const handleOpenExternalFile = async () => {
+    try {
+      if (!selectedFile) return;
+      if (!isDesktopHost && selectedBrowserTargetUrl) {
+        window.open(selectedBrowserTargetUrl, '_blank', 'noopener,noreferrer');
+        return;
       }
+      await handleLocalFileAction('reveal');
     } catch (error) {
-      console.error('Failed to open in IDE:', error);
+      console.error('Failed to open file externally:', error);
       toast.error(t('chat.failed-to-open-folder'));
     }
   };
 
-  const folderHeaderTitle =
-    activeSpace?.name?.trim() || t('layout.spaces-untitled');
-  const canOpenInExternalEditor = Boolean(
-    electronAPI?.openInIDE &&
-    (activeSpace?.rootPath || electronAPI?.getProjectFolderPath)
-  );
+  if (!chatStore && !activeSpace) {
+    return <div>Loading...</div>;
+  }
+
+  const hasVisibleTreeItems = Boolean(sidebarFileTree.children?.length);
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
-      {/* header */}
-      <div className={cn(CONTENT_HEADER_CLASS, CONTENT_HEADER_BORDER_CLASS)}>
-        <div className="flex min-w-0 max-w-[min(20rem,45%)] items-center">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            buttonContent="icon-only"
-            aria-pressed={isFileSidebarOpen}
-            className="shrink-0 text-ds-icon-neutral-default-default"
-            aria-label={
-              isFileSidebarOpen
-                ? t('chat.hide-file-sidebar', {
-                    defaultValue: 'Hide file sidebar',
-                  })
-                : t('chat.show-file-sidebar', {
-                    defaultValue: 'Show file sidebar',
-                  })
-            }
-            title={
-              isFileSidebarOpen
-                ? t('chat.hide-file-sidebar', {
-                    defaultValue: 'Hide file sidebar',
-                  })
-                : t('chat.show-file-sidebar', {
-                    defaultValue: 'Show file sidebar',
-                  })
-            }
-            onClick={() => setIsFileSidebarOpen((open) => !open)}
-          >
-            {isFileSidebarOpen ? (
-              <FolderOpen className="h-3.5 w-3.5 shrink-0" aria-hidden />
-            ) : (
-              <FolderIcon className="h-3.5 w-3.5 shrink-0" aria-hidden />
-            )}
-          </Button>
-          <span
-            className="min-w-0 truncate text-body-sm font-semibold leading-none text-ds-text-neutral-default-default"
-            title={folderHeaderTitle}
-          >
-            {folderHeaderTitle}
-          </span>
-        </div>
-        <div className="ml-auto flex min-w-0 items-center gap-2">
-          <div className="relative h-7 w-32 min-w-[10rem] max-w-xs shrink-0 rounded-lg">
-            <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-ds-text-brand-default-default" />
-            <input
-              type="text"
-              value={fileSearchQuery}
-              onChange={(e) => setFileSearchQuery(e.target.value)}
-              placeholder={t('chat.search')}
-              className="h-7 w-full rounded-lg border border-solid border-ds-border-neutral-subtle-default py-0 pl-7 pr-2 text-sm leading-none focus:outline-none focus:ring-2 focus:ring-ds-ring-brand-default-focus focus:ring-offset-0"
-              aria-label={t('chat.search')}
-            />
-          </div>
-          {canOpenInExternalEditor && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="primary"
-                  size="sm"
-                  buttonContent="text"
-                  textWeight="semibold"
-                  tone="neutral"
-                >
-                  <SquareTerminal className="shrink-0" />
-                  {t('chat.open-in-ide')}
-                  <ChevronDown className="shrink-0 opacity-80" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                align="end"
-                className="z-50 border-ds-border-neutral-default-default bg-ds-bg-neutral-strong-default"
-              >
-                <DropdownMenuItem
-                  onClick={() => handleOpenInIDE('system')}
-                  className="cursor-pointer bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
-                >
-                  <FolderIcon className="size-4 shrink-0" aria-hidden />
-                  {t('chat.open-in-file-manager')}
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() => handleOpenInIDE('cursor')}
-                  className="cursor-pointer bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
-                >
-                  <img
-                    src={cursorIcon}
-                    alt=""
-                    className="size-4 shrink-0"
-                    aria-hidden
-                  />
-                  {t('chat.open-in-cursor')}
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() => handleOpenInIDE('vscode')}
-                  className="cursor-pointer bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
-                >
-                  <img
-                    src={vsCodeIcon}
-                    alt=""
-                    className="size-4 shrink-0"
-                    aria-hidden
-                  />
-                  {t('chat.open-in-vscode')}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-        </div>
-      </div>
-
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        {/* sidebar */}
-        {isFileSidebarOpen ? (
-          <div className="flex h-full w-64 flex-shrink-0 flex-col border-y-0 border-l-0 border-r border-solid border-ds-border-neutral-subtle-default">
-            <div className="flex h-8 items-center px-1">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    buttonContent="text"
-                  >
-                    <span className="min-w-0 truncate text-left font-bold">
-                      {t('chat.files')}
-                    </span>
-                    <ChevronDown className="size-3.5 shrink-0 opacity-70" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  side="bottom"
-                  align="start"
-                  className="z-50 min-w-[10rem] border-ds-border-neutral-default-default bg-ds-bg-neutral-strong-default"
-                >
-                  <DropdownMenuRadioGroup
-                    value={fileTreeScope}
-                    onValueChange={(v) =>
-                      setFileTreeScope(v === 'new' ? 'new' : 'all')
-                    }
-                  >
-                    <DropdownMenuRadioItem
-                      value="all"
-                      className="cursor-pointer bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
-                    >
-                      {t('folder.files-scope-all', {
-                        defaultValue: 'All files',
-                      })}
-                    </DropdownMenuRadioItem>
-                    <DropdownMenuRadioItem
-                      value="new"
-                      className="cursor-pointer bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
-                    >
-                      {t('folder.files-scope-new', {
-                        defaultValue: 'New files',
-                      })}
-                    </DropdownMenuRadioItem>
-                  </DropdownMenuRadioGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
+    <div className="flex h-full min-h-0 w-full min-w-0 overflow-hidden">
+      <FileViewerPanel
+        selectedFile={selectedFile}
+        loading={loading}
+        isShowSourceCode={isShowSourceCode}
+        breadcrumbSegments={fileBreadcrumbSegments}
+        projectFiles={fileGroups[0]?.files || []}
+        surfaceClassName="bg-ds-bg-neutral-subtle-default"
+        embedded
+        openInActions={openInActions}
+        isFileTreeOpen={isFileSidebarOpen}
+        onToggleFileTree={() => setIsFileSidebarOpen((open) => !open)}
+        fileTreeControlsId={fileTreeControlsId}
+        emptyState={
+          filesLoading && hasNoFiles ? (
+            <div className="flex h-full min-h-64 w-full flex-1 flex-col gap-3 p-4">
+              <Skeleton className="h-3 w-48" />
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-[82%]" />
+              <Skeleton className="h-3 w-[68%]" />
             </div>
-            <div className="scrollbar-always-visible min-h-0 flex-1 overflow-y-auto">
-              <div className="h-full pl-1.5">
-                {filesLoading && hasNoFiles ? (
-                  <div
-                    role="status"
-                    aria-label="Loading files"
-                    className="space-y-3 px-2 py-3"
-                  >
-                    {Array.from({ length: 7 }, (_, index) => (
-                      <Skeleton
-                        key={index}
-                        className={cn(
-                          'h-3',
-                          index % 3 === 0 ? 'w-40' : 'ml-4 w-32'
-                        )}
-                      />
-                    ))}
-                  </div>
-                ) : (
-                  <FileTree
-                    node={sidebarFileTree}
-                    selectedFile={selectedFile}
-                    expandedFolders={expandedFolders}
-                    onToggleFolder={toggleFolder}
-                    onSelectFile={(file) =>
-                      selectedFileChange(file, isShowSourceCode)
-                    }
-                    isShowSourceCode={isShowSourceCode}
-                  />
-                )}
-              </div>
-            </div>
-          </div>
-        ) : null}
-
-        {/* content */}
-        <FileViewerPanel
-          selectedFile={selectedFile}
-          loading={loading}
-          isShowSourceCode={isShowSourceCode}
-          breadcrumbSegments={fileBreadcrumbSegments}
-          projectFiles={fileGroups[0]?.files || []}
-          surfaceClassName="bg-ds-bg-neutral-subtle-default"
-          emptyState={
-            filesLoading && hasNoFiles ? (
-              <div className="flex h-full min-h-64 w-full flex-1 flex-col gap-3 p-4">
-                <Skeleton className="h-3 w-48" />
-                <Skeleton className="h-3 w-full" />
-                <Skeleton className="h-3 w-[82%]" />
-                <Skeleton className="h-3 w-[68%]" />
-              </div>
-            ) : undefined
+          ) : undefined
+        }
+        onRevealFile={() => {
+          if (!selectedFile) return;
+          if (isDesktopHost && selectedLocalTargetPath) {
+            void handleLocalFileAction('reveal');
+            return;
           }
-          onRevealFile={() => {
-            if (!selectedFile) return;
-            // if file is remote, don't call reveal-in-folder
-            if (selectedFile.isRemote) {
-              if (selectedFile.preview?.kind === 'blocked') {
-                window.open(selectedFile.path, '_blank', 'noopener,noreferrer');
-                return;
-              }
-              void downloadFromUrl(selectedFile.path, selectedFile.name);
-              return;
+          if (selectedTargetIsRemote) {
+            if (!selectedFile.isFolder) {
+              void downloadOpenedFile(selectedFile);
             }
-            ipcRenderer?.invoke('reveal-in-folder', selectedFile.path);
-          }}
-          onOpenExternalFile={() => {
-            if (!selectedFile) return;
+            return;
+          }
+        }}
+        onOpenExternalFile={() => void handleOpenExternalFile()}
+        onDownloadFile={() => {
+          if (!selectedFile || selectedFile.isFolder) return;
+          if (selectedFile.preview?.kind === 'blocked') {
             if (selectedFile.isRemote) {
               window.open(selectedFile.path, '_blank', 'noopener,noreferrer');
-              return;
             }
-            void ipcRenderer?.invoke('open-local-file', selectedFile.path);
-          }}
-          onDownloadFile={() => {
-            if (!selectedFile || selectedFile.isFolder) return;
-            if (selectedFile.preview?.kind === 'blocked') {
-              if (selectedFile.isRemote) {
-                window.open(selectedFile.path, '_blank', 'noopener,noreferrer');
-              }
-              return;
-            }
-            void downloadOpenedFile(selectedFile);
-          }}
-          onToggleSourceCode={() => isShowSourceCodeChange()}
-        />
-      </div>
+            return;
+          }
+          void downloadOpenedFile(selectedFile);
+        }}
+        onToggleSourceCode={isShowSourceCodeChange}
+      />
+
+      {isFileSidebarOpen ? (
+        <aside
+          data-file-tree-rail
+          className={cn(
+            'flex h-full min-h-0 shrink-0 flex-col overflow-hidden border-y-0 border-l border-r-0 border-solid border-ds-border-neutral-subtle-default bg-ds-bg-neutral-subtle-default',
+            RIGHT_RAIL_CONTENT_WIDTH_CLASS
+          )}
+          style={{ maxWidth: '50%' }}
+          aria-label={t('chat.files')}
+        >
+          <div
+            data-file-tree-header
+            className="flex h-11 min-h-11 shrink-0 items-center gap-2 px-2"
+          >
+            <span className="min-w-0 flex-1 truncate px-1 text-body-sm font-semibold text-ds-text-neutral-default-default">
+              {t('chat.files')}
+            </span>
+          </div>
+
+          <div id={fileTreeControlsId} className="flex min-h-0 flex-1 flex-col">
+            <div className="flex shrink-0 items-center gap-1.5 px-2 pb-2">
+              <div className="relative min-w-0 flex-1">
+                <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-ds-icon-neutral-muted-default" />
+                <input
+                  type="search"
+                  value={fileSearchQuery}
+                  onChange={(event) => setFileSearchQuery(event.target.value)}
+                  placeholder={t('chat.search')}
+                  className="h-8 w-full rounded-lg border border-solid border-ds-border-neutral-subtle-default bg-ds-bg-neutral-default-default py-0 pl-7 pr-2 text-body-sm text-ds-text-neutral-default-default outline-none placeholder:text-ds-text-neutral-muted-default focus:ring-2 focus:ring-ds-ring-brand-default-focus"
+                  aria-label={t('folder.search-files', {
+                    defaultValue: 'Search files',
+                  })}
+                />
+              </div>
+            </div>
+
+            <div className="scrollbar-always-visible min-h-0 flex-1 overflow-y-auto px-1.5 pb-2">
+              {filesLoading && hasNoFiles ? (
+                <div
+                  role="status"
+                  aria-label={t('folder.loading-files', {
+                    defaultValue: 'Loading files',
+                  })}
+                  className="space-y-3 px-2 py-3"
+                >
+                  {Array.from({ length: 7 }, (_, index) => (
+                    <Skeleton
+                      key={index}
+                      className={cn(
+                        'h-3',
+                        index % 3 === 0 ? 'w-40' : 'ml-4 w-32'
+                      )}
+                    />
+                  ))}
+                </div>
+              ) : hasVisibleTreeItems ? (
+                <FileTree
+                  node={sidebarFileTree}
+                  selectedFile={selectedFile}
+                  expandedFolders={visibleExpandedFolders}
+                  onToggleFolder={toggleFolder}
+                  onSelectFile={selectedFileChange}
+                  isShowSourceCode={isShowSourceCode}
+                />
+              ) : (
+                <div className="flex min-h-48 flex-col items-center justify-center gap-2 px-4 text-center text-body-sm text-ds-text-neutral-muted-default">
+                  <FileText className="size-7" aria-hidden />
+                  <p className="m-0">
+                    {fileSearchQuery.trim()
+                      ? t('folder.no-search-results', {
+                          defaultValue: 'No files match your search.',
+                        })
+                      : t('folder.no-files', {
+                          defaultValue: 'No files yet.',
+                        })}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </aside>
+      ) : null}
     </div>
   );
 }
@@ -1965,6 +1944,21 @@ function joinPath(...paths: string[]): string {
     .map((p) => p.replace(/\\/g, '/'))
     .join('/')
     .replace(/\/+/g, '/');
+}
+
+/** Join a renderer-known workspace root without losing Windows/UNC prefixes. */
+export function joinWorkspacePath(
+  workspaceRoot: string,
+  relativePath: string
+): string {
+  const separator = workspaceRoot.includes('\\') ? '\\' : '/';
+  const root = workspaceRoot.replace(/[\\/]+$/, '');
+  const relative = relativePath
+    .replace(/^[\\/]+/, '')
+    .split(/[\\/]+/)
+    .filter(Boolean)
+    .join(separator);
+  return relative ? `${root}${separator}${relative}` : root;
 }
 
 // Helper function to resolve relative paths (handles ../ and ./)
@@ -2863,12 +2857,20 @@ export interface FileViewerPanelProps {
   /** When set, breadcrumb segments are individually clickable (e.g. a "Context"
    * root that navigates elsewhere). Receives the clicked segment index. */
   onBreadcrumbSegmentClick?: (index: number) => void;
-  /** Download button. */
+  /** Remote fallback used only inside the blocked-preview empty state. */
   onDownloadFile: () => void;
   /** Open an oversized or unsupported file with the host system. */
   onOpenExternalFile?: () => void;
+  /** Exact selected-node destinations shown in the Open in menu. */
+  openInActions?: FileViewerOpenAction[];
   /** Toggle the source-code view. */
   onToggleSourceCode: () => void;
+  /** Whether the shared right-side file tree is currently visible. */
+  isFileTreeOpen?: boolean;
+  /** Toggle the shared right-side file tree from the content toolbar. */
+  onToggleFileTree?: () => void;
+  /** Unique id of the controlled file-tree region. */
+  fileTreeControlsId?: string;
   /** Extra controls rendered at the end of the header row (e.g. a close button). */
   headerActionsExtra?: React.ReactNode;
   /** Replaces the default placeholder shown when no file is selected. */
@@ -2955,99 +2957,206 @@ export function FileViewerPanel({
   onBreadcrumbSegmentClick,
   onDownloadFile,
   onOpenExternalFile,
+  openInActions = [],
   onToggleSourceCode,
+  isFileTreeOpen,
+  onToggleFileTree,
+  fileTreeControlsId,
   headerActionsExtra,
   emptyState,
 }: FileViewerPanelProps) {
   const { t } = useTranslation();
   const segmentsClickable = Boolean(onBreadcrumbSegmentClick);
-
+  const selectedType = selectedFile ? getFileType(selectedFile) : '';
+  const supportsRichView =
+    Boolean(selectedFile) &&
+    ['md', 'markdown', 'html', 'htm'].includes(selectedType) &&
+    selectedFile?.preview?.kind !== 'truncated-text' &&
+    selectedFile?.preview?.kind !== 'blocked';
+  const previewViewLabel = t('folder.preview-view', {
+    defaultValue: 'Preview',
+  });
+  const sourceViewLabel = t('folder.source-view', {
+    defaultValue: 'Source',
+  });
+  const viewModeActionLabel = isShowSourceCode
+    ? previewViewLabel
+    : sourceViewLabel;
   return (
     <div
       className={`${
         embedded ? 'min-w-0' : 'mb-sm min-w-0 rounded-xl'
-      } flex flex-1 flex-col overflow-hidden ${surfaceClassName}`}
+      } flex min-h-0 flex-1 flex-col overflow-hidden ${surfaceClassName}`}
     >
       {/* head */}
-      {selectedFile && (
-        <div
-          className={`flex flex-shrink-0 items-center justify-between gap-2 pl-3 pr-2 ${
-            // In the preview panel, match the fixed 40px header the browser
-            // and review tabs use; standalone folder view keeps its padding.
-            embedded ? 'h-10' : 'py-2'
-          }`}
-        >
-          <div
-            onClick={segmentsClickable ? undefined : onRevealFile}
-            className={`flex min-w-0 flex-1 items-center overflow-hidden ${
-              segmentsClickable ? '' : 'cursor-pointer'
-            }`}
-          >
-            <nav
-              className="scrollbar-always-visible flex min-w-0 max-w-full items-center gap-1 overflow-x-auto text-body-sm text-ds-text-neutral-muted-default"
-              aria-label={t('folder.file-path-breadcrumb', {
-                defaultValue: 'File path',
-              })}
+      {(selectedFile || onToggleFileTree) && (
+        <div className="flex min-h-11 flex-shrink-0 flex-wrap items-center justify-between gap-2 border-y-0 border-l-0 border-r-0 border-solid border-ds-border-neutral-subtle-default py-1.5 pl-4 pr-2">
+          {selectedFile ? (
+            <div
+              onClick={segmentsClickable ? undefined : onRevealFile}
+              className={`flex min-w-0 flex-1 basis-32 items-center overflow-hidden ${
+                segmentsClickable ? '' : 'cursor-pointer'
+              }`}
             >
-              {breadcrumbSegments.map((segment, index) => {
-                const isLast = index === breadcrumbSegments.length - 1;
-                const isClickable = segmentsClickable && !isLast;
-                return (
-                  <Fragment key={`${index}-${segment}`}>
-                    {index > 0 ? (
-                      <ChevronRight
-                        className="h-3.5 w-3.5 shrink-0 text-ds-icon-neutral-muted-default"
-                        aria-hidden
-                      />
-                    ) : null}
-                    {isClickable ? (
-                      <button
-                        type="button"
-                        onClick={() => onBreadcrumbSegmentClick?.(index)}
-                        className="shrink-0 cursor-pointer font-normal text-ds-text-neutral-muted-default hover:text-ds-text-neutral-default-default hover:underline"
-                      >
-                        {segment}
-                      </button>
-                    ) : (
-                      <span
-                        className={
-                          isLast
-                            ? 'shrink-0 font-bold text-ds-text-neutral-default-default'
-                            : 'shrink-0 font-normal'
-                        }
-                      >
-                        {segment}
-                      </span>
-                    )}
-                  </Fragment>
-                );
-              })}
-            </nav>
-          </div>
-          <div className="flex flex-shrink-0 items-center gap-0.5">
-            {!(
-              selectedFile.preview?.kind === 'blocked' && !selectedFile.isRemote
-            ) ? (
-              <Button
-                size="icon"
-                variant="ghost"
-                type="button"
-                aria-label={t('folder.download-file', {
-                  defaultValue: 'Download file',
+              <nav
+                className="flex min-w-0 max-w-full items-center gap-1 overflow-hidden text-body-sm text-ds-text-neutral-muted-default"
+                aria-label={t('folder.file-path-breadcrumb', {
+                  defaultValue: 'File path',
                 })}
-                onClick={onDownloadFile}
+                title={breadcrumbSegments.join(' / ')}
               >
-                <Download className="h-4 w-4 text-ds-icon-neutral-muted-default" />
+                {breadcrumbSegments.map((segment, index) => {
+                  const isLast = index === breadcrumbSegments.length - 1;
+                  const isClickable = segmentsClickable && !isLast;
+                  const segmentClassName = cn(
+                    'min-w-0 truncate',
+                    isLast
+                      ? 'shrink font-bold text-ds-text-neutral-default-default'
+                      : 'min-w-[1.25em] shrink-[1000] font-normal'
+                  );
+                  return (
+                    <Fragment key={`${index}-${segment}`}>
+                      {index > 0 ? (
+                        <ChevronRight
+                          className="h-3.5 w-3.5 shrink-0 text-ds-icon-neutral-muted-default"
+                          aria-hidden
+                        />
+                      ) : null}
+                      {isClickable ? (
+                        <button
+                          type="button"
+                          onClick={() => onBreadcrumbSegmentClick?.(index)}
+                          className={cn(
+                            segmentClassName,
+                            'cursor-pointer text-ds-text-neutral-muted-default hover:text-ds-text-neutral-default-default hover:underline'
+                          )}
+                          title={segment}
+                        >
+                          {segment}
+                        </button>
+                      ) : (
+                        <span className={segmentClassName} title={segment}>
+                          {segment}
+                        </span>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </nav>
+            </div>
+          ) : (
+            <div className="min-w-0 flex-1" />
+          )}
+          <div className="scrollbar-hide ml-auto flex max-w-full flex-shrink-0 items-center gap-1 overflow-x-auto">
+            {supportsRichView ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={onToggleSourceCode}
+                aria-label={viewModeActionLabel}
+                className="justify-center"
+              >
+                {isShowSourceCode ? (
+                  <Eye className="size-3.5" aria-hidden />
+                ) : (
+                  <CodeXml className="size-3.5" aria-hidden />
+                )}
+                <span
+                  data-slot="view-mode-label"
+                  className="grid place-items-center"
+                >
+                  <span
+                    aria-hidden={!isShowSourceCode}
+                    className={cn(
+                      'col-start-1 row-start-1',
+                      !isShowSourceCode && 'invisible'
+                    )}
+                  >
+                    {previewViewLabel}
+                  </span>
+                  <span
+                    aria-hidden={isShowSourceCode}
+                    className={cn(
+                      'col-start-1 row-start-1',
+                      isShowSourceCode && 'invisible'
+                    )}
+                  >
+                    {sourceViewLabel}
+                  </span>
+                </span>
               </Button>
             ) : null}
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={onToggleSourceCode}
-            >
-              <CodeXml className="h-4 w-4 text-ds-icon-neutral-muted-default" />
-            </Button>
+
+            {openInActions.length ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="primary"
+                    size="sm"
+                    buttonContent="text"
+                  >
+                    {t('folder.open-in', { defaultValue: 'Open in' })}
+                    <ChevronDown className="size-3.5" aria-hidden />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="end"
+                  className="z-50 min-w-[12rem] border-ds-border-neutral-default-default bg-ds-bg-neutral-strong-default"
+                >
+                  {openInActions.map((action) => (
+                    <DropdownMenuItem
+                      key={action.id}
+                      onClick={action.onSelect}
+                      className="cursor-pointer gap-2 bg-dropdown-item-bg-default hover:bg-dropdown-item-bg-hover"
+                    >
+                      {action.icon}
+                      {action.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
+
+            {onToggleFileTree ? (
+              <TooltipSimple
+                content={
+                  isFileTreeOpen
+                    ? t('chat.hide-file-sidebar', {
+                        defaultValue: 'Hide file tree',
+                      })
+                    : t('chat.show-file-sidebar', {
+                        defaultValue: 'Show file tree',
+                      })
+                }
+                variant="instant"
+              >
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  type="button"
+                  aria-label={
+                    isFileTreeOpen
+                      ? t('chat.hide-file-sidebar', {
+                          defaultValue: 'Hide file tree',
+                        })
+                      : t('chat.show-file-sidebar', {
+                          defaultValue: 'Show file tree',
+                        })
+                  }
+                  aria-expanded={Boolean(isFileTreeOpen)}
+                  aria-controls={fileTreeControlsId}
+                  onClick={onToggleFileTree}
+                >
+                  {isFileTreeOpen ? (
+                    <PanelRightClose className="size-4" aria-hidden />
+                  ) : (
+                    <PanelRight className="size-4" aria-hidden />
+                  )}
+                </Button>
+              </TooltipSimple>
+            ) : null}
             {headerActionsExtra}
           </div>
         </div>
@@ -3056,21 +3165,37 @@ export function FileViewerPanel({
       {/* content */}
       <div
         className={`flex min-h-0 flex-1 flex-col ${
-          selectedFile?.type === 'html' && !isShowSourceCode
+          ['html', 'htm'].includes(selectedType) && !isShowSourceCode
             ? 'overflow-hidden'
             : 'scrollbar-always-visible overflow-y-auto'
         }`}
       >
         <div
           className={`flex flex-col ${
-            selectedFile?.type === 'html' && !isShowSourceCode
+            ['html', 'htm'].includes(selectedType) && !isShowSourceCode
               ? 'h-full min-h-0'
               : 'min-h-full py-2 pl-4 pr-2'
           } file-viewer-content`}
         >
           {selectedFile ? (
             !loading ? (
-              selectedFile.preview?.kind === 'blocked' ? (
+              selectedFile.isFolder ? (
+                <div className="flex h-full min-h-64 w-full items-center justify-center px-6 py-10">
+                  <div className="flex max-w-md flex-col items-center gap-2 text-center">
+                    <FolderOpen className="size-10 text-ds-icon-neutral-muted-default" />
+                    <p className="m-0 text-body-md font-semibold text-ds-text-neutral-default-default">
+                      {selectedFile.name}
+                    </p>
+                    <p className="m-0 text-body-sm text-ds-text-neutral-muted-default">
+                      {t('folder.folder-selected-description', {
+                        defaultValue: openInActions.length
+                          ? 'Use Open in to open this exact folder in Finder or an editor.'
+                          : 'Select a file inside this folder to preview its contents.',
+                      })}
+                    </p>
+                  </div>
+                </div>
+              ) : selectedFile.preview?.kind === 'blocked' ? (
                 <BlockedPreviewPlaceholder
                   file={selectedFile}
                   onRevealFile={onOpenExternalFile || onRevealFile}
@@ -3078,8 +3203,9 @@ export function FileViewerPanel({
                 />
               ) : selectedFile.preview?.kind === 'csv' ? (
                 <CsvPreviewTable preview={selectedFile.preview} />
-              ) : selectedFile.type === 'md' && !isShowSourceCode ? (
-                <div className="max-w-none">
+              ) : ['md', 'markdown'].includes(selectedType) &&
+                !isShowSourceCode ? (
+                <div className="mx-auto w-full max-w-4xl">
                   <TruncatedPreviewNotice file={selectedFile} />
                   <div className="prose prose-sm max-w-none">
                     <MarkDown
@@ -3093,20 +3219,18 @@ export function FileViewerPanel({
                     />
                   </div>
                 </div>
-              ) : selectedFile.type === 'pdf' ? (
+              ) : selectedType === 'pdf' ? (
                 <iframe
                   src={selectedFile.content as string}
                   className="h-full w-full border-0"
                   title={selectedFile.name}
                 />
-              ) : ['doc', 'docx', 'pptx', 'xlsx'].includes(
-                  selectedFile.type
-                ) ? (
+              ) : ['doc', 'docx', 'pptx', 'xlsx'].includes(selectedType) ? (
                 <FolderComponent selectedFile={selectedFile} />
-              ) : selectedFile.type === 'html' ? (
+              ) : ['html', 'htm'].includes(selectedType) ? (
                 isShowSourceCode ||
                 selectedFile.preview?.kind === 'truncated-text' ? (
-                  <div>
+                  <div className="mx-auto w-full max-w-5xl">
                     <TruncatedPreviewNotice file={selectedFile} />
                     <pre className="overflow-auto whitespace-pre-wrap break-words font-mono text-sm text-ds-text-neutral-default-default">
                       {selectedFile.content}
@@ -3118,7 +3242,7 @@ export function FileViewerPanel({
                     projectFiles={projectFiles}
                   />
                 )
-              ) : selectedFile.type === 'zip' ? (
+              ) : selectedType === 'zip' ? (
                 <div className="flex h-full w-full items-center justify-center text-ds-text-neutral-muted-default">
                   <div className="text-center">
                     <FileText className="mx-auto mb-4 h-12 w-12 text-ds-text-neutral-muted-default" />
@@ -3140,7 +3264,7 @@ export function FileViewerPanel({
                   <ImageLoader selectedFile={selectedFile} />
                 </div>
               ) : (
-                <div>
+                <div className="mx-auto w-full max-w-5xl">
                   <TruncatedPreviewNotice file={selectedFile} />
                   <pre className="overflow-auto whitespace-pre-wrap break-words font-mono text-sm text-ds-text-neutral-default-default">
                     {selectedFile.content}

--- a/src/components/Layout/rightRail.ts
+++ b/src/components/Layout/rightRail.ts
@@ -12,9 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-/** Compatibility aliases for Session-specific consumers. */
-export {
-  RIGHT_RAIL_CONTENT_WIDTH_CLASS as SESSION_SIDE_PANEL_CONTENT_WIDTH_CLASS,
-  RIGHT_RAIL_EXPANDED_OUTER_CLASS as SESSION_SIDE_PANEL_EXPANDED_OUTER_CLASS,
-  RIGHT_RAIL_FOLDED_OUTER_CLASS as SESSION_SIDE_PANEL_FOLDED_OUTER_CLASS,
-} from '@/components/Layout/rightRail';
+/** Shared responsive width for fixed right-side content rails. */
+export const RIGHT_RAIL_CONTENT_WIDTH_CLASS =
+  'w-[min(360px,40vw)] max-w-[400px]';
+
+/** Expanded outer rail width; matches its content without an extra clip. */
+export const RIGHT_RAIL_EXPANDED_OUTER_CLASS = RIGHT_RAIL_CONTENT_WIDTH_CLASS;
+
+/** Folded outer rail width; full-width content can remain mounted and clipped. */
+export const RIGHT_RAIL_FOLDED_OUTER_CLASS = 'w-[40px]';

--- a/src/components/Session/SidePanel/index.tsx
+++ b/src/components/Session/SidePanel/index.tsx
@@ -12,11 +12,11 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import { RIGHT_RAIL_CONTENT_WIDTH_CLASS } from '@/components/Layout/rightRail';
 import { SessionActivityPanel } from '@/components/Session/SidePanel/components/ActivityPanel';
 import ExpandedOverlay from '@/components/Session/SidePanel/components/ExpandedOverlay';
 import { SidePanelHeader } from '@/components/Session/SidePanel/components/Header';
 import { WorkforceHeaderAction } from '@/components/Session/SidePanel/components/WorkforceHeaderAction';
-import { SESSION_SIDE_PANEL_CONTENT_WIDTH_CLASS } from '@/components/Session/SidePanel/layout';
 import type { SessionPanelScope } from '@/components/Session/SidePanel/sections/sessionPanelScope';
 import {
   Select,
@@ -78,7 +78,7 @@ export function SessionSidePanel({
       <div
         className={cn(
           'flex h-full min-h-0 flex-shrink-0 flex-col overflow-hidden',
-          SESSION_SIDE_PANEL_CONTENT_WIDTH_CLASS,
+          RIGHT_RAIL_CONTENT_WIDTH_CLASS,
           isFolded &&
             'pointer-events-none opacity-40 transition-opacity duration-200 group-hover:opacity-80'
         )}

--- a/src/components/Session/index.tsx
+++ b/src/components/Session/index.tsx
@@ -13,6 +13,10 @@
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
 import ChatBox from '@/components/ChatBox';
+import {
+  RIGHT_RAIL_EXPANDED_OUTER_CLASS,
+  RIGHT_RAIL_FOLDED_OUTER_CLASS,
+} from '@/components/Layout/rightRail';
 import { HeaderBox } from '@/components/Session/HeaderBox';
 import { PreviewPanel } from '@/components/Session/PreviewPanel';
 import Workspace from '@/components/Workspace';
@@ -31,10 +35,6 @@ import {
 import { AnimatePresence, motion } from 'framer-motion';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SessionSidePanel } from './SidePanel';
-import {
-  SESSION_SIDE_PANEL_EXPANDED_OUTER_CLASS,
-  SESSION_SIDE_PANEL_FOLDED_OUTER_CLASS,
-} from './SidePanel/layout';
 
 /** Maximum width the resizable chat column can reclaim while display is open. */
 const CHAT_PRIORITY_WIDTH = 680;
@@ -369,8 +369,8 @@ export default function Session({ isNewProject = false }: SessionProps) {
             className={cn(
               'flex min-h-0 shrink-0 flex-col overflow-hidden transition-[width] duration-200 ease-out',
               isSidePanelVisible
-                ? SESSION_SIDE_PANEL_EXPANDED_OUTER_CLASS
-                : cn(SESSION_SIDE_PANEL_FOLDED_OUTER_CLASS, 'rounded-l-xl')
+                ? RIGHT_RAIL_EXPANDED_OUTER_CLASS
+                : cn(RIGHT_RAIL_FOLDED_OUTER_CLASS, 'rounded-l-xl')
             )}
           >
             {sessionSidePanel}
@@ -465,8 +465,8 @@ export default function Session({ isNewProject = false }: SessionProps) {
           className={cn(
             'flex min-h-0 shrink-0 flex-col overflow-hidden transition-[width] duration-200 ease-out',
             isSidePanelVisible
-              ? SESSION_SIDE_PANEL_EXPANDED_OUTER_CLASS
-              : cn(SESSION_SIDE_PANEL_FOLDED_OUTER_CLASS, 'rounded-l-xl')
+              ? RIGHT_RAIL_EXPANDED_OUTER_CLASS
+              : cn(RIGHT_RAIL_FOLDED_OUTER_CLASS, 'rounded-l-xl')
           )}
         >
           {sessionSidePanel}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -22,6 +22,10 @@ interface IpcRenderer {
   invoke: (channel: string, ...args: any[]) => Promise<any>;
 }
 
+type LocalPathActionResult =
+  | { success: true }
+  | { success: false; error: string };
+
 interface ElectronAPI {
   closeWindow: () => void;
   minimizeWindow: () => void;
@@ -278,10 +282,14 @@ interface ElectronAPI {
     projectId: string,
     userId?: string | number | null
   ) => Promise<string>;
+  /** Open a selected folder itself, or reveal and highlight a selected file. */
+  revealLocalPath: (targetPath: string) => Promise<LocalPathActionResult>;
+  /** Open a selected non-executable local file with its default OS app. */
+  openLocalFile: (targetPath: string) => Promise<LocalPathActionResult>;
   openInIDE: (
-    folderPath: string,
-    ide: string
-  ) => Promise<{ success: boolean; error?: string }>;
+    targetPath: string,
+    ide: 'vscode' | 'cursor' | 'system'
+  ) => Promise<LocalPathActionResult>;
   // Skills: all operations via Brain REST API
   setBrowserPort: (port: number, isExternal?: boolean) => Promise<any>;
   getBrowserPort: () => Promise<number>;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -23,8 +23,7 @@ interface IpcRenderer {
 }
 
 type LocalPathActionResult =
-  | { success: true }
-  | { success: false; error: string };
+  { success: true } | { success: false; error: string };
 
 interface ElectronAPI {
   closeWindow: () => void;

--- a/test/unit/components/ChatBox/MessageItem/UserMessageCard.test.tsx
+++ b/test/unit/components/ChatBox/MessageItem/UserMessageCard.test.tsx
@@ -12,19 +12,30 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+const { invokeMock, toastErrorMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}));
 
 vi.mock('@/host', () => ({
   useHost: () => ({ ipcRenderer: { invoke: invokeMock } }),
 }));
 
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: toastErrorMock },
+}));
+
 import { UserMessageCard } from '@/components/ChatBox/MessageItem/UserMessageCard';
 
 describe('UserMessageCard', () => {
-  beforeEach(() => invokeMock.mockReset());
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue({ success: true });
+    toastErrorMock.mockReset();
+  });
 
   it('renders as a right-aligned chat bubble with a tighter tail corner', () => {
     const { container } = render(
@@ -94,6 +105,30 @@ describe('UserMessageCard', () => {
     expect(invokeMock).toHaveBeenCalledWith(
       'reveal-in-folder',
       '/workspace/report.pdf'
+    );
+  });
+
+  it('shows feedback when a restored attachment has lost its session grant', async () => {
+    invokeMock.mockResolvedValue({
+      success: false,
+      error: 'Path is outside the active workspace',
+    });
+    render(
+      <UserMessageCard
+        id="restored-local-attachment"
+        content="Restored message"
+        attaches={[
+          { fileName: 'report.pdf', filePath: '/downloads/report.pdf' },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByTitle('report.pdf').closest('div')!);
+
+    await waitFor(() =>
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        'Path is outside the active workspace'
+      )
     );
   });
 });

--- a/test/unit/components/Folder/FilePreview.test.tsx
+++ b/test/unit/components/Folder/FilePreview.test.tsx
@@ -1,0 +1,103 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import { FilePreview } from '@/components/Folder/FilePreview';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  invokeMock,
+  hostMock,
+  loadFilePreviewMock,
+  resolveArtifactAssetFileMock,
+  toastErrorMock,
+} = vi.hoisted(() => {
+  const invokeMock = vi.fn();
+  return {
+    invokeMock,
+    hostMock: { ipcRenderer: { invoke: invokeMock } },
+    loadFilePreviewMock: vi.fn(),
+    resolveArtifactAssetFileMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+  };
+});
+
+vi.mock('@/host', () => ({
+  useHost: () => hostMock,
+}));
+
+vi.mock('@/lib/filePreviewLoader', () => ({
+  loadFilePreview: loadFilePreviewMock,
+}));
+
+vi.mock('@/service/artifactAssetApi', () => ({
+  resolveArtifactAssetFile: resolveArtifactAssetFileMock,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock },
+}));
+
+vi.mock('@/components/Folder/index', () => ({
+  downloadFromUrl: vi.fn(),
+  downloadOpenedFile: vi.fn(),
+  FileViewerPanel: ({
+    selectedFile,
+    onRevealFile,
+  }: {
+    selectedFile: FileInfo | null;
+    onRevealFile: () => void;
+  }) => (
+    <button type="button" disabled={!selectedFile} onClick={onRevealFile}>
+      Reveal file
+    </button>
+  ),
+}));
+
+describe('FilePreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveArtifactAssetFileMock.mockImplementation(async (file) => file);
+    loadFilePreviewMock.mockImplementation(async (file) => ({
+      ...file,
+      content: 'preview content',
+    }));
+    invokeMock.mockResolvedValue({ success: true });
+  });
+
+  it('shows feedback when a local file cannot be revealed', async () => {
+    invokeMock.mockResolvedValue({
+      success: false,
+      error: 'Path is outside the active workspace',
+    });
+    render(
+      <FilePreview
+        file={{
+          name: 'legacy-report.txt',
+          path: '/legacy/legacy-report.txt',
+          relativePath: 'legacy-report.txt',
+          type: 'txt',
+        }}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reveal file' }));
+
+    await waitFor(() =>
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        'Path is outside the active workspace'
+      )
+    );
+  });
+});

--- a/test/unit/components/Folder/FileTree.test.tsx
+++ b/test/unit/components/Folder/FileTree.test.tsx
@@ -20,6 +20,7 @@ import {
   FileTree,
   findMatchingFile,
   isSameFileIdentity,
+  joinWorkspacePath,
 } from '../../../../src/components/Folder/index';
 
 describe('FileTree', () => {
@@ -63,50 +64,41 @@ describe('FileTree', () => {
         expandedFolders={new Set()}
         onToggleFolder={onToggleFolder}
         onSelectFile={onSelectFile}
-        isShowSourceCode={false}
       />
     );
-    expect(screen.getByRole('button', { name: /src/i })).toBeInTheDocument();
+    expect(screen.getByRole('treeitem', { name: 'src' })).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /readme\.md/i })
+      screen.getByRole('treeitem', { name: 'readme.md' })
     ).toBeInTheDocument();
   });
-  it('uses consistent first-column box (h-4 w-4) for folder and file rows for alignment', () => {
-    const { container } = render(
+
+  it('exposes a separate folder disclosure and selection target', async () => {
+    render(
       <FileTree
         node={nodeWithFolderAndFile}
         selectedFile={null}
         expandedFolders={new Set()}
         onToggleFolder={onToggleFolder}
         onSelectFile={onSelectFile}
-        isShowSourceCode={false}
       />
     );
-    const buttons = container.querySelectorAll('button');
-    expect(buttons.length).toBe(2);
-    buttons.forEach((btn) => {
-      // Folder rows wrap the chevron in a `w-4` spacer; file rows render a
-      // `size-4` icon. Both reserve a consistent 16px first column.
-      const firstCol = btn.querySelector('[class*="w-4"], [class*="size-4"]');
-      expect(firstCol).toBeInTheDocument();
-    });
-  });
-  it('uses gap-2 on row for consistent spacing between chevron, icon, and label', () => {
-    const { container } = render(
-      <FileTree
-        node={nodeWithFolderAndFile}
-        selectedFile={null}
-        expandedFolders={new Set()}
-        onToggleFolder={onToggleFolder}
-        onSelectFile={onSelectFile}
-        isShowSourceCode={false}
-      />
+
+    await userEvent.click(screen.getByRole('button', { name: 'Expand src' }));
+    expect(onToggleFolder).toHaveBeenCalledWith('/proj/src');
+    expect(onSelectFile).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    await userEvent.click(screen.getByRole('button', { name: 'src' }));
+    expect(onToggleFolder).not.toHaveBeenCalled();
+    expect(onSelectFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'src',
+        path: '/proj/src',
+        isFolder: true,
+      })
     );
-    const buttons = container.querySelectorAll('button');
-    buttons.forEach((btn) => {
-      expect(btn.className).toMatch(/gap-2/);
-    });
   });
+
   it('file row first column has aria-hidden for accessibility', () => {
     render(
       <FileTree
@@ -115,27 +107,10 @@ describe('FileTree', () => {
         expandedFolders={new Set()}
         onToggleFolder={onToggleFolder}
         onSelectFile={onSelectFile}
-        isShowSourceCode={false}
       />
     );
-    const fileButton = screen.getByRole('button', { name: /readme\.md/i });
-    const spacer = fileButton.querySelector('[aria-hidden="true"]');
-    expect(spacer).toBeInTheDocument();
-  });
-
-  it('calls onToggleFolder when folder row is clicked', async () => {
-    render(
-      <FileTree
-        node={nodeWithFolderAndFile}
-        selectedFile={null}
-        expandedFolders={new Set()}
-        onToggleFolder={onToggleFolder}
-        onSelectFile={onSelectFile}
-        isShowSourceCode={false}
-      />
-    );
-    await userEvent.click(screen.getByRole('button', { name: /src/i }));
-    expect(onToggleFolder).toHaveBeenCalledWith('/proj/src');
+    const fileRow = screen.getByRole('treeitem', { name: 'readme.md' });
+    expect(fileRow.querySelector('[aria-hidden="true"]')).toBeInTheDocument();
   });
 
   it('calls onSelectFile when file row is clicked', async () => {
@@ -146,10 +121,9 @@ describe('FileTree', () => {
         expandedFolders={new Set()}
         onToggleFolder={onToggleFolder}
         onSelectFile={onSelectFile}
-        isShowSourceCode={false}
       />
     );
-    await userEvent.click(screen.getByRole('button', { name: /readme\.md/i }));
+    await userEvent.click(screen.getByRole('treeitem', { name: 'readme.md' }));
     expect(onSelectFile).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'readme.md',
@@ -167,7 +141,6 @@ describe('FileTree', () => {
         expandedFolders={new Set()}
         onToggleFolder={onToggleFolder}
         onSelectFile={onSelectFile}
-        isShowSourceCode={false}
       />
     );
     expect(container.firstChild).toBeNull();
@@ -314,5 +287,17 @@ describe('FileTree', () => {
 
     expect(tree.children?.[0]?.name).toBe('Task_Alpha');
     expect(tree.children?.[0]?.children?.[0]?.name).toBe('Report.MD');
+  });
+
+  it('joins selected folder paths without losing platform path prefixes', () => {
+    expect(joinWorkspacePath('/workspace/project', 'src/nested')).toBe(
+      '/workspace/project/src/nested'
+    );
+    expect(joinWorkspacePath('C:\\workspace\\project', 'src/nested')).toBe(
+      'C:\\workspace\\project\\src\\nested'
+    );
+    expect(joinWorkspacePath('\\\\server\\share', 'src/nested')).toBe(
+      '\\\\server\\share\\src\\nested'
+    );
   });
 });

--- a/test/unit/components/Folder/FileViewerPanel.test.tsx
+++ b/test/unit/components/Folder/FileViewerPanel.test.tsx
@@ -1,0 +1,264 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import { FileViewerPanel } from '@/components/Folder';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/ChatBox/MessageItem/MarkDown', () => ({
+  MarkDown: ({ content }: { content: string }) => <article>{content}</article>,
+}));
+
+type ViewerFile = NonNullable<
+  ComponentProps<typeof FileViewerPanel>['selectedFile']
+>;
+
+const callbacks = {
+  onRevealFile: vi.fn(),
+  onDownloadFile: vi.fn(),
+  onOpenExternalFile: vi.fn(),
+  onToggleSourceCode: vi.fn(),
+};
+
+function textFile(overrides: Partial<ViewerFile> = {}): ViewerFile {
+  return {
+    name: 'notes.txt',
+    path: '/workspace/notes.txt',
+    relativePath: 'notes.txt',
+    type: 'txt',
+    content: 'hello from the file',
+    ...overrides,
+  };
+}
+
+function renderViewer(
+  selectedFile: ViewerFile | null,
+  overrides: Partial<ComponentProps<typeof FileViewerPanel>> = {}
+) {
+  return render(
+    <FileViewerPanel
+      selectedFile={selectedFile}
+      loading={false}
+      isShowSourceCode={false}
+      breadcrumbSegments={selectedFile ? ['Workspace', selectedFile.name] : []}
+      projectFiles={[]}
+      {...callbacks}
+      {...overrides}
+    />
+  );
+}
+
+describe('FileViewerPanel toolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('truncates a long file path instead of showing a scrollbar', () => {
+    renderViewer(
+      textFile({
+        name: 'a-very-long-document-name-that-should-ellipsis.md',
+      })
+    );
+
+    const breadcrumb = screen.getByRole('navigation', { name: 'File path' });
+    expect(breadcrumb).toHaveClass('overflow-hidden');
+    expect(breadcrumb).not.toHaveClass('scrollbar-always-visible');
+    expect(breadcrumb).not.toHaveClass('overflow-x-auto');
+    expect(
+      screen.getByText('a-very-long-document-name-that-should-ellipsis.md')
+    ).toHaveClass('truncate');
+  });
+
+  it('does not render file actions until a file is selected', () => {
+    renderViewer(null);
+
+    expect(screen.queryByRole('navigation', { name: 'File path' })).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: 'Copy file content' })
+    ).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Open in' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Source' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Preview' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Download file' })).toBeNull();
+  });
+
+  it('shows Open in as the only text-file action', () => {
+    renderViewer(textFile(), {
+      openInActions: [
+        {
+          id: 'finder',
+          label: 'Show in Finder',
+          icon: <span aria-hidden>F</span>,
+          onSelect: vi.fn(),
+        },
+      ],
+    });
+
+    const openInButton = screen.getByRole('button', { name: 'Open in' });
+    expect(openInButton).toHaveClass('bg-ds-bg-brand-default-default');
+    expect(openInButton.firstChild?.nodeName).toBe('#text');
+    expect(openInButton.querySelectorAll('svg')).toHaveLength(1);
+    expect(
+      screen.queryByRole('button', { name: 'Copy file content' })
+    ).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Source' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Preview' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Download file' })).toBeNull();
+  });
+
+  it('offers one Source action for a Markdown preview', async () => {
+    const user = userEvent.setup();
+    renderViewer(
+      textFile({
+        name: 'report.md',
+        path: '/workspace/report.md',
+        relativePath: 'report.md',
+        type: 'md',
+        content: '# Report',
+      })
+    );
+
+    expect(screen.queryByRole('button', { name: 'Preview' })).toBeNull();
+    const sourceButton = screen.getByRole('button', { name: 'Source' });
+    const labelSlot = sourceButton.querySelector(
+      '[data-slot="view-mode-label"]'
+    );
+    expect(sourceButton).toHaveClass('justify-center');
+    expect(labelSlot).toHaveClass('grid', 'place-items-center');
+    expect(labelSlot).toHaveTextContent('Preview');
+    expect(labelSlot).toHaveTextContent('Source');
+
+    await user.click(sourceButton);
+
+    expect(callbacks.onToggleSourceCode).toHaveBeenCalledTimes(1);
+    expect(callbacks.onRevealFile).not.toHaveBeenCalled();
+  });
+
+  it('orders view mode, Open in, and file-tree controls from left to right', () => {
+    renderViewer(
+      textFile({
+        name: 'report.md',
+        path: '/workspace/report.md',
+        relativePath: 'report.md',
+        type: 'md',
+        content: '# Report',
+      }),
+      {
+        openInActions: [
+          {
+            id: 'finder',
+            label: 'Show in Finder',
+            icon: <span aria-hidden>F</span>,
+            onSelect: vi.fn(),
+          },
+        ],
+        isFileTreeOpen: true,
+        onToggleFileTree: vi.fn(),
+        fileTreeControlsId: 'file-tree-controls-test',
+      }
+    );
+
+    const sourceButton = screen.getByRole('button', { name: 'Source' });
+    const openInButton = screen.getByRole('button', { name: 'Open in' });
+    const foldButton = screen.getByRole('button', { name: 'Hide file tree' });
+
+    expect(
+      sourceButton.compareDocumentPosition(openInButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      openInButton.compareDocumentPosition(foldButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('offers one Preview action when a rich file is showing source', () => {
+    renderViewer(
+      textFile({
+        name: 'page.html',
+        path: '/workspace/page.html',
+        relativePath: 'page.html',
+        type: 'html',
+        content: '<h1>Page</h1>',
+      }),
+      { isShowSourceCode: true }
+    );
+
+    const previewButton = screen.getByRole('button', { name: 'Preview' });
+    expect(previewButton).toHaveClass('justify-center');
+    expect(
+      previewButton.querySelector('[data-slot="view-mode-label"]')
+    ).toHaveTextContent('PreviewSource');
+    expect(screen.queryByRole('button', { name: 'Source' })).toBeNull();
+  });
+
+  it('hides source switching and removed toolbar actions for a local blocked file', () => {
+    renderViewer(
+      textFile({
+        name: 'blocked.md',
+        path: '/workspace/blocked.md',
+        relativePath: 'blocked.md',
+        type: 'md',
+        content: undefined,
+        preview: {
+          kind: 'blocked',
+          reason: 'too-large',
+          size: 100,
+          limit: 50,
+        },
+      })
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Copy file content' })
+    ).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Source' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Preview' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Download file' })).toBeNull();
+  });
+
+  it('keeps folder destinations available while hiding file-only actions', async () => {
+    const user = userEvent.setup();
+    const openFolder = vi.fn();
+    renderViewer(
+      textFile({ name: 'src', path: 'src', type: '', isFolder: true }),
+      {
+        openInActions: [
+          {
+            id: 'finder',
+            label: 'Open in Finder',
+            icon: <span aria-hidden>F</span>,
+            onSelect: openFolder,
+          },
+        ],
+      }
+    );
+
+    expect(screen.getByRole('button', { name: 'Open in' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Copy file content' })
+    ).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Source' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Preview' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Download file' })).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Open in' }));
+    await user.click(
+      await screen.findByRole('menuitem', { name: 'Open in Finder' })
+    );
+    expect(openFolder).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/components/Folder/FolderLayout.test.tsx
+++ b/test/unit/components/Folder/FolderLayout.test.tsx
@@ -1,0 +1,333 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import Folder from '@/components/Folder';
+import { RIGHT_RAIL_CONTENT_WIDTH_CLASS } from '@/components/Layout/rightRail';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  fetchGet: vi.fn(),
+  getBaseURL: vi.fn(),
+  chatStore: null as any,
+  getElectronAPI: vi.fn(),
+  getIpcRenderer: vi.fn(),
+  loadFilePreview: vi.fn(),
+  openInIDE: vi.fn(),
+  revealLocalPath: vi.fn(),
+  resolveArtifactAssetFile: vi.fn(),
+  setPreferredIDE: vi.fn(),
+  spaceState: {
+    activeSpaceId: 'space-1',
+    spaces: {
+      'space-1': {
+        id: 'space-1',
+        name: 'Remote space',
+        sourceType: 'blank' as 'blank' | 'folder',
+        rootPath: null as string | null,
+        status: 'active',
+        schemaVersion: 2,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    },
+    projectsBySpaceId: {
+      'space-1': {
+        'project-1': {
+          id: 'project-1',
+          spaceId: 'space-1',
+          name: 'Project One',
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      },
+    },
+    getProjectMeta: vi.fn(() => null),
+  },
+}));
+
+vi.mock('@/api/http', () => ({
+  fetchGet: mocks.fetchGet,
+  getBaseURL: mocks.getBaseURL,
+}));
+
+vi.mock('@/lib/filePreviewLoader', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/filePreviewLoader')>();
+  return { ...actual, loadFilePreview: mocks.loadFilePreview };
+});
+
+vi.mock('@/service/artifactAssetApi', () => ({
+  resolveArtifactAssetFile: mocks.resolveArtifactAssetFile,
+}));
+
+vi.mock('@/hooks/useChatStoreAdapter', () => ({
+  default: () => ({
+    chatStore: mocks.chatStore,
+    projectStore: { activeProjectId: null },
+  }),
+}));
+
+vi.mock('@/host', () => ({
+  useHost: () => ({
+    ipcRenderer: mocks.getIpcRenderer(),
+    electronAPI: mocks.getElectronAPI(),
+  }),
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: () => ({
+    email: 'person@example.com',
+    user_id: 'user-1',
+    preferredIDE: 'cursor',
+    setPreferredIDE: mocks.setPreferredIDE,
+  }),
+}));
+
+vi.mock('@/store/spaceStore', () => ({
+  useSpaceStore: (selector: (state: typeof mocks.spaceState) => unknown) =>
+    selector(mocks.spaceState),
+}));
+
+describe('Folder page layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.chatStore = null;
+    mocks.getElectronAPI.mockReturnValue(null);
+    mocks.getIpcRenderer.mockReturnValue(null);
+    Object.assign(mocks.spaceState.spaces['space-1'], {
+      name: 'Remote space',
+      sourceType: 'blank',
+      rootPath: null,
+    });
+    mocks.getBaseURL.mockResolvedValue('https://api.example.test');
+    mocks.openInIDE.mockResolvedValue({ success: true });
+    mocks.revealLocalPath.mockResolvedValue({ success: true });
+    mocks.resolveArtifactAssetFile.mockImplementation(async (file) => file);
+    mocks.loadFilePreview.mockImplementation(async (file) => ({
+      ...file,
+      content: file.content ?? '# Loaded file',
+    }));
+    mocks.fetchGet.mockResolvedValue([
+      {
+        filename: 'needle.md',
+        relativePath: 'src/nested/needle.md',
+        url: '/files/needle.md',
+      },
+      {
+        filename: 'other.txt',
+        relativePath: 'docs/other.txt',
+        url: '/files/other.txt',
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('removes the far-right rail completely and reopens it from the viewer toolbar', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Folder spaceId="space-1" />);
+    const rail = container.querySelector<HTMLElement>('[data-file-tree-rail]');
+
+    expect(rail).not.toBeNull();
+    expect(rail?.parentElement?.lastElementChild).toBe(rail);
+    expect(rail).toHaveClass(...RIGHT_RAIL_CONTENT_WIDTH_CLASS.split(' '));
+    expect(rail).toHaveStyle({ maxWidth: '50%' });
+
+    const foldButton = screen.getByRole('button', {
+      name: 'Hide file tree',
+    });
+    expect(rail).not.toContainElement(foldButton);
+    expect(foldButton.parentElement?.lastElementChild).toBe(foldButton);
+    expect(foldButton).toHaveAttribute('aria-expanded', 'true');
+    expect(
+      document.getElementById(foldButton.getAttribute('aria-controls') || '')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'File tree scope' })
+    ).not.toBeInTheDocument();
+
+    await user.click(foldButton);
+
+    expect(container.querySelector('[data-file-tree-rail]')).toBeNull();
+    const reopenButton = screen.getByRole('button', { name: 'Show file tree' });
+    expect(reopenButton).toHaveAttribute('aria-expanded', 'false');
+    expect(reopenButton.parentElement?.lastElementChild).toBe(reopenButton);
+    expect(
+      screen.queryByRole('searchbox', { name: 'Search files' })
+    ).not.toBeInTheDocument();
+
+    await user.click(reopenButton);
+
+    const reopenedRail = container.querySelector<HTMLElement>(
+      '[data-file-tree-rail]'
+    );
+    expect(reopenedRail).not.toBeNull();
+    expect(reopenedRail).toHaveClass(
+      ...RIGHT_RAIL_CONTENT_WIDTH_CLASS.split(' ')
+    );
+    expect(
+      screen.getByRole('button', { name: 'Hide file tree' })
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('filters by filename and reveals every matching ancestor folder', async () => {
+    const user = userEvent.setup();
+    render(<Folder spaceId="space-1" />);
+
+    await user.type(
+      screen.getByRole('searchbox', { name: 'Search files' }),
+      'needle'
+    );
+
+    expect(
+      await screen.findByRole('treeitem', { name: 'needle.md' })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('treeitem', { name: 'other.txt' })).toBeNull();
+    expect(
+      screen.getByRole('treeitem', { name: 'Project One' })
+    ).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('treeitem', { name: 'src' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(screen.getByRole('treeitem', { name: 'nested' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+  });
+
+  it('opens an HTTPS-backed local Space file through its exact workspace path', async () => {
+    const user = userEvent.setup();
+    Object.assign(mocks.spaceState.spaces['space-1'], {
+      name: 'Local space',
+      sourceType: 'folder',
+      rootPath: '/workspace/local-space',
+    });
+    mocks.getElectronAPI.mockReturnValue({
+      getPlatform: () => 'darwin',
+      openInIDE: mocks.openInIDE,
+      revealLocalPath: mocks.revealLocalPath,
+    } as ElectronAPI);
+    mocks.getIpcRenderer.mockReturnValue({ invoke: vi.fn() } as IpcRenderer);
+    mocks.fetchGet.mockResolvedValue([
+      {
+        filename: 'needle.md',
+        relativePath: 'src/nested/needle.md',
+        url: 'https://api.example.test/files/needle.md',
+      },
+    ]);
+
+    render(<Folder spaceId="space-1" />);
+
+    await user.type(
+      screen.getByRole('searchbox', { name: 'Search files' }),
+      'needle'
+    );
+    await user.click(
+      await screen.findByRole('treeitem', { name: 'needle.md' })
+    );
+    await user.click(await screen.findByRole('button', { name: 'Open in' }));
+
+    const menuItems = await screen.findAllByRole('menuitem');
+    expect(menuItems.map((item) => item.textContent?.trim())).toEqual([
+      'Show in Finder',
+      'Cursor',
+      'VS Code',
+    ]);
+    expect(
+      screen.queryByRole('menuitem', { name: 'Open in browser' })
+    ).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: /default app/i })).toBeNull();
+
+    await user.click(menuItems[0]);
+
+    await waitFor(() =>
+      expect(mocks.revealLocalPath).toHaveBeenCalledWith(
+        '/workspace/local-space/src/nested/needle.md'
+      )
+    );
+  });
+
+  it('opens the exact selected local folder instead of its parent', async () => {
+    const user = userEvent.setup();
+    Object.assign(mocks.spaceState.spaces['space-1'], {
+      name: 'Local space',
+      sourceType: 'folder',
+      rootPath: '/workspace/local-space',
+    });
+    mocks.getElectronAPI.mockReturnValue({
+      getPlatform: () => 'darwin',
+      openInIDE: mocks.openInIDE,
+      revealLocalPath: mocks.revealLocalPath,
+    } as ElectronAPI);
+    mocks.getIpcRenderer.mockReturnValue({ invoke: vi.fn() } as IpcRenderer);
+    mocks.fetchGet.mockResolvedValue([
+      {
+        filename: 'needle.md',
+        relativePath: 'src/nested/needle.md',
+        url: 'https://api.example.test/files/needle.md',
+      },
+    ]);
+
+    render(<Folder spaceId="space-1" />);
+
+    await user.type(
+      screen.getByRole('searchbox', { name: 'Search files' }),
+      'needle'
+    );
+    await user.click(await screen.findByRole('button', { name: 'nested' }));
+    await user.click(await screen.findByRole('button', { name: 'Open in' }));
+
+    const menuItems = await screen.findAllByRole('menuitem');
+    expect(menuItems.map((item) => item.textContent?.trim())).toEqual([
+      'Open in Finder',
+      'Cursor',
+      'VS Code',
+    ]);
+
+    await user.click(menuItems[0]);
+
+    await waitFor(() =>
+      expect(mocks.revealLocalPath).toHaveBeenCalledWith(
+        '/workspace/local-space/src/nested'
+      )
+    );
+  });
+
+  it('offers only Open in browser for a remote file on the web', async () => {
+    const user = userEvent.setup();
+    render(<Folder spaceId="space-1" />);
+
+    await user.type(
+      screen.getByRole('searchbox', { name: 'Search files' }),
+      'needle'
+    );
+    await user.click(
+      await screen.findByRole('treeitem', { name: 'needle.md' })
+    );
+    await user.click(await screen.findByRole('button', { name: 'Open in' }));
+
+    const menuItems = await screen.findAllByRole('menuitem');
+    expect(menuItems.map((item) => item.textContent?.trim())).toEqual([
+      'Open in browser',
+    ]);
+    expect(screen.queryByRole('menuitem', { name: 'Cursor' })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: 'VS Code' })).toBeNull();
+  });
+});

--- a/test/unit/components/Layout/rightRail.test.ts
+++ b/test/unit/components/Layout/rightRail.test.ts
@@ -1,0 +1,47 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import {
+  RIGHT_RAIL_CONTENT_WIDTH_CLASS,
+  RIGHT_RAIL_EXPANDED_OUTER_CLASS,
+  RIGHT_RAIL_FOLDED_OUTER_CLASS,
+} from '@/components/Layout/rightRail';
+import {
+  SESSION_SIDE_PANEL_CONTENT_WIDTH_CLASS,
+  SESSION_SIDE_PANEL_EXPANDED_OUTER_CLASS,
+  SESSION_SIDE_PANEL_FOLDED_OUTER_CLASS,
+} from '@/components/Session/SidePanel/layout';
+import { describe, expect, it } from 'vitest';
+
+describe('right rail layout', () => {
+  it('preserves the Session rail width contract through compatibility aliases', () => {
+    expect(RIGHT_RAIL_CONTENT_WIDTH_CLASS).toBe(
+      'w-[min(360px,40vw)] max-w-[400px]'
+    );
+    expect(RIGHT_RAIL_EXPANDED_OUTER_CLASS).toBe(
+      RIGHT_RAIL_CONTENT_WIDTH_CLASS
+    );
+    expect(RIGHT_RAIL_FOLDED_OUTER_CLASS).toBe('w-[40px]');
+
+    expect(SESSION_SIDE_PANEL_CONTENT_WIDTH_CLASS).toBe(
+      RIGHT_RAIL_CONTENT_WIDTH_CLASS
+    );
+    expect(SESSION_SIDE_PANEL_EXPANDED_OUTER_CLASS).toBe(
+      RIGHT_RAIL_EXPANDED_OUTER_CLASS
+    );
+    expect(SESSION_SIDE_PANEL_FOLDED_OUTER_CLASS).toBe(
+      RIGHT_RAIL_FOLDED_OUTER_CLASS
+    );
+  });
+});

--- a/test/unit/components/Session/ReviewFileTree.test.tsx
+++ b/test/unit/components/Session/ReviewFileTree.test.tsx
@@ -47,14 +47,14 @@ describe('ReviewFileTree', () => {
       />
     );
 
-    expect(screen.getByRole('button', { name: /added\.ts/i })).toBeVisible();
-    expect(screen.getByRole('button', { name: /modified\.ts/i })).toHaveClass(
+    expect(screen.getByRole('treeitem', { name: /added\.ts/i })).toBeVisible();
+    expect(screen.getByRole('treeitem', { name: /modified\.ts/i })).toHaveClass(
       'bg-ds-bg-neutral-default-default'
     );
     expect(screen.getByLabelText('added')).toHaveTextContent('A');
     expect(screen.getByLabelText('modified')).toHaveTextContent('M');
 
-    await user.click(screen.getByRole('button', { name: /added\.ts/i }));
+    await user.click(screen.getByRole('treeitem', { name: /added\.ts/i }));
     expect(onSelect).toHaveBeenCalledWith(files[0].id);
   });
 
@@ -66,9 +66,9 @@ describe('ReviewFileTree', () => {
 
     await user.type(screen.getByRole('textbox'), 'added');
 
-    expect(screen.getByRole('button', { name: /added\.ts/i })).toBeVisible();
+    expect(screen.getByRole('treeitem', { name: /added\.ts/i })).toBeVisible();
     expect(
-      screen.queryByRole('button', { name: /modified\.ts/i })
+      screen.queryByRole('treeitem', { name: /modified\.ts/i })
     ).not.toBeInTheDocument();
   });
 });

--- a/test/unit/electron/main/attachmentGrantWiring.test.ts
+++ b/test/unit/electron/main/attachmentGrantWiring.test.ts
@@ -1,0 +1,70 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function handlerBlock(source: string, channel: string, nextChannel: string) {
+  const start = source.indexOf(`'${channel}'`);
+  const end = source.indexOf(`'${nextChannel}'`, start + channel.length + 2);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe('chat attachment path grant wiring', () => {
+  it('guards and registers every user-driven attachment entry point', () => {
+    const source = fs.readFileSync(
+      path.resolve(process.cwd(), 'electron/main/index.ts'),
+      'utf8'
+    );
+
+    const selectFile = handlerBlock(
+      source,
+      'select-file',
+      'select-agent-plugin-source'
+    );
+    const droppedFiles = handlerBlock(
+      source,
+      'process-dropped-files',
+      'save-pasted-file'
+    );
+    const pastedFile = handlerBlock(
+      source,
+      'save-pasted-file',
+      'reveal-in-folder'
+    );
+
+    for (const block of [selectFile, droppedFiles, pastedFile]) {
+      expect(block).toContain('assertMainRendererSender(event)');
+      expect(block).toContain('rememberUserSelectedLocalPath');
+    }
+    expect(selectFile).toContain('fsp.realpath(filePath)');
+    expect(droppedFiles).toContain('fs.realpathSync(f.path!)');
+    expect(pastedFile).toContain('fsp.realpath(filePath)');
+  });
+
+  it('keeps attachment grants explicitly session-scoped and bounded', () => {
+    const source = fs.readFileSync(
+      path.resolve(process.cwd(), 'electron/main/index.ts'),
+      'utf8'
+    );
+
+    expect(source).toContain(
+      'const userSelectedLocalPaths = new Set<string>()'
+    );
+    expect(source).toContain('const USER_SELECTED_PATH_LIMIT = 512');
+  });
+});

--- a/test/unit/electron/main/localPathActions.test.ts
+++ b/test/unit/electron/main/localPathActions.test.ts
@@ -1,0 +1,256 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  authorizeWorkspaceLocalNode,
+  openWorkspaceLocalFile,
+  rememberBoundedPathGrant,
+  revealUserVisibleLocalNode,
+  revealWorkspaceLocalNode,
+  type LocalPathShell,
+} from '../../../../electron/main/localPathActions';
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryWorkspace(): Promise<string> {
+  const directory = await fsp.mkdtemp(
+    path.join(os.tmpdir(), 'eigent-path-actions-')
+  );
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function shellMock() {
+  return {
+    openPath: vi.fn(async () => ''),
+    showItemInFolder: vi.fn(),
+  } satisfies LocalPathShell;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fsp.rm(directory, { recursive: true, force: true }))
+  );
+});
+
+describe('local path actions', () => {
+  it('evicts the least-recently-used exact grant at the configured limit', () => {
+    const grants = new Set<string>();
+    rememberBoundedPathGrant(grants, '/picked/first', 2);
+    rememberBoundedPathGrant(grants, '/picked/second', 2);
+    rememberBoundedPathGrant(grants, '/picked/first', 2);
+    rememberBoundedPathGrant(grants, '/picked/third', 2);
+
+    expect([...grants]).toEqual(['/picked/first', '/picked/third']);
+  });
+
+  it('opens an exact selected folder instead of its parent', async () => {
+    const workspace = await temporaryWorkspace();
+    const selectedFolder = path.join(workspace, 'reports', 'final');
+    await fsp.mkdir(selectedFolder, { recursive: true });
+    const targetShell = shellMock();
+
+    await expect(
+      revealWorkspaceLocalNode(selectedFolder, [workspace], targetShell)
+    ).resolves.toEqual({ success: true });
+    expect(targetShell.openPath).toHaveBeenCalledWith(
+      await fsp.realpath(selectedFolder)
+    );
+    expect(targetShell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it('reveals and highlights an exact selected file', async () => {
+    const workspace = await temporaryWorkspace();
+    const selectedFile = path.join(workspace, 'reports', 'summary.md');
+    await fsp.mkdir(path.dirname(selectedFile), { recursive: true });
+    await fsp.writeFile(selectedFile, '# Summary');
+    const targetShell = shellMock();
+
+    await expect(
+      revealWorkspaceLocalNode(selectedFile, [workspace], targetShell)
+    ).resolves.toEqual({ success: true });
+    expect(targetShell.showItemInFolder).toHaveBeenCalledWith(
+      await fsp.realpath(selectedFile)
+    );
+    expect(targetShell.openPath).not.toHaveBeenCalled();
+  });
+
+  it('opens an exact selected file with its default app', async () => {
+    const workspace = await temporaryWorkspace();
+    const selectedFile = path.join(workspace, 'report.pdf');
+    await fsp.writeFile(selectedFile, 'pdf');
+    const targetShell = shellMock();
+
+    await expect(
+      openWorkspaceLocalFile(selectedFile, [workspace], targetShell)
+    ).resolves.toEqual({ success: true });
+    expect(targetShell.openPath).toHaveBeenCalledWith(
+      await fsp.realpath(selectedFile)
+    );
+  });
+
+  it('authorizes both file and folder editor targets as exact real paths', async () => {
+    const workspace = await temporaryWorkspace();
+    const selectedFolder = path.join(workspace, 'src');
+    const selectedFile = path.join(selectedFolder, 'index.ts');
+    await fsp.mkdir(selectedFolder);
+    await fsp.writeFile(selectedFile, 'export {};');
+
+    await expect(
+      authorizeWorkspaceLocalNode(selectedFolder, [workspace])
+    ).resolves.toMatchObject({
+      success: true,
+      path: await fsp.realpath(selectedFolder),
+      kind: 'directory',
+    });
+    await expect(
+      authorizeWorkspaceLocalNode(selectedFile, [workspace])
+    ).resolves.toMatchObject({
+      success: true,
+      path: await fsp.realpath(selectedFile),
+      kind: 'file',
+    });
+  });
+
+  it('rejects paths outside the active workspace before opening them', async () => {
+    const root = await temporaryWorkspace();
+    const workspace = path.join(root, 'workspace');
+    const outsideFile = path.join(root, 'secret.txt');
+    await fsp.mkdir(workspace);
+    await fsp.writeFile(outsideFile, 'secret');
+    const targetShell = shellMock();
+
+    await expect(
+      revealWorkspaceLocalNode(outsideFile, [workspace], targetShell)
+    ).resolves.toEqual({
+      success: false,
+      error: 'Path is outside the active workspace',
+    });
+    await expect(
+      openWorkspaceLocalFile(outsideFile, [workspace], targetShell)
+    ).resolves.toEqual({
+      success: false,
+      error: 'Path is outside the active workspace',
+    });
+    expect(targetShell.openPath).not.toHaveBeenCalled();
+    expect(targetShell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it('blocks executable default-app opens and reveals the file instead', async () => {
+    const workspace = await temporaryWorkspace();
+    const executableFile = path.join(workspace, 'install.command');
+    await fsp.writeFile(executableFile, '#!/bin/sh');
+    const targetShell = shellMock();
+
+    await expect(
+      openWorkspaceLocalFile(executableFile, [workspace], targetShell)
+    ).resolves.toEqual({
+      success: false,
+      error: 'Executable files cannot be opened from an agent result',
+    });
+    expect(targetShell.openPath).not.toHaveBeenCalled();
+    expect(targetShell.showItemInFolder).toHaveBeenCalledWith(
+      await fsp.realpath(executableFile)
+    );
+  });
+
+  it('reveals an executable bundle directory instead of launching it', async () => {
+    const workspace = await temporaryWorkspace();
+    const bundle = path.join(workspace, 'Payload.app');
+    await fsp.mkdir(path.join(bundle, 'Contents', 'MacOS'), {
+      recursive: true,
+    });
+    const targetShell = shellMock();
+
+    await expect(
+      revealWorkspaceLocalNode(bundle, [workspace], targetShell)
+    ).resolves.toEqual({ success: true });
+    // shell.openPath would execute the bundle rather than browse it.
+    expect(targetShell.openPath).not.toHaveBeenCalled();
+    expect(targetShell.showItemInFolder).toHaveBeenCalledWith(
+      await fsp.realpath(bundle)
+    );
+  });
+
+  it('still browses an ordinary workspace folder', async () => {
+    const workspace = await temporaryWorkspace();
+    const plainFolder = path.join(workspace, 'reports.output');
+    await fsp.mkdir(plainFolder, { recursive: true });
+    const targetShell = shellMock();
+
+    await expect(
+      revealWorkspaceLocalNode(plainFolder, [workspace], targetShell)
+    ).resolves.toEqual({ success: true });
+    expect(targetShell.openPath).toHaveBeenCalledWith(
+      await fsp.realpath(plainFolder)
+    );
+    expect(targetShell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it('reveals a user-picked attachment stored outside every Space root', async () => {
+    const workspace = await temporaryWorkspace();
+    const elsewhere = await temporaryWorkspace();
+    const attachment = path.join(elsewhere, 'contract.pdf');
+    await fsp.writeFile(attachment, 'pdf');
+    const realAttachment = await fsp.realpath(attachment);
+    const targetShell = shellMock();
+
+    await expect(
+      revealUserVisibleLocalNode(
+        attachment,
+        [workspace],
+        new Set([realAttachment]),
+        targetShell
+      )
+    ).resolves.toEqual({ success: true });
+    expect(targetShell.showItemInFolder).toHaveBeenCalledWith(realAttachment);
+  });
+
+  it('rejects an outside path the user never picked', async () => {
+    const workspace = await temporaryWorkspace();
+    const elsewhere = await temporaryWorkspace();
+    const secret = path.join(elsewhere, 'id_rsa');
+    await fsp.writeFile(secret, 'key');
+    const targetShell = shellMock();
+
+    await expect(
+      revealUserVisibleLocalNode(secret, [workspace], new Set(), targetShell)
+    ).resolves.toEqual({
+      success: false,
+      error: 'Path is outside the active workspace',
+    });
+    expect(targetShell.openPath).not.toHaveBeenCalled();
+    expect(targetShell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it('does not launch a bundle that the user picked in the file dialog', async () => {
+    const elsewhere = await temporaryWorkspace();
+    const bundle = path.join(elsewhere, 'Installer.app');
+    await fsp.mkdir(bundle, { recursive: true });
+    const realBundle = await fsp.realpath(bundle);
+    const targetShell = shellMock();
+
+    await expect(
+      revealUserVisibleLocalNode(bundle, [], new Set([realBundle]), targetShell)
+    ).resolves.toEqual({ success: true });
+    expect(targetShell.openPath).not.toHaveBeenCalled();
+    expect(targetShell.showItemInFolder).toHaveBeenCalledWith(realBundle);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #1816

## Description

The Files page was a dump of the workspace tree. Opening a generated file from a run still dumped people into the full folder list, and desktop reveal/open/IDE actions were inconsistent (and unsafe for paths outside the Space).

This PR turns Files into a usable project workspace:

- **Project changes vs All files** in the session file preview, so a run’s deliverables are the default view instead of the entire Space tree
- **Exact-node Open in actions** from the file viewer (Finder/Explorer, Cursor, VS Code) using the selected file or folder, not a generic workspace root
- **Authorized local path helpers** on the Electron main process: workspace containment for reveal/open/IDE, plus a session allowlist so user-picked chat attachments outside the Space remain revealable without giving the renderer free filesystem access
- **Stable changed-file identity** across relative paths, local paths, stream URLs, and artifact IDs, so the project-changes tree and the all-files tree agree on the same files
- **Shared right-rail widths** so the file tree and session side panel stay aligned when folded or expanded

## Testing Evidence (REQUIRED)

- [ ] I have included human-verified testing evidence in this PR.
- [x] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

**Please attach a screenshot or screen recording before opening.** Suggested captures:

1. Session Files tab defaulting to **Project changes**, with the scope dropdown switching to **All files**
2. Selecting a generated file and using **Show in Finder / File Explorer** and **Open in Cursor / VS Code** on the exact node
3. Empty **Project changes** state with **Show all files**
4. Chat attachment picked outside the Space still revealing correctly, while a path outside both the Space and the picker allowlist is rejected

**Automated coverage added:**

- `test/unit/components/Folder/FolderLayout.test.tsx`
- `test/unit/components/Folder/FileViewerPanel.test.tsx`
- `test/unit/lib/projectChangedFiles.test.ts`
- `test/unit/electron/main/localPathActions.test.ts`
- `test/unit/components/Layout/rightRail.test.ts`

## What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)