### PR TITLE
fix: recover orphaned tool approvals on resume

### DIFF
--- a/backend/app/controller/workspace_git_controller.py
+++ b/backend/app/controller/workspace_git_controller.py
@@ -1253,6 +1253,26 @@ async def run_git_changes(
 ):
     """List one finalized Run's authoritative Git changes lazily."""
 
+    # A Run can legitimately have no Git materialization yet: materialization
+    # is lazy and legacy/overlay-only Runs may never need one.  This is an
+    # availability result for the review UI, not a missing canonical Run.
+    root = _binding_root(space_id=space_id, email=email, user_id=user_id)
+    service = _service()
+    canonical_run = service.journal.get_run(run_id)
+    run_materialization = service.journal.get_run_git_materialization(run_id)
+    if canonical_run is not None and run_materialization is None:
+        repository = service.journal.get_space_git_repository(
+            space_id=space_id
+        )
+        if repository is not None:
+            _assert_repository_binding(repository, root)
+        return {
+            "available": False,
+            "reason": "run_git_not_materialized",
+            "run_id": run_id,
+            "project_id": canonical_run.project_id,
+        }
+
     service, repository, run, base_commit, target_commit = _run_change_context(
         run_id=run_id,
         space_id=space_id,

--- a/backend/app/run_journal/store.py
+++ b/backend/app/run_journal/store.py
@@ -12611,10 +12611,8 @@ class SQLiteRunJournal:
         timestamp: float,
         source: str,
     ) -> tuple[str, ...]:
-        params: tuple[object, ...] = () if run_id is None else (run_id,)
-        run_clause = "" if run_id is None else "AND calls.run_id = ?"
         tools = connection.execute(
-            f"""
+            """
             SELECT calls.*
             FROM tool_calls AS calls
             JOIN approvals AS approval
@@ -12625,10 +12623,10 @@ class SQLiteRunJournal:
                 'completed', 'failed', 'timed_out', 'outcome_unknown'
             )
               AND calls.dispatched_at IS NULL
-              {run_clause}
+              AND (? IS NULL OR calls.run_id = ?)
             ORDER BY calls.created_at, calls.tool_call_id
             """,
-            params,
+            (run_id, run_id),
         ).fetchall()
         cancelled: list[str] = []
         for tool in tools:

--- a/backend/app/run_journal/store.py
+++ b/backend/app/run_journal/store.py
@@ -107,6 +107,7 @@ from app.run_journal.transitions import (
     ATTEMPT_TRANSITIONS,
     COMMAND_TRANSITIONS,
     RUN_TRANSITIONS,
+    TOOL_TERMINAL_STATES,
     TOOL_TRANSITIONS,
     transition_allowed,
 )
@@ -11486,6 +11487,12 @@ class SQLiteRunJournal:
                 raise InvalidRunTransitionError(
                     f"run {run_id!r} has a persisted cancel intent"
                 )
+            self._cancel_orphaned_tool_approvals_in_transaction(
+                connection,
+                run_id=run_id,
+                timestamp=timestamp,
+                source="recovery",
+            )
             active = connection.execute(
                 """
                 SELECT attempt_id FROM run_attempts
@@ -12432,6 +12439,21 @@ class SQLiteRunJournal:
                         tool_call_id,
                     ),
                 )
+            tool = connection.execute(
+                "SELECT * FROM tool_calls WHERE tool_call_id = ?",
+                (tool_call_id,),
+            ).fetchone()
+            assert tool is not None
+            if (
+                status in TOOL_TERMINAL_STATES
+                and tool["dispatched_at"] is None
+            ):
+                self._cancel_orphaned_tool_approval_in_transaction(
+                    connection,
+                    tool=tool,
+                    timestamp=timestamp,
+                    source="desktop",
+                )
             event_type = f"tool.{status}"
             event_id = f"tool:{tool_call_id}:{status}"
             payload = {
@@ -12461,6 +12483,163 @@ class SQLiteRunJournal:
             ).fetchone()
             assert row is not None
             return self._tool_call_from_row(row)
+
+    def _cancel_orphaned_tool_approval_in_transaction(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        tool: sqlite3.Row,
+        timestamp: float,
+        source: str,
+    ) -> bool:
+        """Close a pending approval whose ToolCall can no longer dispatch."""
+
+        if tool["status"] not in TOOL_TERMINAL_STATES:
+            return False
+        if tool["dispatched_at"] is not None:
+            return False
+        approval_id = f"approval:{tool['tool_call_id']}"
+        approval = connection.execute(
+            """
+            SELECT * FROM approvals
+            WHERE approval_id = ? AND run_id = ? AND status = 'pending'
+            """,
+            (approval_id, tool["run_id"]),
+        ).fetchone()
+        if approval is None:
+            return False
+
+        reason = "tool_terminal_before_dispatch"
+        decision_json = json.dumps(
+            {"decision": "rejected", "reason": reason},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        connection.execute(
+            """
+            UPDATE approvals
+            SET status = 'rejected', decision_json = ?, resolved_at = ?,
+                version = version + 1
+            WHERE approval_id = ? AND status = 'pending'
+            """,
+            (decision_json, timestamp, approval_id),
+        )
+        connection.execute(
+            """
+            UPDATE human_interactions
+            SET status = 'cancelled', resolved_at = ?, updated_at = ?,
+                version = version + 1
+            WHERE interaction_id = ?
+              AND status IN ('requested', 'presented')
+            """,
+            (timestamp, timestamp, approval_id),
+        )
+        decision_request_id = f"{source}:{approval_id}:{reason}"
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO human_interaction_decisions(
+                decision_id, interaction_id, decision_request_id,
+                decision_json, actor_type, actor_id, source,
+                action_digest, created_at
+            ) VALUES (?, ?, ?, ?, 'system', NULL, ?, ?, ?)
+            """,
+            (
+                f"decision:{decision_request_id}",
+                approval_id,
+                decision_request_id,
+                decision_json,
+                source,
+                approval["action_digest"],
+                timestamp,
+            ),
+        )
+        remaining_interaction = connection.execute(
+            """
+            SELECT 1 FROM human_interactions
+            WHERE run_id = ? AND status IN ('requested', 'presented')
+            LIMIT 1
+            """,
+            (tool["run_id"],),
+        ).fetchone()
+        run = connection.execute(
+            "SELECT status FROM runs WHERE run_id = ?",
+            (tool["run_id"],),
+        ).fetchone()
+        interrupt_run = bool(
+            remaining_interaction is None
+            and run is not None
+            and run["status"] not in {"completed", "failed", "cancelled"}
+        )
+        if interrupt_run and approval["attempt_id"] is not None:
+            connection.execute(
+                """
+                UPDATE run_attempts
+                SET status = 'interrupted', ended_at = COALESCE(ended_at, ?),
+                    outcome = COALESCE(outcome, ?)
+                WHERE attempt_id = ? AND status = 'waiting_for_user'
+                """,
+                (timestamp, reason, approval["attempt_id"]),
+            )
+        self._append_event_in_transaction(
+            connection,
+            tool["run_id"],
+            RunEventDraft(
+                event_id=f"approval:{approval_id}:cancelled:{reason}",
+                event_type="approval.cancelled",
+                payload={
+                    "approval_id": approval_id,
+                    "interaction_id": approval_id,
+                    "attempt_id": approval["attempt_id"],
+                    "tool_call_id": tool["tool_call_id"],
+                    "decision": "rejected",
+                    "reason": reason,
+                    "source": source,
+                    "continued_attempt": False,
+                },
+                created_at=timestamp,
+            ),
+            run_status="interrupted" if interrupt_run else None,
+            clear_active_attempt=interrupt_run,
+        )
+        return True
+
+    def _cancel_orphaned_tool_approvals_in_transaction(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        run_id: str | None,
+        timestamp: float,
+        source: str,
+    ) -> tuple[str, ...]:
+        params: tuple[object, ...] = () if run_id is None else (run_id,)
+        run_clause = "" if run_id is None else "AND calls.run_id = ?"
+        tools = connection.execute(
+            f"""
+            SELECT calls.*
+            FROM tool_calls AS calls
+            JOIN approvals AS approval
+              ON approval.approval_id = 'approval:' || calls.tool_call_id
+             AND approval.run_id = calls.run_id
+             AND approval.status = 'pending'
+            WHERE calls.status IN (
+                'completed', 'failed', 'timed_out', 'outcome_unknown'
+            )
+              AND calls.dispatched_at IS NULL
+              {run_clause}
+            ORDER BY calls.created_at, calls.tool_call_id
+            """,
+            params,
+        ).fetchall()
+        cancelled: list[str] = []
+        for tool in tools:
+            if self._cancel_orphaned_tool_approval_in_transaction(
+                connection,
+                tool=tool,
+                timestamp=timestamp,
+                source=source,
+            ):
+                cancelled.append(f"approval:{tool['tool_call_id']}")
+        return tuple(cancelled)
 
     def list_tool_calls(self, run_id: str) -> list[ToolCallRecord]:
         with self._lock:
@@ -14206,6 +14385,12 @@ class SQLiteRunJournal:
                         extra={"tool_call_id": tool["tool_call_id"]},
                     )
                     continue
+            self._cancel_orphaned_tool_approvals_in_transaction(
+                connection,
+                run_id=None,
+                timestamp=timestamp,
+                source="recovery",
+            )
             runs = connection.execute(
                 """
                 SELECT * FROM runs

--- a/backend/tests/app/controller/test_workspace_git_controller.py
+++ b/backend/tests/app/controller/test_workspace_git_controller.py
@@ -464,7 +464,6 @@ def test_project_git_changes_returns_lazy_authoritative_diff(git_api):
     assert files["note.md"]["status"] == "added"
     assert files["image.bin"]["binary"] is True
     assert str(space) not in response.text
-
     run_response = client.get(
         "/api/v1/runs/run-review/git/changes",
         params={"space_id": "space-1", "email": "user@example.com"},
@@ -526,6 +525,35 @@ def test_project_git_changes_returns_lazy_authoritative_diff(git_api):
         headers=_headers(),
     )
     assert response.status_code == 404
+
+
+def test_run_git_changes_reports_unmaterialized_run_without_404(git_api):
+    client, service, _, _ = git_api
+    service.journal.ensure_run(
+        run_id="run-not-materialized",
+        project_id="project-not-materialized",
+    )
+
+    response = client.get(
+        "/api/v1/runs/run-not-materialized/git/changes",
+        params={"space_id": "space-1", "email": "user@example.com"},
+        headers=_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "available": False,
+        "reason": "run_git_not_materialized",
+        "run_id": "run-not-materialized",
+        "project_id": "project-not-materialized",
+    }
+
+    missing = client.get(
+        "/api/v1/runs/run-does-not-exist/git/changes",
+        params={"space_id": "space-1", "email": "user@example.com"},
+        headers=_headers(),
+    )
+    assert missing.status_code == 404
 
 
 def test_run_workspace_api_stays_lazy_until_explicit_materialization(git_api):

--- a/backend/tests/app/run_journal/test_recovery.py
+++ b/backend/tests/app/run_journal/test_recovery.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
 from app.run_journal import (
@@ -174,6 +176,9 @@ def test_pending_approval_survives_restart_but_old_attempt_detaches(tmp_path):
         assert reopened.list_approvals("run-1", pending_only=True)[
             0
         ].prompt == {"question": "Allow write?"}
+        active = reopened.get_active_project_run("project-1")
+        assert active is not None
+        assert active.run_id == "run-1"
         with pytest.raises(
             InvalidRunTransitionError, match="pending approvals"
         ):
@@ -183,6 +188,125 @@ def test_pending_approval_survives_restart_but_old_attempt_detaches(tmp_path):
                 reason="explicit_resume",
                 now=4,
             )
+
+
+def test_terminal_tool_before_dispatch_cancels_its_pending_approval(tmp_path):
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(run_id="run-1", project_id="project-1")
+        attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+            activate=True,
+            now=1,
+        )
+        values = dict(
+            tool_call_id="tool-1",
+            run_id="run-1",
+            attempt_id=attempt.attempt_id,
+            tool_name="send_message_to_user",
+            safety_class=ToolSafetyClass.UNSAFE_WRITE,
+            request={"message": "hello"},
+        )
+        journal.checkpoint_tool_call(status="prepared", now=2, **values)
+        journal.create_approval(
+            approval_id="approval:tool-1",
+            run_id="run-1",
+            attempt_id=attempt.attempt_id,
+            prompt={"question": "Allow message?"},
+            now=3,
+        )
+
+        journal.checkpoint_tool_call(
+            status="failed",
+            outcome="failed",
+            result={"error": "tool execution cancelled or timed out"},
+            now=4,
+            **values,
+        )
+
+        approval = journal.list_approvals("run-1")[0]
+        interaction = journal.get_human_interaction("approval:tool-1")
+        assert approval.status == "rejected"
+        assert approval.decision == {
+            "decision": "rejected",
+            "reason": "tool_terminal_before_dispatch",
+        }
+        assert interaction is not None
+        assert interaction.status == "cancelled"
+        assert journal.get_run_attempt(attempt.attempt_id).status == (
+            "interrupted"
+        )
+        assert journal.get_run("run-1").status == "interrupted"
+        assert journal.get_active_project_run("project-1") is None
+        assert "approval.cancelled" in {
+            event.event_type for event in journal.list_events("run-1")
+        }
+
+        resumed = journal.create_run_attempt(
+            "run-1",
+            request_id="resume-1",
+            reason="explicit_resume",
+            now=5,
+        )
+        assert resumed.status == "pending"
+
+
+def test_resume_repairs_legacy_terminal_tool_with_pending_approval(tmp_path):
+    path = tmp_path / "journal.sqlite3"
+    with SQLiteRunJournal(path) as journal:
+        journal.ensure_run(run_id="run-1", project_id="project-1")
+        attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+            activate=True,
+            now=1,
+        )
+        journal.checkpoint_tool_call(
+            tool_call_id="tool-1",
+            run_id="run-1",
+            attempt_id=attempt.attempt_id,
+            tool_name="send_message_to_user",
+            status="prepared",
+            safety_class=ToolSafetyClass.UNSAFE_WRITE,
+            request={"message": "hello"},
+            now=2,
+        )
+        journal.create_approval(
+            approval_id="approval:tool-1",
+            run_id="run-1",
+            attempt_id=attempt.attempt_id,
+            prompt={"question": "Allow message?"},
+            now=3,
+        )
+
+    # Reproduce a pre-fix row: the waiter was cancelled and the ToolCall was
+    # closed, but its durable Approval/interaction remained pending.
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            UPDATE tool_calls
+            SET status = 'failed', outcome = 'failed', completed_at = 4,
+                updated_at = 4
+            WHERE tool_call_id = 'tool-1'
+            """
+        )
+
+    with SQLiteRunJournal(path) as reopened:
+        resumed = reopened.create_run_attempt(
+            "run-1",
+            request_id="resume-legacy",
+            reason="explicit_resume",
+            now=5,
+        )
+
+        assert resumed.status == "pending"
+        assert reopened.list_approvals("run-1")[0].status == "rejected"
+        assert (
+            reopened.get_human_interaction("approval:tool-1").status
+            == "cancelled"
+        )
 
 
 def test_dispatched_unsafe_tool_is_fail_closed_after_restart(tmp_path):

--- a/src/components/Session/PreviewPanel/tabs/review/useReviewChanges.ts
+++ b/src/components/Session/PreviewPanel/tabs/review/useReviewChanges.ts
@@ -23,6 +23,8 @@ import {
   fetchProjectGitChanges,
   fetchRunGitChangeContent,
   fetchRunGitChanges,
+  type ProjectGitChanges,
+  type RunGitChangesUnavailable,
 } from '@/service/workspaceGitApi';
 import { useAuthStore } from '@/store/authStore';
 import {
@@ -44,6 +46,11 @@ export type ReviewFileStatus = 'added' | 'modified' | 'deleted';
  * shipping a huge buffer over IPC just to reject it in the renderer).
  */
 export const MAX_DIFF_BYTES = 2_000_000;
+
+const isRunGitChangesUnavailable = (
+  value: ProjectGitChanges | RunGitChangesUnavailable
+): value is RunGitChangesUnavailable =>
+  'available' in value && value.available === false;
 
 /** One changed file of the current project, ready for the diff view. */
 export interface ReviewFile {
@@ -410,6 +417,9 @@ export function useReviewChanges(
           const response = runId
             ? await fetchRunGitChanges(runId, spaceId, identity)
             : await fetchProjectGitChanges(projectId, spaceId, identity);
+          if (isRunGitChangesUnavailable(response)) {
+            return loadLegacyFiles();
+          }
           const files = response.files.map((file): ReviewFile => {
             const baseCommit = response.base_commit;
             const targetCommit = response.target_commit;

--- a/src/lib/projector/reduce.ts
+++ b/src/lib/projector/reduce.ts
@@ -32,6 +32,7 @@ const RUN_STATUS_BY_EVENT: Record<string, ProjectedRun['status']> = {
   'approval.requested': 'waiting_for_user',
   'approval.decided': 'interrupted',
   'approval.expired_rejected': 'interrupted',
+  'approval.cancelled': 'interrupted',
   'run.completed': 'completed',
   'run.failed': 'failed',
   'run.deadline_reached': 'failed',

--- a/src/service/workspaceGitApi.ts
+++ b/src/service/workspaceGitApi.ts
@@ -151,6 +151,13 @@ export interface RunGitChanges extends ProjectGitChanges {
   run_id: string;
 }
 
+export interface RunGitChangesUnavailable {
+  available: false;
+  reason: 'run_git_not_materialized';
+  run_id: string;
+  project_id: string;
+}
+
 export interface RunGitChangeContent extends ProjectGitChangeContent {
   run_id: string;
   project_id: string;
@@ -275,7 +282,7 @@ export const fetchRunGitChanges = async (
   runId: string,
   spaceId: string,
   identity: WorkspaceGitIdentity
-): Promise<RunGitChanges> =>
+): Promise<RunGitChanges | RunGitChangesUnavailable> =>
   fetchGet(`/runs/${encodeURIComponent(runId)}/git/changes`, {
     ...identityParams(identity),
     space_id: spaceId,

--- a/test/unit/components/Session/useReviewChanges.test.tsx
+++ b/test/unit/components/Session/useReviewChanges.test.tsx
@@ -356,6 +356,33 @@ describe('useReviewChanges', () => {
     });
   });
 
+  it('falls back to retained overlays when Run Git was never materialized', async () => {
+    mockFetchRunGitChanges.mockResolvedValue({
+      available: false,
+      reason: 'run_git_not_materialized',
+      run_id: 'run-1',
+      project_id: 'project-1',
+    });
+    mockReviewListBackups.mockResolvedValue([]);
+    mockFetchOverlays.mockResolvedValue({
+      space_id: 'space-1',
+      project_id: 'project-1',
+      overlays: [],
+    });
+
+    const { result } = renderHook(() =>
+      useReviewChanges({
+        scope: 'run',
+        runId: 'run-1',
+        focusRequestId: 0,
+      })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockFetchOverlays).toHaveBeenCalledWith('space-1', 'project-1');
+    expect(result.current.error).toBeNull();
+  });
+
   it('uses authoritative overlays and removes applied entries on refresh', async () => {
     mockFetchOverlays
       .mockResolvedValueOnce({

--- a/test/unit/lib/projector.test.ts
+++ b/test/unit/lib/projector.test.ts
@@ -896,6 +896,7 @@ describe('projector pipeline', () => {
   it.each([
     ['run.deadline_reached', 'failed'],
     ['runtime.interrupted', 'interrupted'],
+    ['approval.cancelled', 'interrupted'],
   ] as const)('projects %s as the terminal status %s', (eventType, status) => {
     const result = projectRawEvents(
       'project-1',


### PR DESCRIPTION
# Pull Request

## Related Issue

N/A — follow-up to the reproduced Desktop Run recovery incident.

## Description

Fixes Resume failures caused by an orphaned approval that remains pending after its paired tool call fails before dispatch.

- Detects only approvals whose paired tool call is terminal and was never dispatched.
- Atomically cancels the approval and interaction, projects the Run to `interrupted`, and releases the Project execution lease.
- Reconciles historical orphaned approvals at startup and before creating a new Run attempt.
- Preserves the existing serial-admission rule for genuine pending approvals; they continue to retain the execution lease.
- Returns an explicit `run_git_not_materialized` response for canonical Runs without Run Git state, allowing Review Changes to fall back to the legacy overlay instead of surfacing a 404.

## Testing Evidence (REQUIRED)

- [x] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

Non-visual frontend fallback only; screenshots are not applicable.

- `uv run pytest tests/app/run_journal/test_recovery.py tests/app/controller/test_workspace_git_controller.py` — 37 passed
- `npx vitest run --no-cache test/unit/components/Session/useReviewChanges.test.tsx test/unit/lib/projector.test.ts` — 46 passed
- `npm run type-check` — passed
- Relevant full backend suite — 111 passed
- Relevant full frontend suite — 51 passed
- Verified the original durable SQLite state on a temporary database copy: the orphan approval/interaction is cancelled, the Run becomes recoverable, and a new Attempt can be admitted without modifying the live database.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [x] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
