### PR TITLE
feat: add workload evidence foundation

### DIFF
--- a/backend/app/run_journal/__init__.py
+++ b/backend/app/run_journal/__init__.py
@@ -17,6 +17,7 @@ from app.run_journal.models import (
     ApprovalRuleRecord,
     ArtifactUploadSyncItem,
     AttemptEnvironmentBinding,
+    AttemptEvidenceGapRecord,
     CloudRunEventReplica,
     CloudRunReplica,
     CommandResultEvent,
@@ -96,12 +97,14 @@ from app.run_journal.store import (
     UnsafeResumeError,
     UnsupportedSchemaVersionError,
 )
+from app.workload import WorkloadProfileRecord
 
 __all__ = [
     "SCHEMA_VERSION",
     "ApprovalRecord",
     "ApprovalRuleRecord",
     "ArtifactUploadSyncItem",
+    "AttemptEvidenceGapRecord",
     "AttemptEnvironmentBinding",
     "CloudRunEventReplica",
     "CloudRunReplica",
@@ -169,6 +172,7 @@ __all__ = [
     "WorkspaceWriterLeaseRecord",
     "WorkspaceWriterReleaseResult",
     "WorkspaceWriterRequestRecord",
+    "WorkloadProfileRecord",
     "UnsafeResumeError",
     "UnsupportedSchemaVersionError",
     "close_default_run_journal",

--- a/backend/app/run_journal/model_capture.py
+++ b/backend/app/run_journal/model_capture.py
@@ -30,18 +30,24 @@ import threading
 import uuid
 from types import MethodType
 from typing import Any
+from weakref import WeakKeyDictionary
 
 from app.permission_policy.models import redact_action_arguments
 from app.run_context.context import get_current_run_context
 from app.run_journal.models import ModelInvocationRecord
 from app.run_journal.runtime import get_default_run_journal
 from app.run_journal.store import SQLiteRunJournal
+from app.workload import capture_required
 from app.workspace_config.models import canonical_digest
 
 logger = logging.getLogger("model_invocation_capture")
 
 _CAPTURE_INSTALLED = "_eigent_model_invocation_capture_installed"
 _REDACTION_VERSION = "model-invocation-v1"
+_CAPTURE_POLICY_CACHE: WeakKeyDictionary[SQLiteRunJournal, dict[str, bool]] = (
+    WeakKeyDictionary()
+)
+_CAPTURE_POLICY_CACHE_LOCK = threading.Lock()
 
 
 def _json_value(value: Any) -> Any:
@@ -184,6 +190,20 @@ class _StreamAccumulator:
         self.usage: dict[str, Any] | None = None
         self.tool_calls: dict[int, dict[str, Any]] = {}
 
+    @property
+    def terminal_document_ready(self) -> bool:
+        """Return whether a provider terminal chunk is fully captured.
+
+        CAMEL may stop consuming a stream as soon as it observes the final
+        usage-bearing chunk.  In that case the wrapper never receives the
+        following ``StopIteration``/``StopAsyncIteration`` callback.  A
+        finish reason plus usage is the provider-neutral terminal shape that
+        CAMEL itself uses before breaking, so it is safe to persist the
+        accumulated response immediately without changing stream semantics.
+        """
+
+        return self.finish_reason is not None and self.usage is not None
+
     def add(self, chunk: Any) -> bool:
         payload = _response_document(chunk)
         event_type = payload.get("type")
@@ -269,9 +289,11 @@ class _CaptureSession:
         *,
         journal: SQLiteRunJournal,
         record: ModelInvocationRecord,
+        required: bool,
     ) -> None:
         self.journal = journal
         self.record = record
+        self.required = required
         self._closed = False
         self._first_token = False
         self._lock = threading.Lock()
@@ -290,8 +312,18 @@ class _CaptureSession:
             self.journal.mark_model_invocation_first_token(
                 self.record.invocation_id
             )
-        except Exception:
+        except Exception as exc:
             logger.exception("Failed to persist model first-token marker")
+            _record_capture_gap(
+                self.journal,
+                run_id=self.record.run_id,
+                attempt_id=self.record.attempt_id,
+                step_id=self.record.step_id,
+                gap_id=f"capture-gap:{self.record.invocation_id}:first-token",
+                detail_code=type(exc).__name__,
+            )
+            if self.required:
+                raise
 
     async def afirst_token(self) -> None:
         await asyncio.to_thread(self.first_token)
@@ -310,8 +342,18 @@ class _CaptureSession:
                 finish_reason=_finish_reason(response),
                 **usage,
             )
-        except Exception:
+        except Exception as exc:
             logger.exception("Failed to complete durable model invocation")
+            _record_capture_gap(
+                self.journal,
+                run_id=self.record.run_id,
+                attempt_id=self.record.attempt_id,
+                step_id=self.record.step_id,
+                gap_id=f"capture-gap:{self.record.invocation_id}:terminal",
+                detail_code=type(exc).__name__,
+            )
+            if self.required:
+                raise
 
     async def acomplete(self, response: dict[str, Any]) -> None:
         await asyncio.to_thread(self.complete, response)
@@ -331,8 +373,16 @@ class _CaptureSession:
                 error_code=_error_code(exc),
                 error_message=str(exc),
             )
-        except Exception:
+        except Exception as capture_exc:
             logger.exception("Failed to close durable model invocation")
+            _record_capture_gap(
+                self.journal,
+                run_id=self.record.run_id,
+                attempt_id=self.record.attempt_id,
+                step_id=self.record.step_id,
+                gap_id=f"capture-gap:{self.record.invocation_id}:failure",
+                detail_code=type(capture_exc).__name__,
+            )
 
     async def afail(
         self, exc: BaseException, *, outcome_unknown: bool = False
@@ -363,10 +413,18 @@ class _RecordedSyncStream:
         try:
             if self._accumulator.add(chunk):
                 self._session.first_token()
+            if (
+                self._accumulator.terminal_document_ready
+                and not self._session.closed
+            ):
+                self._session.complete(self._accumulator.document())
         except Exception as exc:
-            # A capture projection failure must not corrupt a provider stream
-            # that CAMEL can otherwise consume.
+            # Best-effort capture must not corrupt a provider stream that
+            # CAMEL can otherwise consume. A required CapturePolicy instead
+            # makes this projection failure terminal for the Attempt.
             self._session.fail(exc, outcome_unknown=True)
+            if self._session.required:
+                raise
         return chunk
 
     def __enter__(self) -> _RecordedSyncStream:
@@ -407,6 +465,8 @@ class _RecordedSyncStream:
             )
         except Exception as exc:
             self._session.fail(exc, outcome_unknown=True)
+            if self._session.required:
+                raise
             return
         self._session.complete(response)
 
@@ -417,6 +477,8 @@ class _RecordedSyncStream:
                 self._session.complete(_response_document(response))
             except Exception as exc:
                 self._session.fail(exc, outcome_unknown=True)
+                if self._session.required:
+                    raise
         return response
 
     def until_done(self) -> Any:
@@ -495,8 +557,15 @@ class _RecordedAsyncStream:
         try:
             if self._accumulator.add(chunk):
                 await self._session.afirst_token()
+            if (
+                self._accumulator.terminal_document_ready
+                and not self._session.closed
+            ):
+                await self._session.acomplete(self._accumulator.document())
         except Exception as exc:
             await self._session.afail(exc, outcome_unknown=True)
+            if self._session.required:
+                raise
         return chunk
 
     async def __aenter__(self) -> _RecordedAsyncStream:
@@ -539,6 +608,8 @@ class _RecordedAsyncStream:
                 document = self._accumulator.document()
         except Exception as exc:
             await self._session.afail(exc, outcome_unknown=True)
+            if self._session.required:
+                raise
             return
         await self._session.acomplete(document)
 
@@ -551,6 +622,8 @@ class _RecordedAsyncStream:
                 await self._session.acomplete(_response_document(response))
             except Exception as exc:
                 await self._session.afail(exc, outcome_unknown=True)
+                if self._session.required:
+                    raise
         return response
 
     async def until_done(self) -> Any:
@@ -624,6 +697,75 @@ def _exception_outcome_unknown(exc: BaseException) -> bool:
     )
 
 
+def _capture_is_required(
+    journal: SQLiteRunJournal,
+    attempt_id: str | None,
+) -> bool:
+    if attempt_id:
+        with _CAPTURE_POLICY_CACHE_LOCK:
+            cached = _CAPTURE_POLICY_CACHE.get(journal, {}).get(attempt_id)
+        if cached is not None:
+            return cached
+        try:
+            attempt = journal.get_run_attempt(attempt_id)
+        except Exception:
+            logger.exception("Failed to resolve Attempt capture policy")
+        else:
+            if attempt is not None:
+                # Attempt admission freezes the environment compatibility
+                # setting into an immutable WorkloadProfile. Never let a
+                # later process-wide env change override that audit fact.
+                required = capture_required(attempt.workload_profile)
+                with _CAPTURE_POLICY_CACHE_LOCK:
+                    journal_cache = _CAPTURE_POLICY_CACHE.setdefault(
+                        journal, {}
+                    )
+                    journal_cache[attempt_id] = required
+                return required
+    # Compatibility entry point. New Test/A-B/Rollout callers should bind a
+    # required CapturePolicy in the immutable WorkloadProfile instead.
+    return os.environ.get("EIGENT_MODEL_CAPTURE_REQUIRED", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _record_capture_gap(
+    journal: SQLiteRunJournal,
+    *,
+    run_id: str,
+    attempt_id: str | None,
+    step_id: str | None,
+    gap_id: str,
+    detail_code: str,
+) -> None:
+    if not attempt_id:
+        return
+    for candidate_step_id in (step_id, None) if step_id else (None,):
+        try:
+            journal.record_attempt_evidence_gap(
+                gap_id=gap_id,
+                run_id=run_id,
+                attempt_id=attempt_id,
+                step_id=candidate_step_id,
+                dimension="model_decisions",
+                reason_code="capture_failed",
+                source="model_capture",
+                detail_code=detail_code,
+            )
+            return
+        except Exception:
+            # A stale runtime Step must not make the Attempt-level gap
+            # disappear. Retry once without Step correlation; a secondary
+            # storage failure still must not replace the original failure.
+            logger.exception(
+                "Failed to persist model capture evidence gap%s",
+                " with Step correlation" if candidate_step_id else "",
+            )
+
+
 def _start_capture(
     *,
     journal: SQLiteRunJournal,
@@ -638,12 +780,41 @@ def _start_capture(
     context = get_current_run_context()
     if context is None:
         return None
+    # Import locally to keep the capture adapter independent from runtime
+    # initialization order. The ContextVar value is copied into asyncio worker
+    # threads, so async and sync dispatch observe the same authored Step.
+    from app.run_runtime.step_coordinator import (
+        RunStepCoordinator,
+        get_current_step_id,
+    )
+
+    step_id = get_current_step_id()
+    if step_id is None:
+        # Model dispatch happens between tool scopes, so the ContextVar alone
+        # cannot correlate the ordinary CAMEL think/tool/think loop.  Resolve
+        # the uniquely running authored Step using the same conservative
+        # agent-aware fallback already used by legacy event projection.
+        try:
+            step_id = RunStepCoordinator(journal).current_running_step_id(
+                context.run_id,
+                agent_id=agent_id,
+            )
+        except Exception:
+            # Step attribution is enrichment. A transient replay failure must
+            # not turn best-effort model capture into a dispatch gate.
+            logger.exception(
+                "Failed to resolve running Step for model capture",
+                extra={"run_id": context.run_id, "agent_id": agent_id},
+            )
+            step_id = None
+    required = _capture_is_required(journal, context.attempt_id)
     response_format = call_kwargs.get(
         "response_format", call_args[0] if call_args else None
     )
     tools = call_kwargs.get(
         "tools", call_args[1] if len(call_args) > 1 else None
     )
+    logical_call_id = ""
     try:
         request = _request_document(
             model_backend, messages, response_format, tools
@@ -668,6 +839,7 @@ def _start_capture(
             invocation_id=f"modelinv_{uuid.uuid4().hex}",
             run_id=context.run_id,
             attempt_id=context.attempt_id,
+            step_id=step_id,
             agent_id=agent_id,
             logical_call_id=logical_call_id,
             provider=provider,
@@ -677,17 +849,24 @@ def _start_capture(
             request=request,
             redaction_version=_REDACTION_VERSION,
         )
-    except Exception:
+    except Exception as exc:
         logger.exception("Failed to start durable model invocation")
-        if os.environ.get("EIGENT_MODEL_CAPTURE_REQUIRED", "").lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }:
+        _record_capture_gap(
+            journal,
+            run_id=context.run_id,
+            attempt_id=context.attempt_id,
+            step_id=step_id,
+            gap_id=(
+                f"capture-gap:{logical_call_id}:dispatch"
+                if logical_call_id
+                else f"capture-gap:{uuid.uuid4().hex}:dispatch"
+            ),
+            detail_code=type(exc).__name__,
+        )
+        if required:
             raise
         return None
-    return _CaptureSession(journal=journal, record=record)
+    return _CaptureSession(journal=journal, record=record, required=required)
 
 
 def instrument_model_backend(
@@ -750,6 +929,8 @@ def instrument_model_backend(
             document = _response_document(response)
         except Exception as exc:
             session.fail(exc, outcome_unknown=True)
+            if session.required:
+                raise
             return response
         session.complete(document)
         return response
@@ -789,6 +970,8 @@ def instrument_model_backend(
             document = _response_document(response)
         except Exception as exc:
             await session.afail(exc, outcome_unknown=True)
+            if session.required:
+                raise
             return response
         await session.acomplete(document)
         return response

--- a/backend/app/run_journal/models.py
+++ b/backend/app/run_journal/models.py
@@ -22,6 +22,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+from app.workload import WorkloadProfileRecord
+
 
 @dataclass(frozen=True)
 class RunRecord:
@@ -150,6 +152,7 @@ class ModelInvocationRecord:
     invocation_id: str
     run_id: str
     attempt_id: str | None
+    step_id: str | None
     agent_id: str
     logical_call_id: str
     retry_index: int
@@ -182,6 +185,30 @@ class ModelInvocationEventRecord:
     event_index: int
     event_type: str
     payload: dict[str, Any]
+    created_at: float
+
+
+@dataclass(frozen=True)
+class ModelDocumentRetentionResult:
+    """Outcome of one bounded local model-document retention batch."""
+
+    expired_invocation_ids: tuple[str, ...]
+    skipped_invocation_ids: tuple[str, ...]
+    remaining_candidate_count: int
+
+
+@dataclass(frozen=True)
+class AttemptEvidenceGapRecord:
+    """One explicit reason why an Attempt evidence dimension is incomplete."""
+
+    gap_id: str
+    run_id: str
+    attempt_id: str
+    step_id: str | None
+    dimension: str
+    reason_code: str
+    source: str
+    detail_code: str | None
     created_at: float
 
 
@@ -340,6 +367,8 @@ class RunAttemptRecord:
     thinking_effort_requested: str | None = None
     thinking_effort_effective: str | None = None
     provider_capability_revision: str | None = None
+    workload_profile: WorkloadProfileRecord | None = None
+    workload_profile_digest: str | None = None
 
 
 @dataclass(frozen=True)

--- a/backend/app/run_journal/otel_projection.py
+++ b/backend/app/run_journal/otel_projection.py
@@ -1,0 +1,287 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+"""Versioned RunJournal -> OpenTelemetry GenAI projection contract.
+
+This module is intentionally pure. RunJournal stays canonical and exporters
+consume these projections asynchronously; exporter failure must never alter a
+Run fact or block Production dispatch.
+
+Intentionally unwired in v1: this is a frozen projection contract; exporter
+wiring lands separately after the contract and privacy boundary are reviewed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from app.run_journal.models import ModelInvocationRecord, RunAttemptRecord
+
+OTEL_GENAI_PROJECTOR_VERSION = 1
+# The dedicated GenAI repository has not published a semantic-convention
+# version or schema URL yet. Keep both unset so a future exporter omits
+# schema_url rather than advertising an unresolvable schema. The projection
+# contract is instead pinned to a reviewed upstream source snapshot.
+OTEL_GENAI_SEMCONV_VERSION: str | None = None
+OTEL_GENAI_SCHEMA_URL: str | None = None
+OTEL_GENAI_SEMCONV_SOURCE_REF = (
+    "open-telemetry/semantic-conventions-genai@"
+    "56d6b11a02129319bf371083fa134b7ce989c976"
+)
+# Verified on 2026-08-25 against model/gen-ai/registry.yaml at the source ref
+# above. The opt-in network conformance test also checks current upstream main
+# so registry drift becomes visible before exporter wiring lands.
+OTEL_GENAI_ATTRIBUTE_ALLOWLIST = frozenset(
+    {
+        "gen_ai.operation.name",
+        "gen_ai.provider.name",
+        "gen_ai.request.model",
+        "gen_ai.request.reasoning.level",
+        "gen_ai.request.stream",
+        "gen_ai.response.finish_reasons",
+        "gen_ai.response.id",
+        "gen_ai.response.model",
+        "gen_ai.usage.cache_read.input_tokens",
+        "gen_ai.usage.cache_write.input_tokens",
+        "gen_ai.usage.input_tokens",
+        "gen_ai.usage.output_tokens",
+    }
+)
+_PROVIDER_NAMES = {
+    "azure": "azure.ai.openai",
+    "aws-bedrock": "aws.bedrock",
+    "aws-bedrock-converse": "aws.bedrock",
+    "bedrock": "aws.bedrock",
+    "gemini": "gcp.gemini",
+    "mistral": "mistral_ai",
+    "vertex-ai": "gcp.vertex_ai",
+    "vertexai": "gcp.vertex_ai",
+}
+
+
+@dataclass(frozen=True)
+class OtelSpanProjection:
+    projector_version: int
+    semconv_version: str | None
+    semconv_source_ref: str
+    schema_url: str | None
+    span_name: str
+    span_kind: Literal["INTERNAL", "CLIENT"]
+    status_code: Literal["UNSET", "ERROR"]
+    start_time_unix_seconds: float
+    end_time_unix_seconds: float | None
+    attributes: dict[str, Any]
+
+
+def project_attempt_span(attempt: RunAttemptRecord) -> OtelSpanProjection:
+    profile = attempt.workload_profile
+    attributes: dict[str, Any] = {
+        # A local Eigent Attempt is the trace root, not a remote agent-client
+        # call. Model invocations beneath it use the standard GenAI fields.
+        "eigent.operation.name": "run_attempt",
+        "eigent.run.id": attempt.run_id,
+        "eigent.attempt.id": attempt.attempt_id,
+        "eigent.attempt.number": attempt.attempt_number,
+        "eigent.otel.projector.version": OTEL_GENAI_PROJECTOR_VERSION,
+    }
+    _set_optional(
+        attributes,
+        "eigent.workload.profile.digest",
+        attempt.workload_profile_digest,
+    )
+    if profile is not None:
+        attributes.update(
+            {
+                "eigent.workload.kind": profile.workload_kind,
+                "eigent.workload.profile.version": profile.profile_version,
+                "eigent.workload.isolation_policy.ref": (
+                    profile.isolation_policy_ref
+                ),
+                "eigent.workload.capture_policy.ref": (
+                    profile.capture_policy_ref
+                ),
+                "eigent.workload.verifier_policy.ref": (
+                    profile.verifier_policy_ref
+                ),
+                "eigent.workload.budget_policy.ref": (
+                    profile.budget_policy_ref
+                ),
+                "eigent.workload.network_policy.ref": (
+                    profile.network_policy_ref
+                ),
+                "eigent.workload.retention_policy.ref": (
+                    profile.retention_policy_ref
+                ),
+            }
+        )
+        _set_optional(
+            attributes, "eigent.workload.pairing_key", profile.pairing_key
+        )
+        _set_optional(
+            attributes, "eigent.workload.experiment.id", profile.experiment_id
+        )
+        _set_optional(
+            attributes,
+            "eigent.workload.rollout_batch.id",
+            profile.rollout_batch_id,
+        )
+    if attempt.environment_spec_digest:
+        attributes["eigent.environment.spec.digest"] = (
+            attempt.environment_spec_digest
+        )
+    return OtelSpanProjection(
+        projector_version=OTEL_GENAI_PROJECTOR_VERSION,
+        semconv_version=OTEL_GENAI_SEMCONV_VERSION,
+        semconv_source_ref=OTEL_GENAI_SEMCONV_SOURCE_REF,
+        schema_url=OTEL_GENAI_SCHEMA_URL,
+        span_name="run_attempt",
+        span_kind="INTERNAL",
+        status_code=_attempt_status(attempt.status),
+        start_time_unix_seconds=attempt.started_at,
+        end_time_unix_seconds=attempt.ended_at,
+        attributes=attributes,
+    )
+
+
+def project_model_invocation_span(
+    record: ModelInvocationRecord,
+) -> OtelSpanProjection:
+    attributes: dict[str, Any] = {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": _otel_provider_name(record.provider),
+        "gen_ai.request.model": record.model,
+        "eigent.run.id": record.run_id,
+        "eigent.model.invocation.id": record.invocation_id,
+        "eigent.model.logical_call.id": record.logical_call_id,
+        "eigent.model.retry.index": record.retry_index,
+        "eigent.agent.id": record.agent_id,
+        "eigent.model.transport": record.transport,
+        "eigent.model.provider": record.provider,
+        "eigent.model.request.digest": record.request_digest,
+        "eigent.otel.projector.version": OTEL_GENAI_PROJECTOR_VERSION,
+        # V1 intentionally exports correlation and usage only. Canonical
+        # request/response JSON does not implement the OTel message schemas.
+        "eigent.otel.content.mode": "excluded",
+    }
+    if record.attempt_id:
+        attributes["eigent.attempt.id"] = record.attempt_id
+    if record.step_id:
+        attributes["eigent.step.id"] = record.step_id
+    if record.thinking_effort:
+        attributes["eigent.model.thinking_effort"] = record.thinking_effort
+        attributes["gen_ai.request.reasoning.level"] = record.thinking_effort
+    if record.response_digest:
+        attributes["eigent.model.response.digest"] = record.response_digest
+    request_config = record.request.get("model_config_dict")
+    if (
+        isinstance(request_config, dict)
+        and request_config.get("stream") is True
+    ):
+        # The convention says absence means non-streaming; emit this only for
+        # an actual streaming request.
+        attributes["gen_ai.request.stream"] = True
+    _set_optional(
+        attributes, "gen_ai.usage.input_tokens", record.prompt_tokens
+    )
+    _set_optional(
+        attributes,
+        "gen_ai.usage.output_tokens",
+        record.completion_tokens,
+    )
+    _set_optional(
+        attributes,
+        "gen_ai.usage.cache_read.input_tokens",
+        record.cache_read_tokens,
+    )
+    _set_optional(
+        attributes,
+        "gen_ai.usage.cache_write.input_tokens",
+        record.cache_write_tokens,
+    )
+    if record.finish_reason:
+        attributes["gen_ai.response.finish_reasons"] = [record.finish_reason]
+
+    response = record.response or {}
+    response_model = response.get("model")
+    response_id = response.get("id")
+    _set_optional(attributes, "gen_ai.response.model", response_model)
+    _set_optional(attributes, "gen_ai.response.id", response_id)
+
+    if record.error_code:
+        attributes["error.type"] = record.error_code
+    _validate_gen_ai_attributes(attributes)
+    return OtelSpanProjection(
+        projector_version=OTEL_GENAI_PROJECTOR_VERSION,
+        semconv_version=OTEL_GENAI_SEMCONV_VERSION,
+        semconv_source_ref=OTEL_GENAI_SEMCONV_SOURCE_REF,
+        schema_url=OTEL_GENAI_SCHEMA_URL,
+        span_name=f"chat {record.model}",
+        span_kind="CLIENT",
+        status_code=(
+            "ERROR"
+            if record.status in {"failed", "outcome_unknown"}
+            else "UNSET"
+        ),
+        start_time_unix_seconds=record.started_at,
+        end_time_unix_seconds=record.completed_at,
+        attributes=attributes,
+    )
+
+
+def _attempt_status(status: str) -> Literal["UNSET", "ERROR"]:
+    if status in {
+        "failed",
+        "cancelled",
+        "interrupted",
+        "timed_out",
+    }:
+        return "ERROR"
+    return "UNSET"
+
+
+def _set_optional(attributes: dict[str, Any], key: str, value: Any) -> None:
+    if value is not None and value != "":
+        attributes[key] = value
+
+
+def _otel_provider_name(provider: str) -> str:
+    normalized = provider.strip().lower()
+    return _PROVIDER_NAMES.get(normalized, normalized)
+
+
+def _validate_gen_ai_attributes(attributes: dict[str, Any]) -> None:
+    unknown = {
+        key
+        for key in attributes
+        if key.startswith("gen_ai.")
+        and key not in OTEL_GENAI_ATTRIBUTE_ALLOWLIST
+    }
+    if unknown:
+        raise ValueError(
+            "unreviewed OpenTelemetry GenAI attribute(s): "
+            + ", ".join(sorted(unknown))
+        )
+
+
+__all__ = [
+    "OTEL_GENAI_PROJECTOR_VERSION",
+    "OTEL_GENAI_SCHEMA_URL",
+    "OTEL_GENAI_SEMCONV_SOURCE_REF",
+    "OTEL_GENAI_SEMCONV_VERSION",
+    "OTEL_GENAI_ATTRIBUTE_ALLOWLIST",
+    "OtelSpanProjection",
+    "project_attempt_span",
+    "project_model_invocation_span",
+]

--- a/backend/app/run_journal/recorder.py
+++ b/backend/app/run_journal/recorder.py
@@ -27,6 +27,17 @@ from app.run_journal.store import SQLiteRunJournal
 
 logger = logging.getLogger("event_recorder")
 
+_WORKFORCE_SUBTASK_EVENT_TYPES = frozenset(
+    {
+        "subtask.created",
+        "subtask.queued",
+        "subtask.started",
+        "subtask.completed",
+        "subtask.failed",
+        "subtask.cancelled",
+    }
+)
+
 
 class EventRecorder:
     def __init__(
@@ -87,13 +98,33 @@ class EventRecorder:
 
         enriched_data = dict(data)
         step_id = str(enriched_data.get("step_id") or "").strip() or None
+        semantic = project_legacy_semantic_event(
+            step=step,
+            data=enriched_data,
+            run_id=run_id,
+        )
         if step_id is None:
             from app.run_runtime.step_coordinator import (
                 RunStepCoordinator,
                 get_current_step_id,
+                stable_step_id,
             )
 
-            step_id = get_current_step_id()
+            # A Workforce subtask has a deterministic identity. Resolve it
+            # before the generic ContextVar/sole-running-Step fallback so a
+            # queued sibling can never inherit another task's running Step.
+            if (
+                semantic is not None
+                and semantic.event_type in _WORKFORCE_SUBTASK_EVENT_TYPES
+            ):
+                task_id = str(semantic.payload.get("task_id") or "").strip()
+                if task_id:
+                    step_id = stable_step_id(
+                        run_id,
+                        f"subtask:{task_id}",
+                    )
+            if step_id is None:
+                step_id = get_current_step_id()
             if step_id is None:
                 step_id = await asyncio.to_thread(
                     RunStepCoordinator(self._journal).current_running_step_id,
@@ -102,11 +133,6 @@ class EventRecorder:
         if step_id:
             enriched_data["step_id"] = step_id
 
-        semantic = project_legacy_semantic_event(
-            step=step,
-            data=enriched_data,
-            run_id=run_id,
-        )
         projected_payload = (
             dict(semantic.payload) if semantic is not None else enriched_data
         )
@@ -133,12 +159,23 @@ class EventRecorder:
         if created_at is not None:
             values["created_at"] = created_at
         draft = RunEventDraft(**values)
-        event = await asyncio.to_thread(
-            self._journal.append_event,
-            run_id,
-            draft,
-            expected_project_id=project_id,
-        )
+        if (
+            semantic is not None
+            and semantic.event_type in _WORKFORCE_SUBTASK_EVENT_TYPES
+        ):
+            event = await asyncio.to_thread(
+                self._journal.append_event_with_workforce_step_projection,
+                run_id,
+                draft,
+                expected_project_id=project_id,
+            )
+        else:
+            event = await asyncio.to_thread(
+                self._journal.append_event,
+                run_id,
+                draft,
+                expected_project_id=project_id,
+            )
         self._notify_commit()
         return event
 

--- a/backend/app/run_journal/store.py
+++ b/backend/app/run_journal/store.py
@@ -29,7 +29,7 @@ import sqlite3
 import threading
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
@@ -42,6 +42,7 @@ from app.run_journal.models import (
     ApprovalRuleRecord,
     ArtifactUploadSyncItem,
     AttemptEnvironmentBinding,
+    AttemptEvidenceGapRecord,
     CloudRunEventReplica,
     CloudRunReplica,
     CommandResultEvent,
@@ -68,6 +69,7 @@ from app.run_journal.models import (
     MemoryMutationSyncItem,
     MemoryReconciliationRecord,
     MemoryScopeStateRecord,
+    ModelDocumentRetentionResult,
     ModelInvocationEventRecord,
     ModelInvocationRecord,
     ProjectExecutionStateRecord,
@@ -119,6 +121,16 @@ from app.run_policy import (
     ToolSafetyClass,
     automatic_tool_replay_allowed,
 )
+from app.workload import (
+    DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+    PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS,
+    RETENTION_POLICY_PRODUCT_DEFAULT,
+    WorkloadProfileRecord,
+    default_workload_profile,
+    workload_profile_digest,
+    workload_profile_from_payload,
+    workload_profile_payload,
+)
 from app.workspace_config.models import (
     EffectiveEnvironmentSpec,
     ThinkingEffort,
@@ -126,7 +138,7 @@ from app.workspace_config.models import (
     canonical_json,
 )
 
-SCHEMA_VERSION = 33
+SCHEMA_VERSION = 34
 logger = logging.getLogger("run_journal")
 # Per redacted request or response. Oversized documents retain a bounded JSON
 # prefix plus the byte count and digest of the full redacted projection.
@@ -208,6 +220,50 @@ _MEMORY_SOURCE_TRUST = {
     "legacy_unverified",
 }
 _MEMORY_DEFAULT_TOKEN_LIMITS = {"project": 1024, "space": 640, "user": 384}
+
+_EVIDENCE_DIMENSIONS = {
+    "intent",
+    "harness",
+    "model_decisions",
+    "tool_actions",
+    "external_observations",
+    "initial_environment",
+    "checkpoints",
+    "terminal_environment",
+    "workspace_delta",
+    "artifacts",
+    "user_outcome",
+    "verifier_result",
+}
+_EVIDENCE_GAP_REASON_CODES = {
+    "capture_disabled",
+    "capture_failed",
+    "provider_capability_missing",
+    "content_not_enabled",
+    "redacted",
+    "truncated_budget",
+    "process_crashed",
+    "outcome_unknown",
+    "consent_missing",
+    "reference_unresolvable",
+    "retention_expired",
+    "not_yet_implemented",
+}
+_DEFAULT_WORKLOAD_PROFILE_JSON = canonical_json(
+    workload_profile_payload(DEFAULT_PRODUCTION_WORKLOAD_PROFILE)
+)
+_DEFAULT_WORKLOAD_PROFILE_DIGEST = workload_profile_digest(
+    DEFAULT_PRODUCTION_WORKLOAD_PROFILE
+)
+_MODEL_DOCUMENT_RETENTION_MARKER = canonical_json(
+    {
+        "_eigent_retention": {
+            "expired": True,
+            "policy_ref": RETENTION_POLICY_PRODUCT_DEFAULT,
+            "version": 1,
+        }
+    }
+)
 
 _MIGRATION_V1 = """
 BEGIN IMMEDIATE;
@@ -2167,6 +2223,72 @@ INSERT OR IGNORE INTO run_journal_migrations(version, applied_at)
 VALUES (33, CAST(strftime('%s', 'now') AS REAL));
 
 PRAGMA user_version = 33;
+COMMIT;
+"""
+
+_MIGRATION_V34 = """
+BEGIN IMMEDIATE;
+
+-- Workload purpose and SLA policy are immutable Attempt bindings. They are
+-- deliberately separate from Workspace Bundle and EnvironmentSpec identity.
+ALTER TABLE run_attempts
+ADD COLUMN workload_kind TEXT NOT NULL DEFAULT 'production'
+    CHECK(workload_kind IN ('production', 'test', 'ab', 'rollout'));
+ALTER TABLE run_attempts
+ADD COLUMN workload_profile_json TEXT NOT NULL
+    DEFAULT '{"budget_policy_ref":"budget.product-default.v1","capture_policy_ref":"capture.best-effort.v1","isolation_policy_ref":"isolation.product-default.v1","network_policy_ref":"network.product-default.v1","profile_version":"1","retention_policy_ref":"retention.product-default.v1","schema_version":1,"verifier_policy_ref":"verifier.noop.v1","workload_kind":"production"}';
+ALTER TABLE run_attempts
+ADD COLUMN workload_profile_digest TEXT NOT NULL
+    DEFAULT '4786bb51388abddfbbe18decc88ada3e3e896b4aa9967970c2b99865d4999302'
+    CHECK(length(workload_profile_digest) = 64);
+CREATE INDEX IF NOT EXISTS run_attempts_workload_kind_idx
+ON run_attempts(workload_kind, started_at, attempt_id);
+
+-- Model calls bind to the authored Step that was current at dispatch. Steps
+-- remain canonical Run events; this nullable correlation is not a second Step
+-- state store.
+ALTER TABLE model_invocations ADD COLUMN step_id TEXT;
+CREATE INDEX IF NOT EXISTS model_invocations_step_idx
+ON model_invocations(run_id, step_id, started_at, invocation_id)
+WHERE step_id IS NOT NULL;
+
+-- A capture failure is a durable, queryable fact instead of a log line.
+-- AttemptEvidenceManifest can aggregate these rows without rewriting canonical
+-- ModelInvocation or ToolCall records.
+CREATE TABLE IF NOT EXISTS attempt_evidence_gaps(
+    gap_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+    attempt_id TEXT NOT NULL REFERENCES run_attempts(attempt_id)
+        ON DELETE CASCADE,
+    step_id TEXT,
+    dimension TEXT NOT NULL CHECK(
+        dimension IN (
+            'intent', 'harness', 'model_decisions', 'tool_actions',
+            'external_observations', 'initial_environment', 'checkpoints',
+            'terminal_environment', 'workspace_delta', 'artifacts',
+            'user_outcome', 'verifier_result'
+        )
+    ),
+    reason_code TEXT NOT NULL CHECK(
+        reason_code IN (
+            'capture_disabled', 'capture_failed',
+            'provider_capability_missing', 'content_not_enabled', 'redacted',
+            'truncated_budget', 'process_crashed', 'outcome_unknown',
+            'consent_missing', 'reference_unresolvable',
+            'retention_expired', 'not_yet_implemented'
+        )
+    ),
+    source TEXT NOT NULL,
+    detail_code TEXT,
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS attempt_evidence_gaps_attempt_idx
+ON attempt_evidence_gaps(attempt_id, step_id, created_at, gap_id);
+
+INSERT OR IGNORE INTO run_journal_migrations(version, applied_at)
+VALUES (34, CAST(strftime('%s', 'now') AS REAL));
+
+PRAGMA user_version = 34;
 COMMIT;
 """
 
@@ -7650,6 +7772,7 @@ class SQLiteRunJournal:
         invocation_id: str,
         run_id: str,
         attempt_id: str | None,
+        step_id: str | None = None,
         agent_id: str,
         logical_call_id: str,
         provider: str,
@@ -7671,6 +7794,10 @@ class SQLiteRunJournal:
             raise ValueError("model invocation ids are required")
         if not agent_id.strip() or not provider.strip() or not model.strip():
             raise ValueError("model invocation identity is incomplete")
+        if step_id is not None:
+            step_id = step_id.strip()
+            if not step_id:
+                raise ValueError("model invocation step id cannot be blank")
         timestamp = now if now is not None else time.time()
         safe_request, request_json = _project_model_document(
             "request", request
@@ -7687,6 +7814,8 @@ class SQLiteRunJournal:
             if duplicate is not None:
                 if (
                     duplicate["run_id"] != run_id
+                    or duplicate["attempt_id"] != attempt_id
+                    or duplicate["step_id"] != step_id
                     or duplicate["logical_call_id"] != logical_call_id
                     or duplicate["request_digest"] != request_digest
                 ):
@@ -7709,6 +7838,17 @@ class SQLiteRunJournal:
                     raise IdempotencyConflictError(
                         "model invocation attempt does not belong to the Run"
                     )
+            if step_id is not None:
+                step_exists = self._step_belongs_to_attempt_in_transaction(
+                    connection,
+                    run_id=run_id,
+                    step_id=step_id,
+                    attempt_id=attempt_id,
+                )
+                if not step_exists:
+                    raise IdempotencyConflictError(
+                        "model invocation step does not belong to the Run"
+                    )
             retry_index = int(
                 connection.execute(
                     """
@@ -7721,7 +7861,7 @@ class SQLiteRunJournal:
             connection.execute(
                 """
                 INSERT INTO model_invocations(
-                    invocation_id, run_id, attempt_id, agent_id,
+                    invocation_id, run_id, attempt_id, step_id, agent_id,
                     logical_call_id, retry_index, status, provider, model,
                     transport, thinking_effort, request_json, response_json,
                     request_digest, response_digest, prompt_tokens,
@@ -7729,7 +7869,7 @@ class SQLiteRunJournal:
                     finish_reason, error_code, error_message,
                     redaction_version, started_at, first_token_at, completed_at
                 ) VALUES (
-                    ?, ?, ?, ?, ?, ?, 'dispatched', ?, ?, ?, ?, ?, NULL,
+                    ?, ?, ?, ?, ?, ?, ?, 'dispatched', ?, ?, ?, ?, ?, NULL,
                     ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
                     ?, ?, NULL, NULL
                 )
@@ -7738,6 +7878,7 @@ class SQLiteRunJournal:
                     invocation_id,
                     run_id,
                     attempt_id,
+                    step_id,
                     agent_id,
                     logical_call_id,
                     retry_index,
@@ -7754,6 +7895,7 @@ class SQLiteRunJournal:
             event_payload = {
                 "invocation_id": invocation_id,
                 "attempt_id": attempt_id,
+                "step_id": step_id,
                 "agent_id": agent_id,
                 "logical_call_id": logical_call_id,
                 "retry_index": retry_index,
@@ -7925,6 +8067,7 @@ class SQLiteRunJournal:
             event_payload: dict[str, Any] = {
                 "invocation_id": invocation_id,
                 "attempt_id": row["attempt_id"],
+                "step_id": row["step_id"],
                 "agent_id": row["agent_id"],
                 "status": status,
                 "request_digest": row["request_digest"],
@@ -7962,6 +8105,151 @@ class SQLiteRunJournal:
             assert updated is not None
             return self._model_invocation_from_row(updated)
 
+    def _record_model_capture_outcome_gap_in_transaction(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        invocation: sqlite3.Row,
+        detail_code: str,
+        suffix: str,
+        timestamp: float,
+    ) -> None:
+        attempt_id = invocation["attempt_id"]
+        if attempt_id is None:
+            return
+        invocation_id = str(invocation["invocation_id"])
+        run_id = str(invocation["run_id"])
+        gap_id = f"capture-gap:{invocation_id}:{suffix}"
+        inserted = connection.execute(
+            """
+            INSERT OR IGNORE INTO attempt_evidence_gaps(
+                gap_id, run_id, attempt_id, step_id, dimension,
+                reason_code, source, detail_code, created_at
+            ) VALUES (?, ?, ?, ?, 'model_decisions',
+                      'outcome_unknown', 'model_capture', ?, ?)
+            """,
+            (
+                gap_id,
+                run_id,
+                attempt_id,
+                invocation["step_id"],
+                detail_code,
+                timestamp,
+            ),
+        )
+        if inserted.rowcount != 1:
+            return
+        self._append_event_in_transaction(
+            connection,
+            run_id,
+            RunEventDraft(
+                event_id=f"attempt-evidence-gap:{gap_id}",
+                event_type="attempt.evidence_gap_recorded",
+                payload={
+                    "gap_id": gap_id,
+                    "attempt_id": attempt_id,
+                    "step_id": invocation["step_id"],
+                    "dimension": "model_decisions",
+                    "reason_code": "outcome_unknown",
+                    "source": "model_capture",
+                    "detail_code": detail_code,
+                },
+                created_at=timestamp,
+            ),
+        )
+
+    def _close_dispatched_model_invocations_in_transaction(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        run_id: str,
+        terminal_event_type: str,
+        timestamp: float,
+    ) -> tuple[str, ...]:
+        """Close provider calls that outlived their owning Run Attempt.
+
+        Normal streaming capture commits the terminal provider chunk before a
+        Run can finish.  This barrier covers consumer/provider edge cases and
+        process integrations that return without exhausting or explicitly
+        closing a stream.  Best-effort capture must remain non-blocking, but
+        it must never leave a silently dispatched row in a terminal Run.
+        """
+
+        pending = connection.execute(
+            """
+            SELECT * FROM model_invocations
+            WHERE run_id = ? AND status = 'dispatched'
+            ORDER BY started_at, invocation_id
+            """,
+            (run_id,),
+        ).fetchall()
+        closed: list[str] = []
+        for invocation in pending:
+            invocation_id = str(invocation["invocation_id"])
+            error_code = "run_terminal_before_model_capture_completed"
+            error_message = (
+                f"Run reached {terminal_event_type} before the model "
+                "response was durably finalized"
+            )
+            updated = connection.execute(
+                """
+                UPDATE model_invocations
+                SET status = 'outcome_unknown', error_code = ?,
+                    error_message = ?, completed_at = ?
+                WHERE invocation_id = ? AND status = 'dispatched'
+                """,
+                (error_code, error_message, timestamp, invocation_id),
+            )
+            if updated.rowcount != 1:
+                continue
+            payload = {
+                "invocation_id": invocation_id,
+                "attempt_id": invocation["attempt_id"],
+                "step_id": invocation["step_id"],
+                "agent_id": invocation["agent_id"],
+                "status": "outcome_unknown",
+                "request_digest": invocation["request_digest"],
+                "response_digest": None,
+                "finish_reason": None,
+                "usage": {
+                    "prompt_tokens": None,
+                    "completion_tokens": None,
+                    "cache_read_tokens": None,
+                    "cache_write_tokens": None,
+                },
+                "error_code": error_code,
+            }
+            self._insert_model_invocation_event(
+                connection,
+                invocation_id=invocation_id,
+                event_type="outcome_unknown",
+                payload=payload,
+                created_at=timestamp,
+            )
+            self._append_event_in_transaction(
+                connection,
+                run_id,
+                RunEventDraft(
+                    event_id=(
+                        "run-terminal:model-invocation-outcome-unknown:"
+                        f"{invocation_id}"
+                    ),
+                    event_type="model.invocation.outcome_unknown",
+                    payload=payload,
+                    created_at=timestamp,
+                ),
+            )
+
+            self._record_model_capture_outcome_gap_in_transaction(
+                connection,
+                invocation=invocation,
+                detail_code=error_code,
+                suffix="run-terminal",
+                timestamp=timestamp,
+            )
+            closed.append(invocation_id)
+        return tuple(closed)
+
     def get_model_invocation(
         self, invocation_id: str
     ) -> ModelInvocationRecord | None:
@@ -7985,6 +8273,204 @@ class SQLiteRunJournal:
             ).fetchall()
         return tuple(self._model_invocation_from_row(row) for row in rows)
 
+    def list_model_invocation_retention_candidates(
+        self,
+        *,
+        now: float | None = None,
+        limit: int = 100,
+    ) -> tuple[str, ...]:
+        """Return a bounded, policy-aware plan without mutating evidence.
+
+        The immutable Attempt profile is the authority. Evidence-required
+        workloads are therefore excluded even when their documents are old.
+        Applying the plan is intentionally a separate, explicitly authorized
+        data-lifecycle operation.
+        """
+
+        if limit < 1:
+            raise ValueError("retention candidate limit must be positive")
+        timestamp = now if now is not None else time.time()
+        cutoff = timestamp - PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS
+        with self._lock:
+            rows = self._connection.execute(
+                """
+                SELECT model_invocations.invocation_id
+                FROM model_invocations
+                JOIN run_attempts
+                  ON run_attempts.attempt_id = model_invocations.attempt_id
+                WHERE model_invocations.status != 'dispatched'
+                  AND model_invocations.completed_at IS NOT NULL
+                  AND model_invocations.completed_at <= ?
+                  AND run_attempts.workload_kind = 'production'
+                  AND json_extract(
+                        run_attempts.workload_profile_json,
+                        '$.retention_policy_ref'
+                      ) = ?
+                  AND CASE
+                        WHEN json_valid(model_invocations.request_json)
+                        THEN json_extract(
+                            model_invocations.request_json,
+                            '$._eigent_retention.expired'
+                        ) IS NULL
+                        ELSE 1
+                      END
+                ORDER BY model_invocations.completed_at,
+                         model_invocations.invocation_id
+                LIMIT ?
+                """,
+                (cutoff, RETENTION_POLICY_PRODUCT_DEFAULT, limit),
+            ).fetchall()
+        return tuple(str(row["invocation_id"]) for row in rows)
+
+    def expire_model_invocation_documents(
+        self,
+        *,
+        now: float | None = None,
+        limit: int = 100,
+    ) -> ModelDocumentRetentionResult:
+        """Expire one bounded batch of product-default model documents.
+
+        The original request/response digests, usage, outcome, timing and
+        identity remain canonical. Only the large redacted documents become
+        a policy tombstone, with one durable evidence gap per invocation.
+        """
+
+        if limit < 1 or limit > 100:
+            raise ValueError("retention batch limit must be between 1 and 100")
+        timestamp = now if now is not None else time.time()
+        with self._write_transaction() as connection:
+            candidates = connection.execute(
+                """
+                SELECT model_invocations.*
+                FROM model_invocations
+                JOIN run_attempts
+                  ON run_attempts.attempt_id = model_invocations.attempt_id
+                WHERE model_invocations.status != 'dispatched'
+                  AND model_invocations.completed_at IS NOT NULL
+                  AND model_invocations.completed_at <= ?
+                  AND run_attempts.workload_kind = 'production'
+                  AND json_extract(
+                        run_attempts.workload_profile_json,
+                        '$.retention_policy_ref'
+                      ) = ?
+                  AND CASE
+                        WHEN json_valid(model_invocations.request_json)
+                        THEN json_extract(
+                            model_invocations.request_json,
+                            '$._eigent_retention.expired'
+                        ) IS NULL
+                        ELSE 1
+                      END
+                ORDER BY model_invocations.completed_at,
+                         model_invocations.invocation_id
+                LIMIT ?
+                """,
+                (
+                    timestamp - PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS,
+                    RETENTION_POLICY_PRODUCT_DEFAULT,
+                    limit,
+                ),
+            ).fetchall()
+            expired: list[str] = []
+            skipped: list[str] = []
+            for invocation in candidates:
+                invocation_id = str(invocation["invocation_id"])
+                try:
+                    with self._savepoint(
+                        connection, "model_document_retention"
+                    ):
+                        self._expire_model_invocation_document_in_transaction(
+                            connection,
+                            invocation=invocation,
+                            timestamp=timestamp,
+                        )
+                except Exception:
+                    skipped.append(invocation_id)
+                    logger.exception(
+                        "Skipping model-document retention candidate",
+                        extra={"invocation_id": invocation_id},
+                    )
+                    continue
+                expired.append(invocation_id)
+            remaining = int(
+                connection.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM model_invocations
+                    JOIN run_attempts
+                      ON run_attempts.attempt_id = model_invocations.attempt_id
+                    WHERE model_invocations.status != 'dispatched'
+                      AND model_invocations.completed_at IS NOT NULL
+                      AND model_invocations.completed_at <= ?
+                      AND run_attempts.workload_kind = 'production'
+                      AND json_extract(
+                            run_attempts.workload_profile_json,
+                            '$.retention_policy_ref'
+                          ) = ?
+                      AND CASE
+                            WHEN json_valid(model_invocations.request_json)
+                            THEN json_extract(
+                                model_invocations.request_json,
+                                '$._eigent_retention.expired'
+                            ) IS NULL
+                            ELSE 1
+                          END
+                    """,
+                    (
+                        timestamp - PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS,
+                        RETENTION_POLICY_PRODUCT_DEFAULT,
+                    ),
+                ).fetchone()[0]
+            )
+            return ModelDocumentRetentionResult(
+                expired_invocation_ids=tuple(expired),
+                skipped_invocation_ids=tuple(skipped),
+                remaining_candidate_count=remaining,
+            )
+
+    def _expire_model_invocation_document_in_transaction(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        invocation: sqlite3.Row,
+        timestamp: float,
+    ) -> None:
+        """Replace one retained document without mutating its Run timeline."""
+
+        invocation_id = str(invocation["invocation_id"])
+        connection.execute(
+            """
+            UPDATE model_invocations
+            SET request_json = ?,
+                response_json = CASE
+                    WHEN response_json IS NULL THEN NULL ELSE ? END,
+                redaction_version = redaction_version || '+retention-v1'
+            WHERE invocation_id = ?
+            """,
+            (
+                _MODEL_DOCUMENT_RETENTION_MARKER,
+                _MODEL_DOCUMENT_RETENTION_MARKER,
+                invocation_id,
+            ),
+        )
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO attempt_evidence_gaps(
+                gap_id, run_id, attempt_id, step_id, dimension,
+                reason_code, source, detail_code, created_at
+            ) VALUES (?, ?, ?, ?, 'model_decisions',
+                      'retention_expired', 'model_capture_retention',
+                      'model_invocation_document_expired', ?)
+            """,
+            (
+                f"retention-gap:{invocation_id}",
+                invocation["run_id"],
+                invocation["attempt_id"],
+                invocation["step_id"],
+                timestamp,
+            ),
+        )
+
     def list_model_invocation_events(
         self, invocation_id: str
     ) -> tuple[ModelInvocationEventRecord, ...]:
@@ -7999,6 +8485,132 @@ class SQLiteRunJournal:
         return tuple(
             self._model_invocation_event_from_row(row) for row in rows
         )
+
+    def record_attempt_evidence_gap(
+        self,
+        *,
+        gap_id: str,
+        run_id: str,
+        attempt_id: str,
+        step_id: str | None = None,
+        dimension: str,
+        reason_code: str,
+        source: str,
+        detail_code: str | None = None,
+        now: float | None = None,
+    ) -> AttemptEvidenceGapRecord:
+        """Persist one idempotent completeness gap and its lightweight event."""
+
+        if not gap_id.strip() or not source.strip():
+            raise ValueError("evidence gap id and source are required")
+        if dimension not in _EVIDENCE_DIMENSIONS:
+            raise ValueError(f"unsupported evidence dimension {dimension!r}")
+        if reason_code not in _EVIDENCE_GAP_REASON_CODES:
+            raise ValueError(
+                f"unsupported evidence gap reason {reason_code!r}"
+            )
+        safe_detail = detail_code.strip()[:160] if detail_code else None
+        if step_id is not None:
+            step_id = step_id.strip()
+            if not step_id:
+                raise ValueError("evidence gap step id cannot be blank")
+        timestamp = now if now is not None else time.time()
+        with self._write_transaction() as connection:
+            duplicate = connection.execute(
+                "SELECT * FROM attempt_evidence_gaps WHERE gap_id = ?",
+                (gap_id,),
+            ).fetchone()
+            expected = (
+                run_id,
+                attempt_id,
+                step_id,
+                dimension,
+                reason_code,
+                source,
+                safe_detail,
+            )
+            if duplicate is not None:
+                persisted = (
+                    duplicate["run_id"],
+                    duplicate["attempt_id"],
+                    duplicate["step_id"],
+                    duplicate["dimension"],
+                    duplicate["reason_code"],
+                    duplicate["source"],
+                    duplicate["detail_code"],
+                )
+                if persisted != expected:
+                    raise IdempotencyConflictError(
+                        "evidence gap id was reused with different input"
+                    )
+                return self._attempt_evidence_gap_from_row(duplicate)
+
+            attempt = connection.execute(
+                "SELECT run_id FROM run_attempts WHERE attempt_id = ?",
+                (attempt_id,),
+            ).fetchone()
+            if attempt is None or attempt["run_id"] != run_id:
+                raise IdempotencyConflictError(
+                    "evidence gap Attempt does not belong to the Run"
+                )
+            if step_id is not None:
+                step_exists = self._step_belongs_to_attempt_in_transaction(
+                    connection,
+                    run_id=run_id,
+                    step_id=step_id,
+                    attempt_id=attempt_id,
+                )
+                if not step_exists:
+                    raise IdempotencyConflictError(
+                        "evidence gap Step does not belong to the Run"
+                    )
+            connection.execute(
+                """
+                INSERT INTO attempt_evidence_gaps(
+                    gap_id, run_id, attempt_id, step_id, dimension,
+                    reason_code, source, detail_code, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (gap_id, *expected, timestamp),
+            )
+            payload = {
+                "gap_id": gap_id,
+                "attempt_id": attempt_id,
+                "step_id": step_id,
+                "dimension": dimension,
+                "reason_code": reason_code,
+                "source": source,
+                "detail_code": safe_detail,
+            }
+            self._append_event_in_transaction(
+                connection,
+                run_id,
+                RunEventDraft(
+                    event_id=f"attempt-evidence-gap:{gap_id}",
+                    event_type="attempt.evidence_gap_recorded",
+                    payload=payload,
+                    created_at=timestamp,
+                ),
+            )
+            row = connection.execute(
+                "SELECT * FROM attempt_evidence_gaps WHERE gap_id = ?",
+                (gap_id,),
+            ).fetchone()
+            assert row is not None
+            return self._attempt_evidence_gap_from_row(row)
+
+    def list_attempt_evidence_gaps(
+        self, attempt_id: str
+    ) -> tuple[AttemptEvidenceGapRecord, ...]:
+        with self._lock:
+            rows = self._connection.execute(
+                """
+                SELECT * FROM attempt_evidence_gaps
+                WHERE attempt_id = ? ORDER BY created_at, gap_id
+                """,
+                (attempt_id,),
+            ).fetchall()
+        return tuple(self._attempt_evidence_gap_from_row(row) for row in rows)
 
     def list_runs(
         self,
@@ -9642,6 +10254,72 @@ class SQLiteRunJournal:
                 for draft in drafts
             ]
 
+    def append_event_with_workforce_step_projection(
+        self,
+        run_id: str,
+        draft: RunEventDraft,
+        *,
+        expected_project_id: str,
+    ) -> CommittedRunEvent:
+        """Append a subtask fact plus its Step projection or a durable gap.
+
+        Producer-side Workforce code authors the Step before dispatch. This
+        transaction is the compatibility path for older or restored streams
+        that contain only legacy subtask events. A savepoint prevents a failed
+        projection from leaking a partial Step lifecycle; the legacy fact and
+        a bounded projection-gap event still commit so UI narration is not
+        misreported as a canonical write failure.
+        """
+
+        with self._write_transaction() as connection:
+            event = self._append_event_in_transaction(
+                connection,
+                run_id,
+                draft,
+                expected_project_id=expected_project_id,
+            )
+            try:
+                with self._savepoint(connection, "workforce_step_projection"):
+                    self._project_workforce_subtask_step_in_transaction(
+                        connection,
+                        run_id=run_id,
+                        event=event,
+                    )
+            except Exception as exc:
+                logger.exception(
+                    "Workforce Step compatibility projection failed",
+                    extra={
+                        "run_id": run_id,
+                        "source_event_id": event.event_id,
+                        "source_event_type": event.event_type,
+                    },
+                )
+                gap_digest = hashlib.sha256(
+                    event.event_id.encode("utf-8")
+                ).hexdigest()[:24]
+                self._append_event_in_transaction(
+                    connection,
+                    run_id,
+                    RunEventDraft(
+                        event_id=(
+                            f"projection-gap:workforce-step:{gap_digest}"
+                        ),
+                        event_type="projection.workforce_step_failed",
+                        payload={
+                            "projection": "workforce_step.v1",
+                            "source_event_id": event.event_id,
+                            "source_event_type": event.event_type,
+                            "task_id": str(event.payload.get("task_id") or "")[
+                                :160
+                            ],
+                            "error_type": type(exc).__name__[:160],
+                            "retryable": True,
+                        },
+                        created_at=event.created_at,
+                    ),
+                )
+            return event
+
     def append_artifact_manifest_events(
         self,
         run_id: str,
@@ -9857,6 +10535,13 @@ class SQLiteRunJournal:
                     f"({blocking_tool['tool_call_id']})"
                 )
 
+            self._close_dispatched_model_invocations_in_transaction(
+                connection,
+                run_id=run_id,
+                terminal_event_type=terminal.event_type,
+                timestamp=terminal.created_at,
+            )
+
             # Artifact discovery happens outside this short transaction and
             # two terminal paths may race. Pin the newest committed manifest
             # under the same writer lock as run.completed; never trust the
@@ -9926,6 +10611,12 @@ class SQLiteRunJournal:
             latest_manifest = self._latest_artifact_manifest_in_transaction(
                 connection,
                 run_id,
+            )
+            self._close_dispatched_model_invocations_in_transaction(
+                connection,
+                run_id=run_id,
+                terminal_event_type=draft.event_type,
+                timestamp=draft.created_at,
             )
             enriched = RunEventDraft(
                 event_id=draft.event_id,
@@ -9999,6 +10690,7 @@ class SQLiteRunJournal:
         *,
         after_sequence: int = 0,
         limit: int | None = None,
+        event_type_prefix: str | None = None,
     ) -> list[CommittedRunEvent]:
         if limit is not None and limit < 1:
             raise ValueError("event query limit must be positive")
@@ -10007,9 +10699,15 @@ class SQLiteRunJournal:
                    payload_json, legacy_step, created_at
             FROM run_events
             WHERE run_id = ? AND sequence > ?
-            ORDER BY sequence
         """
         parameters: list[Any] = [run_id, after_sequence]
+        if event_type_prefix is not None:
+            normalized_prefix = event_type_prefix.strip()
+            if not normalized_prefix:
+                raise ValueError("event type prefix cannot be blank")
+            query += " AND event_type LIKE ?"
+            parameters.append(f"{normalized_prefix}%")
+        query += " ORDER BY sequence"
         if limit is not None:
             query += " LIMIT ?"
             parameters.append(limit)
@@ -11521,6 +12219,7 @@ class SQLiteRunJournal:
         activate: bool = False,
         attempt_id: str | None = None,
         environment: AttemptEnvironmentBinding | None = None,
+        workload_profile: WorkloadProfileRecord | None = None,
         now: float | None = None,
     ) -> RunAttemptRecord:
         if not request_id.strip() or not reason.strip():
@@ -11528,6 +12227,8 @@ class SQLiteRunJournal:
         timestamp = now if now is not None else time.time()
         identifier = attempt_id or str(uuid.uuid4())
         environment_values = self._attempt_environment_values(environment)
+        workload = workload_profile or default_workload_profile()
+        workload_values = self._attempt_workload_values(workload)
         with self._write_transaction() as connection:
             run = connection.execute(
                 "SELECT * FROM runs WHERE run_id = ?", (run_id,)
@@ -11559,6 +12260,16 @@ class SQLiteRunJournal:
                     raise IdempotencyConflictError(
                         f"attempt request_id {request_id!r} was reused with "
                         "a different environment"
+                    )
+                persisted_workload = (
+                    duplicate["workload_kind"],
+                    duplicate["workload_profile_json"],
+                    duplicate["workload_profile_digest"],
+                )
+                if persisted_workload != workload_values:
+                    raise IdempotencyConflictError(
+                        f"attempt request_id {request_id!r} was reused with "
+                        "a different workload profile"
                     )
                 # An idempotent row loaded from SQLite is audit/recovery data,
                 # not a fresh control-plane attestation. The original process
@@ -11733,10 +12444,12 @@ class SQLiteRunJournal:
                     last_consumer_heartbeat_at, environment_spec_id,
                     environment_spec_digest, bundle_revision_id,
                     permission_profile_revision, thinking_effort_requested,
-                    thinking_effort_effective, provider_capability_revision
+                    thinking_effort_effective, provider_capability_revision,
+                    workload_kind, workload_profile_json,
+                    workload_profile_digest
                 ) VALUES (
                     ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?, 0, ?,
-                    ?, ?, ?, ?, ?, ?, ?
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
                 )
                 """,
                 (
@@ -11750,6 +12463,7 @@ class SQLiteRunJournal:
                     run["timeout_policy_version"],
                     timestamp if activate else None,
                     *environment_values,
+                    *workload_values,
                 ),
             )
             try:
@@ -11807,6 +12521,8 @@ class SQLiteRunJournal:
                         "reason": reason,
                         "status": status,
                         "policy_version": run["timeout_policy_version"],
+                        "workload_profile": workload_profile_payload(workload),
+                        "workload_profile_digest": workload_values[2],
                         **environment_payload,
                     },
                     created_at=timestamp,
@@ -14807,6 +15523,7 @@ class SQLiteRunJournal:
                         payload = {
                             "invocation_id": invocation["invocation_id"],
                             "attempt_id": invocation["attempt_id"],
+                            "step_id": invocation["step_id"],
                             "agent_id": invocation["agent_id"],
                             "status": "outcome_unknown",
                             "request_digest": invocation["request_digest"],
@@ -14839,6 +15556,13 @@ class SQLiteRunJournal:
                                 payload=payload,
                                 created_at=timestamp,
                             ),
+                        )
+                        self._record_model_capture_outcome_gap_in_transaction(
+                            connection,
+                            invocation=invocation,
+                            detail_code="brain_restart_after_dispatch",
+                            suffix="startup-reconciliation",
+                            timestamp=timestamp,
                         )
                 except Exception:
                     logger.exception(
@@ -15364,6 +16088,38 @@ class SQLiteRunJournal:
                 """,
                 (timestamp,),
             )
+        try:
+            retention = self.expire_model_invocation_documents(
+                now=timestamp,
+                limit=100,
+            )
+        except Exception:
+            # Retention maintenance cannot make the Desktop unavailable. The
+            # immutable policy query is level-triggered and will retry on the
+            # next startup.
+            logger.exception(
+                "Startup model-document retention maintenance failed"
+            )
+        else:
+            if retention.remaining_candidate_count:
+                logger.warning(
+                    "Model-document retention batch left %s candidate(s); "
+                    "expired=%s skipped=%s",
+                    retention.remaining_candidate_count,
+                    len(retention.expired_invocation_ids),
+                    len(retention.skipped_invocation_ids),
+                )
+            elif (
+                retention.expired_invocation_ids
+                or retention.skipped_invocation_ids
+            ):
+                logger.info(
+                    "Model-document retention batch completed; "
+                    "expired=%s skipped=%s remaining=0",
+                    len(retention.expired_invocation_ids),
+                    len(retention.skipped_invocation_ids),
+                )
+
         return StartupReconciliationResult(
             interrupted_run_ids=tuple(interrupted_runs),
             completed_cancel_run_ids=tuple(completed_cancels),
@@ -17476,6 +18232,316 @@ class SQLiteRunJournal:
             )
         return snapshots
 
+    def _project_workforce_subtask_step_in_transaction(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        run_id: str,
+        event: CommittedRunEvent,
+    ) -> None:
+        """Project one legacy Workforce event without leaving the txn."""
+
+        self._apply_workforce_subtask_step_in_transaction(
+            connection,
+            run_id=run_id,
+            event_type=event.event_type,
+            payload=event.payload,
+            provenance_source="legacy_workforce_projection",
+        )
+
+    def persist_workforce_subtask_step(
+        self,
+        *,
+        run_id: str,
+        expected_project_id: str,
+        task_id: str,
+        title: str,
+        agent_id: str | None,
+        phase: str,
+        summary: str | None = None,
+    ) -> str:
+        """Author one Workforce Step transition in a single transaction.
+
+        The producer calls this before publishing queue/dispatch UI facts.
+        State lookup and transition commit share one SQLite writer lock, so a
+        concurrent legacy projection cannot race the producer's decision.
+        """
+
+        event_type = {
+            "queued": "subtask.queued",
+            "running": "subtask.started",
+            "completed": "subtask.completed",
+            "failed": "subtask.failed",
+            "cancelled": "subtask.cancelled",
+        }.get(phase)
+        if event_type is None:
+            raise ValueError(f"unsupported Workforce Step phase {phase!r}")
+        normalized_task_id = task_id.strip()
+        if not normalized_task_id:
+            raise ValueError("Workforce task id is required")
+
+        from app.run_runtime.step_coordinator import stable_step_id
+
+        with self._write_transaction() as connection:
+            run = connection.execute(
+                "SELECT project_id FROM runs WHERE run_id = ?", (run_id,)
+            ).fetchone()
+            if run is None:
+                raise RunNotFoundError(f"run_id {run_id!r} does not exist")
+            if run["project_id"] != expected_project_id:
+                raise IdempotencyConflictError(
+                    f"run_id {run_id!r} belongs to another project"
+                )
+            self._apply_workforce_subtask_step_in_transaction(
+                connection,
+                run_id=run_id,
+                event_type=event_type,
+                payload={
+                    "task_id": normalized_task_id,
+                    "display_title": title,
+                    "display_summary": summary,
+                    "assignee_id": agent_id,
+                },
+                provenance_source="workforce_dispatch",
+            )
+        return stable_step_id(run_id, f"subtask:{normalized_task_id}")
+
+    def _apply_workforce_subtask_step_in_transaction(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        run_id: str,
+        event_type: str,
+        payload: Mapping[str, Any],
+        provenance_source: str,
+    ) -> None:
+        """Apply one Workforce lifecycle fact to authored Step history."""
+
+        if event_type not in {
+            "subtask.created",
+            "subtask.queued",
+            "subtask.started",
+            "subtask.completed",
+            "subtask.failed",
+            "subtask.cancelled",
+        }:
+            return
+        task_id = str(payload.get("task_id") or "").strip()
+        if not task_id:
+            return
+
+        from app.run_runtime.step_coordinator import (
+            stable_step_id,
+            step_event_draft,
+        )
+
+        run = connection.execute(
+            "SELECT active_attempt_id FROM runs WHERE run_id = ?", (run_id,)
+        ).fetchone()
+        if run is None:
+            raise RunNotFoundError(f"run_id {run_id!r} does not exist")
+
+        plan_item_id = f"subtask:{task_id}"
+        step_id = stable_step_id(run_id, plan_item_id)
+        snapshots = self._latest_step_snapshots_in_transaction(
+            connection,
+            run_id=run_id,
+        )
+        snapshot = next(
+            (
+                candidate
+                for candidate in snapshots
+                if candidate["step"].get("step_id") == step_id
+            ),
+            None,
+        )
+        semantic = payload.get("semantic")
+        actor = semantic.get("actor") if isinstance(semantic, dict) else None
+        actor_id = (
+            str(actor.get("id") or "").strip()
+            if isinstance(actor, dict)
+            else ""
+        )
+        agent_id = (
+            str(payload.get("assignee_id") or "").strip() or actor_id or None
+        )
+        title = str(payload.get("display_title") or "Subtask")
+        summary = str(payload.get("display_summary") or "").strip() or None
+
+        def append_step(
+            *,
+            step: dict[str, Any],
+            transition: str,
+            status: str,
+            transition_summary: str | None,
+            reason_code: str | None = None,
+        ) -> None:
+            owner = step.get("owner")
+            owner = owner if isinstance(owner, dict) else {}
+            persisted_owner_kind = str(owner.get("kind") or "workforce")
+            if persisted_owner_kind not in {
+                "single_agent",
+                "subagent",
+                "workforce",
+                "system",
+            }:
+                persisted_owner_kind = "workforce"
+            persisted_source = str(step.get("source") or "workforce")
+            if persisted_source not in {"plan", "subagent", "workforce"}:
+                persisted_source = "workforce"
+            self._append_event_in_transaction(
+                connection,
+                run_id,
+                step_event_draft(
+                    run_id=run_id,
+                    attempt_id=(
+                        str(run["active_attempt_id"])
+                        if run["active_attempt_id"]
+                        else None
+                    ),
+                    step_id=step_id,
+                    plan_item_id=str(step.get("plan_item_id") or plan_item_id),
+                    parent_step_id=(
+                        str(step["parent_step_id"])
+                        if step.get("parent_step_id")
+                        else None
+                    ),
+                    title=str(step.get("title") or title),
+                    summary=transition_summary,
+                    ordinal=int(step.get("ordinal") or 0),
+                    agent_id=(
+                        str(owner["agent_id"])
+                        if owner.get("agent_id")
+                        else agent_id
+                    ),
+                    event=transition,
+                    status=status,  # type: ignore[arg-type]
+                    reason_code=reason_code,
+                    provenance_source=provenance_source,
+                    authored_by="system",
+                    owner_kind=persisted_owner_kind,  # type: ignore[arg-type]
+                    source=persisted_source,  # type: ignore[arg-type]
+                ),
+            )
+
+        if snapshot is None:
+            if event_type not in {
+                "subtask.created",
+                "subtask.queued",
+                "subtask.started",
+            }:
+                # Parent completion facts and incomplete historical streams do
+                # not prove that a delegated child Step ever existed.
+                return
+            step = {
+                "step_id": step_id,
+                "plan_item_id": plan_item_id,
+                "parent_step_id": None,
+                "title": title,
+                "ordinal": max(
+                    (
+                        int(candidate["step"].get("ordinal") or 0)
+                        for candidate in snapshots
+                    ),
+                    default=0,
+                )
+                + 1,
+                "owner": {"kind": "workforce", "agent_id": agent_id},
+                "source": "workforce",
+            }
+            append_step(
+                step=step,
+                transition="created",
+                status="pending",
+                transition_summary=None,
+            )
+            if event_type == "subtask.started":
+                append_step(
+                    step=step,
+                    transition="started",
+                    status="running",
+                    transition_summary=summary or "Delegated work started.",
+                )
+            return
+
+        step = snapshot["step"]
+        current_status = str(step.get("status") or "pending")
+        if event_type in {"subtask.created", "subtask.queued"}:
+            return
+        if event_type == "subtask.started":
+            transition = {
+                "pending": "started",
+                "blocked": "resumed",
+                "interrupted": "resumed",
+            }.get(current_status)
+            if transition is not None:
+                append_step(
+                    step=step,
+                    transition=transition,
+                    status="running",
+                    transition_summary=summary or "Delegated work started.",
+                )
+            return
+
+        outcome = {
+            "subtask.completed": "completed",
+            "subtask.failed": "failed",
+            "subtask.cancelled": "cancelled",
+        }[event_type]
+        allowed = {"pending", "running", "blocked"}
+        if outcome == "cancelled":
+            allowed.add("interrupted")
+        if current_status not in allowed:
+            return
+        append_step(
+            step=step,
+            transition=outcome,
+            status=outcome,
+            transition_summary=summary,
+            reason_code=(
+                "workforce_failed"
+                if outcome == "failed"
+                else "workforce_cancelled"
+                if outcome == "cancelled"
+                else None
+            ),
+        )
+
+    @staticmethod
+    def _step_belongs_to_attempt_in_transaction(
+        connection: sqlite3.Connection,
+        *,
+        run_id: str,
+        step_id: str,
+        attempt_id: str | None,
+    ) -> bool:
+        """Return whether canonical Step history contains this binding.
+
+        A stable Step identity may receive events across multiple Attempts.
+        Correlation validation therefore scans historical Step facts instead
+        of consulting only the newest replay snapshot.
+        """
+
+        rows = connection.execute(
+            """
+            SELECT payload_json FROM run_events
+            WHERE run_id = ? AND event_type LIKE 'step.%'
+            ORDER BY sequence DESC
+            """,
+            (run_id,),
+        ).fetchall()
+        for row in rows:
+            try:
+                payload = json.loads(row["payload_json"])
+            except (TypeError, ValueError):
+                continue
+            step = payload.get("step")
+            if not isinstance(step, dict) or step.get("step_id") != step_id:
+                continue
+            if attempt_id is None or payload.get("attempt_id") == attempt_id:
+                return True
+        return False
+
     @staticmethod
     def _interaction_step_id_in_transaction(
         connection: sqlite3.Connection,
@@ -17579,10 +18645,15 @@ class SQLiteRunJournal:
         owner = step.get("owner")
         owner = owner if isinstance(owner, dict) else {}
         owner_kind = str(owner.get("kind") or "single_agent")
-        if owner_kind not in {"single_agent", "subagent", "system"}:
+        if owner_kind not in {
+            "single_agent",
+            "subagent",
+            "workforce",
+            "system",
+        }:
             owner_kind = "single_agent"
         step_source = str(step.get("source") or "plan")
-        if step_source not in {"plan", "subagent"}:
+        if step_source not in {"plan", "subagent", "workforce"}:
             step_source = "plan"
         from app.run_runtime.step_coordinator import step_event_draft
 
@@ -17781,6 +18852,12 @@ class SQLiteRunJournal:
                 f"found {current_version}"
             )
         if run_status in {"interrupted", "completed", "failed", "cancelled"}:
+            self._close_dispatched_model_invocations_in_transaction(
+                connection,
+                run_id=run_id,
+                terminal_event_type=draft.event_type,
+                timestamp=draft.created_at,
+            )
             self._append_step_terminals_for_run_transition_in_transaction(
                 connection,
                 run_id=run_id,
@@ -18141,6 +19218,51 @@ ADD COLUMN source TEXT NOT NULL DEFAULT 'local'
                     "ALTER TABLE follow_up_requests\n"
                     "ADD COLUMN review_handoff_ids_json TEXT NOT NULL "
                     "DEFAULT '[]';\n",
+                    "",
+                )
+            self._connection.executescript(migration)
+        if version < 34:
+            attempt_columns = {
+                row["name"]
+                for row in self._connection.execute(
+                    "PRAGMA table_info(run_attempts)"
+                ).fetchall()
+            }
+            migration = _MIGRATION_V34
+            for column, statement in (
+                (
+                    "workload_kind",
+                    "ALTER TABLE run_attempts\n"
+                    "ADD COLUMN workload_kind TEXT NOT NULL DEFAULT "
+                    "'production'\n"
+                    "    CHECK(workload_kind IN "
+                    "('production', 'test', 'ab', 'rollout'));\n",
+                ),
+                (
+                    "workload_profile_json",
+                    "ALTER TABLE run_attempts\n"
+                    "ADD COLUMN workload_profile_json TEXT NOT NULL\n"
+                    '    DEFAULT \'{"budget_policy_ref":"budget.product-default.v1","capture_policy_ref":"capture.best-effort.v1","isolation_policy_ref":"isolation.product-default.v1","network_policy_ref":"network.product-default.v1","profile_version":"1","retention_policy_ref":"retention.product-default.v1","schema_version":1,"verifier_policy_ref":"verifier.noop.v1","workload_kind":"production"}\';\n',
+                ),
+                (
+                    "workload_profile_digest",
+                    "ALTER TABLE run_attempts\n"
+                    "ADD COLUMN workload_profile_digest TEXT NOT NULL\n"
+                    "    DEFAULT '4786bb51388abddfbbe18decc88ada3e3e896b4aa9967970c2b99865d4999302'\n"
+                    "    CHECK(length(workload_profile_digest) = 64);\n",
+                ),
+            ):
+                if column in attempt_columns:
+                    migration = migration.replace(statement, "")
+            model_invocation_columns = {
+                row["name"]
+                for row in self._connection.execute(
+                    "PRAGMA table_info(model_invocations)"
+                ).fetchall()
+            }
+            if "step_id" in model_invocation_columns:
+                migration = migration.replace(
+                    "ALTER TABLE model_invocations ADD COLUMN step_id TEXT;\n",
                     "",
                 )
             self._connection.executescript(migration)
@@ -18506,6 +19628,17 @@ ADD COLUMN source TEXT NOT NULL DEFAULT 'local'
 
     @staticmethod
     def _attempt_from_row(row: sqlite3.Row) -> RunAttemptRecord:
+        workload_profile = workload_profile_from_payload(
+            json.loads(row["workload_profile_json"])
+        )
+        if workload_profile.workload_kind != row["workload_kind"]:
+            raise RunJournalError("persisted WorkloadProfile kind mismatch")
+        persisted_workload_digest = row["workload_profile_digest"]
+        if (
+            workload_profile_digest(workload_profile)
+            != persisted_workload_digest
+        ):
+            raise RunJournalError("persisted WorkloadProfile digest mismatch")
         return RunAttemptRecord(
             attempt_id=row["attempt_id"],
             run_id=row["run_id"],
@@ -18533,6 +19666,8 @@ ADD COLUMN source TEXT NOT NULL DEFAULT 'local'
             thinking_effort_requested=row["thinking_effort_requested"],
             thinking_effort_effective=row["thinking_effort_effective"],
             provider_capability_revision=row["provider_capability_revision"],
+            workload_profile=workload_profile,
+            workload_profile_digest=persisted_workload_digest,
         )
 
     @staticmethod
@@ -18568,6 +19703,17 @@ ADD COLUMN source TEXT NOT NULL DEFAULT 'local'
             environment.thinking_effort_requested,
             environment.thinking_effort_effective,
             environment.provider_capability_revision,
+        )
+
+    @staticmethod
+    def _attempt_workload_values(
+        profile: WorkloadProfileRecord,
+    ) -> tuple[str, str, str]:
+        payload = workload_profile_payload(profile)
+        return (
+            profile.workload_kind,
+            canonical_json(payload),
+            workload_profile_digest(profile),
         )
 
     @staticmethod
@@ -19423,6 +20569,7 @@ ADD COLUMN source TEXT NOT NULL DEFAULT 'local'
             invocation_id=row["invocation_id"],
             run_id=row["run_id"],
             attempt_id=row["attempt_id"],
+            step_id=row["step_id"],
             agent_id=row["agent_id"],
             logical_call_id=row["logical_call_id"],
             retry_index=int(row["retry_index"]),
@@ -19486,6 +20633,22 @@ ADD COLUMN source TEXT NOT NULL DEFAULT 'local'
             event_index=int(row["event_index"]),
             event_type=row["event_type"],
             payload=json.loads(row["payload_json"]),
+            created_at=float(row["created_at"]),
+        )
+
+    @staticmethod
+    def _attempt_evidence_gap_from_row(
+        row: sqlite3.Row,
+    ) -> AttemptEvidenceGapRecord:
+        return AttemptEvidenceGapRecord(
+            gap_id=row["gap_id"],
+            run_id=row["run_id"],
+            attempt_id=row["attempt_id"],
+            step_id=row["step_id"],
+            dimension=row["dimension"],
+            reason_code=row["reason_code"],
+            source=row["source"],
+            detail_code=row["detail_code"],
             created_at=float(row["created_at"]),
         )
 

--- a/backend/app/run_runtime/step_coordinator.py
+++ b/backend/app/run_runtime/step_coordinator.py
@@ -42,8 +42,8 @@ StepStatus = Literal[
     "cancelled",
     "interrupted",
 ]
-StepOwnerKind = Literal["single_agent", "subagent", "system"]
-StepSource = Literal["plan", "subagent"]
+StepOwnerKind = Literal["single_agent", "subagent", "workforce", "system"]
+StepSource = Literal["plan", "subagent", "workforce"]
 
 TERMINAL_STEP_STATUSES = frozenset({"completed", "failed", "cancelled"})
 
@@ -224,9 +224,9 @@ class RunStepCoordinator:
 
     def replay(self, run_id: str) -> dict[str, StepSnapshot]:
         snapshots: dict[str, StepSnapshot] = {}
-        for event in self._journal.list_events(run_id):
-            if not event.event_type.startswith("step."):
-                continue
+        for event in self._journal.list_events(
+            run_id, event_type_prefix="step."
+        ):
             payload = event.payload
             raw = payload.get("step")
             if not isinstance(raw, dict):
@@ -238,10 +238,15 @@ class RunStepCoordinator:
             owner = raw.get("owner")
             owner = owner if isinstance(owner, dict) else {}
             owner_kind = str(owner.get("kind") or "single_agent")
-            if owner_kind not in {"single_agent", "subagent", "system"}:
+            if owner_kind not in {
+                "single_agent",
+                "subagent",
+                "workforce",
+                "system",
+            }:
                 owner_kind = "single_agent"
             source = str(raw.get("source") or "plan")
-            if source not in {"plan", "subagent"}:
+            if source not in {"plan", "subagent", "workforce"}:
                 source = "plan"
             snapshots[step_id] = StepSnapshot(
                 step_id=step_id,
@@ -348,6 +353,8 @@ class RunStepCoordinator:
         title: str,
         agent_id: str | None,
         start: bool = True,
+        owner_kind: StepOwnerKind = "subagent",
+        source: StepSource = "subagent",
     ) -> str:
         """Create the Step owned by one delegated subtask."""
 
@@ -393,9 +400,13 @@ class RunStepCoordinator:
                 agent_id=agent_id,
                 event="created",
                 status="pending",
-                provenance_source="subagent_dispatch",
-                owner_kind="subagent",
-                source="subagent",
+                provenance_source=(
+                    "workforce_dispatch"
+                    if owner_kind == "workforce"
+                    else "subagent_dispatch"
+                ),
+                owner_kind=owner_kind,
+                source=source,
             )
         ]
         if start:
@@ -412,9 +423,13 @@ class RunStepCoordinator:
                     agent_id=agent_id,
                     event="started",
                     status="running",
-                    provenance_source="subagent_dispatch",
-                    owner_kind="subagent",
-                    source="subagent",
+                    provenance_source=(
+                        "workforce_dispatch"
+                        if owner_kind == "workforce"
+                        else "subagent_dispatch"
+                    ),
+                    owner_kind=owner_kind,
+                    source=source,
                 )
             )
         self._journal.append_events(
@@ -469,7 +484,11 @@ class RunStepCoordinator:
                 agent_id=snapshot.agent_id,
                 event=event,
                 status=status,  # type: ignore[arg-type]
-                provenance_source="subagent_dispatch",
+                provenance_source=(
+                    "workforce_dispatch"
+                    if snapshot.owner_kind == "workforce"
+                    else "subagent_dispatch"
+                ),
                 owner_kind=snapshot.owner_kind,
                 source=snapshot.source,
             ),
@@ -530,7 +549,11 @@ class RunStepCoordinator:
                 event=event,
                 status=status,  # type: ignore[arg-type]
                 reason_code=reason,
-                provenance_source="subagent_dispatch",
+                provenance_source=(
+                    "workforce_dispatch"
+                    if snapshot.owner_kind == "workforce"
+                    else "subagent_dispatch"
+                ),
                 owner_kind=snapshot.owner_kind,
                 source=snapshot.source,
             )
@@ -559,7 +582,11 @@ class RunStepCoordinator:
                             if outcome == "failed"
                             else "child_step_outcome_unknown"
                         ),
-                        provenance_source="subagent_dispatch",
+                        provenance_source=(
+                            "workforce_dispatch"
+                            if parent.owner_kind == "workforce"
+                            else "subagent_dispatch"
+                        ),
                         authored_by="system",
                         owner_kind=parent.owner_kind,
                         source=parent.source,

--- a/backend/app/utils/workforce.py
+++ b/backend/app/utils/workforce.py
@@ -15,6 +15,7 @@
 import asyncio
 import logging
 from collections.abc import Generator
+from typing import Literal
 
 from camel.agents import ChatAgent
 from camel.societies.workforce.base import BaseNode
@@ -43,6 +44,9 @@ from camel.tasks.task import Task, TaskState, validate_task_content
 from app.agent.listen_chat_agent import ListenChatAgent
 from app.component import code
 from app.exception.exception import UserException
+from app.run_context import get_current_run_context
+from app.run_journal.runtime import get_default_run_journal
+from app.run_runtime.step_coordinator import stable_step_id
 from app.run_runtime.timeout_config import (
     normalize_optional_timeout_seconds,
     optional_timeout_seconds_from_env,
@@ -65,6 +69,72 @@ logger = logging.getLogger("workforce")
 
 _ANALYZE_TASK_MAX_RETRIES = 3
 _WORKFORCE_PROGRESS_POLL_SECONDS = 30.0
+
+_WorkforceStepPhase = Literal[
+    "queued", "running", "completed", "failed", "cancelled"
+]
+
+
+async def _persist_workforce_subtask_step(
+    task_lock,
+    *,
+    task_id: str,
+    title: str,
+    agent_id: str | None,
+    phase: _WorkforceStepPhase,
+    summary: str | None = None,
+) -> str | None:
+    """Persist the delegated Step before publishing its UI/runtime fact.
+
+    The TaskLock context is the fallback because CAMEL background tasks may
+    outlive the ContextVar scope that admitted the Run. Persistence remains
+    fail-open for user experience, but the task is explicitly marked degraded
+    so the loss is observable instead of silently mis-correlated.
+    """
+
+    context = get_current_run_context() or task_lock.run_context
+    if context is None:
+        return None
+    run_id_value = getattr(context, "run_id", None)
+    project_id_value = getattr(context, "project_id", None)
+    if not isinstance(run_id_value, str) or not isinstance(
+        project_id_value, str
+    ):
+        return None
+    run_id = run_id_value.strip()
+    project_id = project_id_value.strip()
+    if not run_id or not project_id:
+        return None
+    step_id = stable_step_id(run_id, f"subtask:{task_id}")
+
+    def persist() -> None:
+        get_default_run_journal().persist_workforce_subtask_step(
+            run_id=run_id,
+            expected_project_id=project_id,
+            task_id=task_id,
+            title=title,
+            agent_id=agent_id,
+            phase=phase,
+            summary=summary,
+        )
+
+    try:
+        await asyncio.to_thread(persist)
+    except Exception as exc:
+        task_lock.mark_local_history_degraded(
+            f"workforce Step {phase} persistence failed: {exc}"
+        )
+        logger.exception(
+            "Failed to persist Workforce subtask Step",
+            extra={
+                "run_id": run_id,
+                "task_id": task_id,
+                "step_id": step_id,
+                "phase": phase,
+            },
+        )
+        return None
+    return step_id
 
 
 def default_workforce_task_timeout() -> float | None:
@@ -585,6 +655,13 @@ class Workforce(BaseWorkforce):
                 )
                 continue  # Skip sending notification for unmapped worker
 
+            await _persist_workforce_subtask_step(
+                task_lock,
+                task_id=item.task_id,
+                title=content,
+                agent_id=agent_id,
+                phase="queued",
+            )
             # Asynchronously send waiting notification
             task = asyncio.create_task(
                 task_lock.put_queue(
@@ -643,7 +720,14 @@ class Workforce(BaseWorkforce):
                     f"Available workers: "
                     f"{workers}"
                 )
-            else:
+            await _persist_workforce_subtask_step(
+                task_lock,
+                task_id=task.id,
+                title=task.content,
+                agent_id=agent_id,
+                phase="running",
+            )
+            if agent_id is not None:
                 await task_lock.put_queue(
                     ActionAssignTaskData(
                         action=Action.assign_task,
@@ -783,6 +867,22 @@ class Workforce(BaseWorkforce):
         logger.info(f"[TASK-RESULT] Content: {content_preview}")
         logger.info(f"[TASK-RESULT] Result: {result_preview}")
 
+        if not is_main_task:
+            assigned_worker_id = getattr(task, "assigned_worker_id", None)
+            agent_id = (
+                self._get_agent_id_from_node_id(assigned_worker_id)
+                if assigned_worker_id
+                else None
+            )
+            await _persist_workforce_subtask_step(
+                task_lock,
+                task_id=task.id,
+                title=task.content or "Subtask",
+                agent_id=agent_id,
+                phase="completed",
+                summary=str(task.result or "") or None,
+            )
+
         # Send to frontend
         task_data = {
             "task_id": task.id,
@@ -852,6 +952,22 @@ class Workforce(BaseWorkforce):
                     break
 
         task_lock = get_task_lock(self.api_task_id)
+        is_main_task = self._task and task.id == self._task.id
+        if not is_main_task:
+            assigned_worker_id = getattr(task, "assigned_worker_id", None)
+            agent_id = (
+                self._get_agent_id_from_node_id(assigned_worker_id)
+                if assigned_worker_id
+                else None
+            )
+            await _persist_workforce_subtask_step(
+                task_lock,
+                task_id=task.id,
+                title=task.content or "Subtask",
+                agent_id=agent_id,
+                phase="failed",
+                summary=str(error_message or task.result or "") or None,
+            )
         await task_lock.put_queue(
             ActionTaskStateData(
                 data={

--- a/backend/app/workload/__init__.py
+++ b/backend/app/workload/__init__.py
@@ -1,0 +1,213 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+"""Product-neutral workload contracts shared by every Run Attempt.
+
+The profile describes purpose and SLA policy references. It deliberately does
+not fork the Run state machine and is not part of Workspace Bundle or
+EffectiveEnvironmentSpec identity.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, replace
+from typing import Any
+
+from app.workspace_config.models import canonical_digest
+
+WORKLOAD_PROFILE_SCHEMA_VERSION = 1
+WORKLOAD_PROFILE_MIN_SUPPORTED_SCHEMA_VERSION = 1
+WORKLOAD_KINDS = frozenset({"production", "test", "ab", "rollout"})
+
+CAPTURE_POLICY_BEST_EFFORT = "capture.best-effort.v1"
+CAPTURE_POLICY_REQUIRED = "capture.required.v1"
+CAPTURE_POLICIES = frozenset(
+    {CAPTURE_POLICY_BEST_EFFORT, CAPTURE_POLICY_REQUIRED}
+)
+RETENTION_POLICY_PRODUCT_DEFAULT = "retention.product-default.v1"
+RETENTION_POLICY_EVIDENCE_REQUIRED = "retention.evidence-required.v1"
+PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS = 30 * 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class WorkloadProfileRecord:
+    """Immutable purpose/SLA policy binding for one Run Attempt."""
+
+    schema_version: int
+    workload_kind: str
+    profile_version: str
+    isolation_policy_ref: str
+    capture_policy_ref: str
+    verifier_policy_ref: str
+    budget_policy_ref: str
+    network_policy_ref: str
+    retention_policy_ref: str
+    pairing_key: str | None = None
+    experiment_id: str | None = None
+    rollout_batch_id: str | None = None
+
+
+DEFAULT_PRODUCTION_WORKLOAD_PROFILE = WorkloadProfileRecord(
+    schema_version=WORKLOAD_PROFILE_SCHEMA_VERSION,
+    workload_kind="production",
+    profile_version="1",
+    isolation_policy_ref="isolation.product-default.v1",
+    capture_policy_ref=CAPTURE_POLICY_BEST_EFFORT,
+    verifier_policy_ref="verifier.noop.v1",
+    budget_policy_ref="budget.product-default.v1",
+    network_policy_ref="network.product-default.v1",
+    retention_policy_ref=RETENTION_POLICY_PRODUCT_DEFAULT,
+)
+
+
+def default_workload_profile() -> WorkloadProfileRecord:
+    """Resolve compatibility configuration once, at Attempt admission.
+
+    Runtime capture decisions must use the immutable profile persisted on the
+    Attempt. The environment variable remains a compatibility entry point,
+    but it is translated into that profile instead of being consulted for
+    every model dispatch.
+    """
+
+    if os.environ.get("EIGENT_MODEL_CAPTURE_REQUIRED", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return replace(
+            DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+            capture_policy_ref=CAPTURE_POLICY_REQUIRED,
+        )
+    return DEFAULT_PRODUCTION_WORKLOAD_PROFILE
+
+
+def workload_profile_payload(profile: WorkloadProfileRecord) -> dict[str, Any]:
+    """Return the only canonical JSON shape used for profile persistence."""
+
+    payload: dict[str, Any] = {
+        "schema_version": profile.schema_version,
+        "workload_kind": profile.workload_kind,
+        "profile_version": profile.profile_version,
+        "isolation_policy_ref": profile.isolation_policy_ref,
+        "capture_policy_ref": profile.capture_policy_ref,
+        "verifier_policy_ref": profile.verifier_policy_ref,
+        "budget_policy_ref": profile.budget_policy_ref,
+        "network_policy_ref": profile.network_policy_ref,
+        "retention_policy_ref": profile.retention_policy_ref,
+    }
+    for key in ("pairing_key", "experiment_id", "rollout_batch_id"):
+        value = getattr(profile, key)
+        if value is not None:
+            payload[key] = value
+    return payload
+
+
+def validate_workload_profile(
+    profile: WorkloadProfileRecord,
+) -> WorkloadProfileRecord:
+    if not (
+        WORKLOAD_PROFILE_MIN_SUPPORTED_SCHEMA_VERSION
+        <= profile.schema_version
+        <= WORKLOAD_PROFILE_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            f"unsupported WorkloadProfile schema {profile.schema_version}"
+        )
+    if profile.workload_kind not in WORKLOAD_KINDS:
+        raise ValueError(
+            f"unsupported workload kind {profile.workload_kind!r}"
+        )
+    required = (
+        profile.profile_version,
+        profile.isolation_policy_ref,
+        profile.capture_policy_ref,
+        profile.verifier_policy_ref,
+        profile.budget_policy_ref,
+        profile.network_policy_ref,
+        profile.retention_policy_ref,
+    )
+    if any(not value.strip() for value in required):
+        raise ValueError("WorkloadProfile policy references are required")
+    if profile.capture_policy_ref not in CAPTURE_POLICIES:
+        raise ValueError(
+            f"unsupported capture policy {profile.capture_policy_ref!r}"
+        )
+    optional = (
+        profile.pairing_key,
+        profile.experiment_id,
+        profile.rollout_batch_id,
+    )
+    if any(value is not None and not value.strip() for value in optional):
+        raise ValueError("WorkloadProfile optional identities cannot be blank")
+    return profile
+
+
+def workload_profile_digest(profile: WorkloadProfileRecord) -> str:
+    return canonical_digest(
+        workload_profile_payload(validate_workload_profile(profile))
+    )
+
+
+def workload_profile_from_payload(
+    payload: dict[str, Any],
+) -> WorkloadProfileRecord:
+    profile = WorkloadProfileRecord(
+        schema_version=int(payload["schema_version"]),
+        workload_kind=str(payload["workload_kind"]),
+        profile_version=str(payload["profile_version"]),
+        isolation_policy_ref=str(payload["isolation_policy_ref"]),
+        capture_policy_ref=str(payload["capture_policy_ref"]),
+        verifier_policy_ref=str(payload["verifier_policy_ref"]),
+        budget_policy_ref=str(payload["budget_policy_ref"]),
+        network_policy_ref=str(payload["network_policy_ref"]),
+        retention_policy_ref=str(payload["retention_policy_ref"]),
+        pairing_key=_optional_text(payload.get("pairing_key")),
+        experiment_id=_optional_text(payload.get("experiment_id")),
+        rollout_batch_id=_optional_text(payload.get("rollout_batch_id")),
+    )
+    return validate_workload_profile(profile)
+
+
+def capture_required(profile: WorkloadProfileRecord | None) -> bool:
+    return bool(
+        profile is not None
+        and profile.capture_policy_ref == CAPTURE_POLICY_REQUIRED
+    )
+
+
+def _optional_text(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+__all__ = [
+    "CAPTURE_POLICY_BEST_EFFORT",
+    "CAPTURE_POLICIES",
+    "CAPTURE_POLICY_REQUIRED",
+    "DEFAULT_PRODUCTION_WORKLOAD_PROFILE",
+    "PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS",
+    "RETENTION_POLICY_EVIDENCE_REQUIRED",
+    "RETENTION_POLICY_PRODUCT_DEFAULT",
+    "WORKLOAD_KINDS",
+    "WORKLOAD_PROFILE_MIN_SUPPORTED_SCHEMA_VERSION",
+    "WORKLOAD_PROFILE_SCHEMA_VERSION",
+    "WorkloadProfileRecord",
+    "capture_required",
+    "default_workload_profile",
+    "validate_workload_profile",
+    "workload_profile_digest",
+    "workload_profile_from_payload",
+    "workload_profile_payload",
+]

--- a/backend/tests/app/run_journal/test_model_capture.py
+++ b/backend/tests/app/run_journal/test_model_capture.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -22,8 +23,17 @@ from unittest.mock import patch
 import pytest
 
 from app.run_context.context import RunContext, run_context_scope
-from app.run_journal.model_capture import instrument_model_backend
+from app.run_journal.model_capture import (
+    _capture_is_required,
+    instrument_model_backend,
+)
 from app.run_journal.store import SQLiteRunJournal
+from app.run_runtime.step_coordinator import step_event_draft, step_scope
+from app.workload import (
+    CAPTURE_POLICY_REQUIRED,
+    DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+    RETENTION_POLICY_EVIDENCE_REQUIRED,
+)
 
 
 class _Response:
@@ -35,6 +45,48 @@ class _Response:
             "choices": [{"finish_reason": "stop"}],
             "usage": {"prompt_tokens": 3, "completion_tokens": 2},
         }
+
+
+def test_persisted_best_effort_capture_is_not_overridden_by_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EIGENT_MODEL_CAPTURE_REQUIRED", "true")
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        workload_profile=DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+    )
+
+    assert _capture_is_required(journal, attempt.attempt_id) is False
+
+
+def test_attempt_capture_policy_is_cached_after_first_resolution(
+    tmp_path: Path,
+) -> None:
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        workload_profile=DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+    )
+
+    with patch.object(
+        journal, "get_run_attempt", wraps=journal.get_run_attempt
+    ) as get_attempt:
+        assert _capture_is_required(journal, attempt.attempt_id) is False
+        assert _capture_is_required(journal, attempt.attempt_id) is False
+
+    get_attempt.assert_called_once_with(attempt.attempt_id)
 
 
 class _Chunk:
@@ -347,6 +399,128 @@ def test_non_streaming_call_is_committed_without_changing_camel_logger(
     assert not _context(tmp_path).camel_log_dir.exists()
 
 
+def test_model_capture_binds_current_authored_step(tmp_path: Path) -> None:
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+    )
+    journal.append_event(
+        "run-1",
+        step_event_draft(
+            run_id="run-1",
+            attempt_id=attempt.attempt_id,
+            step_id="step-1",
+            plan_item_id="plan-item-1",
+            title="Call model",
+            summary=None,
+            ordinal=0,
+            agent_id="agent-1",
+            event="created",
+            status="pending",
+        ),
+    )
+    model = instrument_model_backend(
+        _FakeModel(_Response()),
+        agent_id="agent-1",
+        provider="openai",
+        model_name="gpt-test",
+        journal=journal,
+    )
+
+    with (
+        run_context_scope(_context(tmp_path, attempt_id=attempt.attempt_id)),
+        step_scope("step-1"),
+    ):
+        model.run([{"role": "user", "content": "hello"}])
+
+    record = journal.list_model_invocations("run-1")[0]
+    assert record.attempt_id == attempt.attempt_id
+    assert record.step_id == "step-1"
+
+
+def test_model_capture_resolves_unique_running_step_without_tool_scope(
+    tmp_path: Path,
+) -> None:
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+    )
+    for event, status in (("created", "pending"), ("started", "running")):
+        journal.append_event(
+            "run-1",
+            step_event_draft(
+                run_id="run-1",
+                attempt_id=attempt.attempt_id,
+                step_id="step-1",
+                plan_item_id="plan-item-1",
+                title="Call model",
+                summary=None,
+                ordinal=0,
+                agent_id="agent-1",
+                event=event,
+                status=status,
+            ),
+        )
+    model = instrument_model_backend(
+        _FakeModel(_Response()),
+        agent_id="agent-1",
+        provider="openai",
+        model_name="gpt-test",
+        journal=journal,
+    )
+
+    with run_context_scope(_context(tmp_path, attempt_id=attempt.attempt_id)):
+        model.run([{"role": "user", "content": "hello"}])
+
+    record = journal.list_model_invocations("run-1")[0]
+    assert record.step_id == "step-1"
+
+
+def test_stale_step_falls_back_to_attempt_level_capture_gap(
+    tmp_path: Path,
+) -> None:
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+    )
+    response = _Response()
+    model = instrument_model_backend(
+        _FakeModel(response),
+        agent_id="agent-1",
+        provider="openai",
+        model_name="gpt-test",
+        journal=journal,
+    )
+
+    with (
+        run_context_scope(_context(tmp_path, attempt_id=attempt.attempt_id)),
+        step_scope("stale-step"),
+    ):
+        returned = model.run([{"role": "user", "content": "hello"}])
+
+    assert returned is response
+    assert journal.list_model_invocations("run-1") == ()
+    gaps = journal.list_attempt_evidence_gaps(attempt.attempt_id)
+    assert len(gaps) == 1
+    assert gaps[0].step_id is None
+    assert gaps[0].detail_code == "IdempotencyConflictError"
+
+
 def test_invocation_uses_attempt_pinned_in_immutable_context(
     tmp_path: Path,
 ) -> None:
@@ -508,6 +682,34 @@ async def test_streaming_model_call_aggregates_without_token_delta_rows(
 
 
 @pytest.mark.asyncio
+async def test_terminal_usage_chunk_completes_before_stream_exhaustion(
+    tmp_path: Path,
+) -> None:
+    journal = _journal(tmp_path)
+    model = instrument_model_backend(
+        _FakeModel(_AsyncChunks()),
+        agent_id="agent-1",
+        provider="openai",
+        model_name="gpt-test",
+        journal=journal,
+    )
+
+    with run_context_scope(_context(tmp_path)):
+        stream = await model.arun([{"role": "user", "content": "hi"}])
+        first = await stream.__anext__()
+        terminal = await stream.__anext__()
+
+    assert first.payload["choices"][0]["finish_reason"] is None
+    assert terminal.payload["choices"][0]["finish_reason"] == "stop"
+    record = journal.list_model_invocations("run-1")[0]
+    assert record.status == "completed"
+    assert record.response is not None
+    assert record.response["content"] == "hello world"
+    assert record.prompt_tokens == 5
+    assert record.completion_tokens == 2
+
+
+@pytest.mark.asyncio
 async def test_async_structured_stream_preserves_final_completion_api(
     tmp_path: Path,
 ) -> None:
@@ -652,3 +854,260 @@ async def test_async_stream_context_manager_is_recorded_on_exhaustion(
     record = journal.list_model_invocations("run-1")[0]
     assert record.status == "completed"
     assert model._log_enabled is True
+
+
+def test_best_effort_capture_start_failure_records_gap_and_dispatches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EIGENT_MODEL_CAPTURE_REQUIRED", raising=False)
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+    )
+    response = _Response()
+    model = instrument_model_backend(
+        _FakeModel(response),
+        agent_id="agent-1",
+        provider="openai",
+        model_name="gpt-test",
+        journal=journal,
+    )
+
+    with (
+        patch.object(
+            journal,
+            "start_model_invocation",
+            side_effect=RuntimeError("capture unavailable"),
+        ),
+        run_context_scope(_context(tmp_path, attempt_id=attempt.attempt_id)),
+    ):
+        returned = model.run([{"role": "user", "content": "hello"}])
+
+    assert returned is response
+    gaps = journal.list_attempt_evidence_gaps(attempt.attempt_id)
+    assert len(gaps) == 1
+    assert gaps[0].dimension == "model_decisions"
+    assert gaps[0].reason_code == "capture_failed"
+    assert gaps[0].detail_code == "RuntimeError"
+
+
+def test_required_capture_profile_blocks_dispatch_after_recording_gap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EIGENT_MODEL_CAPTURE_REQUIRED", raising=False)
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    strict = replace(
+        DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+        workload_kind="test",
+        profile_version="test-v1",
+        capture_policy_ref=CAPTURE_POLICY_REQUIRED,
+        retention_policy_ref=RETENTION_POLICY_EVIDENCE_REQUIRED,
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        workload_profile=strict,
+    )
+    model = instrument_model_backend(
+        _FakeModel(_Response()),
+        agent_id="agent-1",
+        provider="openai",
+        model_name="gpt-test",
+        journal=journal,
+    )
+
+    with (
+        patch.object(
+            journal,
+            "start_model_invocation",
+            side_effect=RuntimeError("capture unavailable"),
+        ),
+        run_context_scope(_context(tmp_path, attempt_id=attempt.attempt_id)),
+        pytest.raises(RuntimeError, match="capture unavailable"),
+    ):
+        model.run([{"role": "user", "content": "hello"}])
+
+    gaps = journal.list_attempt_evidence_gaps(attempt.attempt_id)
+    assert len(gaps) == 1
+    assert gaps[0].reason_code == "capture_failed"
+
+
+def test_required_capture_profile_stops_stream_on_first_token_gap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EIGENT_MODEL_CAPTURE_REQUIRED", raising=False)
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    strict = replace(
+        DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+        workload_kind="test",
+        profile_version="test-v1",
+        capture_policy_ref=CAPTURE_POLICY_REQUIRED,
+        retention_policy_ref=RETENTION_POLICY_EVIDENCE_REQUIRED,
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        workload_profile=strict,
+    )
+    model = instrument_model_backend(
+        _FakeModel(_SyncChunks()),
+        agent_id="agent-1",
+        provider="openai",
+        model_name="gpt-test",
+        journal=journal,
+    )
+
+    with (
+        patch.object(
+            journal,
+            "mark_model_invocation_first_token",
+            side_effect=RuntimeError("first token capture unavailable"),
+        ),
+        run_context_scope(_context(tmp_path, attempt_id=attempt.attempt_id)),
+    ):
+        stream = model.run([{"role": "user", "content": "hello"}])
+        with pytest.raises(
+            RuntimeError, match="first token capture unavailable"
+        ):
+            next(stream)
+
+    gaps = journal.list_attempt_evidence_gaps(attempt.attempt_id)
+    assert len(gaps) == 1
+    assert gaps[0].detail_code == "RuntimeError"
+
+
+def test_best_effort_first_token_gap_does_not_interrupt_provider_stream(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EIGENT_MODEL_CAPTURE_REQUIRED", raising=False)
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+    )
+    model = instrument_model_backend(
+        _FakeModel(_SyncChunks()),
+        agent_id="agent-1",
+        provider="openai",
+        model_name="gpt-test",
+        journal=journal,
+    )
+
+    with (
+        patch.object(
+            journal,
+            "mark_model_invocation_first_token",
+            side_effect=RuntimeError("first token capture unavailable"),
+        ),
+        run_context_scope(_context(tmp_path, attempt_id=attempt.attempt_id)),
+    ):
+        chunks = list(model.run([{"role": "user", "content": "hello"}]))
+
+    assert len(chunks) == 2
+    gaps = journal.list_attempt_evidence_gaps(attempt.attempt_id)
+    assert len(gaps) == 1
+
+
+def test_required_capture_profile_surfaces_terminal_persistence_gap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EIGENT_MODEL_CAPTURE_REQUIRED", raising=False)
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    strict = replace(
+        DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+        workload_kind="test",
+        profile_version="test-v1",
+        capture_policy_ref=CAPTURE_POLICY_REQUIRED,
+        retention_policy_ref=RETENTION_POLICY_EVIDENCE_REQUIRED,
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        workload_profile=strict,
+    )
+    model = instrument_model_backend(
+        _FakeModel(_Response()),
+        agent_id="agent-1",
+        provider="openai",
+        model_name="gpt-test",
+        journal=journal,
+    )
+
+    with (
+        patch.object(
+            journal,
+            "finish_model_invocation",
+            side_effect=RuntimeError("terminal capture unavailable"),
+        ),
+        run_context_scope(_context(tmp_path, attempt_id=attempt.attempt_id)),
+        pytest.raises(RuntimeError, match="terminal capture unavailable"),
+    ):
+        model.run([{"role": "user", "content": "hello"}])
+
+    gaps = journal.list_attempt_evidence_gaps(attempt.attempt_id)
+    assert len(gaps) == 1
+    assert gaps[0].detail_code == "RuntimeError"
+
+
+def test_best_effort_terminal_persistence_gap_returns_provider_response(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EIGENT_MODEL_CAPTURE_REQUIRED", raising=False)
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+    )
+    response = _Response()
+    model = instrument_model_backend(
+        _FakeModel(response),
+        agent_id="agent-1",
+        provider="openai",
+        model_name="gpt-test",
+        journal=journal,
+    )
+
+    with (
+        patch.object(
+            journal,
+            "finish_model_invocation",
+            side_effect=RuntimeError("terminal capture unavailable"),
+        ),
+        run_context_scope(_context(tmp_path, attempt_id=attempt.attempt_id)),
+    ):
+        returned = model.run([{"role": "user", "content": "hello"}])
+
+    assert returned is response
+    gaps = journal.list_attempt_evidence_gaps(attempt.attempt_id)
+    assert len(gaps) == 1

--- a/backend/tests/app/run_journal/test_model_invocations.py
+++ b/backend/tests/app/run_journal/test_model_invocations.py
@@ -13,16 +13,25 @@
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
 import sqlite3
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
+from app.run_journal.models import RunEventDraft
 from app.run_journal.store import (
     _MODEL_INVOCATION_DOCUMENT_MAX_BYTES,
     SCHEMA_VERSION,
     IdempotencyConflictError,
     InvalidRunTransitionError,
     SQLiteRunJournal,
+)
+from app.workload import (
+    CAPTURE_POLICY_REQUIRED,
+    DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+    PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS,
+    RETENTION_POLICY_EVIDENCE_REQUIRED,
+    RETENTION_POLICY_PRODUCT_DEFAULT,
 )
 
 
@@ -256,6 +265,409 @@ def test_startup_reconciliation_closes_dispatched_model_call(
         event.event_type
         for event in journal.list_model_invocation_events("inv-crashed")
     ] == ["dispatched", "outcome_unknown"]
+
+
+@pytest.mark.parametrize(
+    ("terminal_event_type", "expected_status"),
+    [
+        ("run.interrupted", "interrupted"),
+        ("run.failed", "failed"),
+    ],
+)
+def test_generic_terminal_transition_closes_dispatched_model_call(
+    tmp_path: Path,
+    terminal_event_type: str,
+    expected_status: str,
+) -> None:
+    journal = _journal(tmp_path)
+    attempt = journal.create_run_attempt(
+        "run-1", request_id="initial", reason="initial", activate=True
+    )
+    journal.start_model_invocation(
+        invocation_id="inv-terminal",
+        run_id="run-1",
+        attempt_id=attempt.attempt_id,
+        agent_id="agent-1",
+        logical_call_id="logical-terminal",
+        provider="openai",
+        model="gpt-test",
+        transport="responses",
+        thinking_effort=None,
+        request={"messages": []},
+        now=10,
+    )
+
+    journal.append_event(
+        "run-1",
+        RunEventDraft(
+            event_id=f"terminal:{expected_status}",
+            event_type=terminal_event_type,
+            payload={"reason": "test_terminal"},
+            created_at=20,
+        ),
+    )
+
+    invocation = journal.get_model_invocation("inv-terminal")
+    assert invocation is not None
+    assert invocation.status == "outcome_unknown"
+    assert invocation.error_code == (
+        "run_terminal_before_model_capture_completed"
+    )
+    assert journal.get_run("run-1").status == expected_status
+    assert (
+        journal.list_attempt_evidence_gaps(attempt.attempt_id)[0].reason_code
+        == "outcome_unknown"
+    )
+
+
+def test_completed_cancel_closes_dispatched_model_call(tmp_path: Path) -> None:
+    journal = _journal(tmp_path)
+    attempt = journal.create_run_attempt(
+        "run-1", request_id="initial", reason="initial", activate=True
+    )
+    journal.start_model_invocation(
+        invocation_id="inv-cancel",
+        run_id="run-1",
+        attempt_id=attempt.attempt_id,
+        agent_id="agent-1",
+        logical_call_id="logical-cancel",
+        provider="openai",
+        model="gpt-test",
+        transport="responses",
+        thinking_effort=None,
+        request={"messages": []},
+        now=10,
+    )
+
+    journal.request_cancel(
+        "run-1", request_id="cancel-1", reason="user", now=19
+    )
+    journal.complete_cancel("run-1", request_id="cancel-1", now=20)
+
+    invocation = journal.get_model_invocation("inv-cancel")
+    assert invocation is not None
+    assert invocation.status == "outcome_unknown"
+    assert journal.get_run("run-1").status == "cancelled"
+    assert (
+        journal.list_attempt_evidence_gaps(attempt.attempt_id)[0].reason_code
+        == "outcome_unknown"
+    )
+
+
+def test_retention_candidates_follow_immutable_attempt_policy(
+    tmp_path: Path,
+) -> None:
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    product_attempt = journal.create_run_attempt(
+        "run-1", request_id="product", reason="initial"
+    )
+    journal.start_model_invocation(
+        invocation_id="inv-product",
+        run_id="run-1",
+        attempt_id=product_attempt.attempt_id,
+        agent_id="agent-1",
+        logical_call_id="logical-product",
+        provider="openai",
+        model="gpt-test",
+        transport="responses",
+        thinking_effort=None,
+        request={"messages": [{"role": "user", "content": "retain me"}]},
+        now=1,
+    )
+    journal.finish_model_invocation(
+        "inv-product",
+        status="completed",
+        response={"output": "done"},
+        now=2,
+    )
+
+    journal.ensure_run(
+        run_id="run-2", project_id="project-2", status="pending"
+    )
+    evidence_profile = replace(
+        DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+        workload_kind="test",
+        profile_version="test-v1",
+        capture_policy_ref=CAPTURE_POLICY_REQUIRED,
+        retention_policy_ref=RETENTION_POLICY_EVIDENCE_REQUIRED,
+    )
+    evidence_attempt = journal.create_run_attempt(
+        "run-2",
+        request_id="evidence",
+        reason="test",
+        workload_profile=evidence_profile,
+    )
+    journal.start_model_invocation(
+        invocation_id="inv-evidence",
+        run_id="run-2",
+        attempt_id=evidence_attempt.attempt_id,
+        agent_id="agent-2",
+        logical_call_id="logical-evidence",
+        provider="openai",
+        model="gpt-test",
+        transport="responses",
+        thinking_effort=None,
+        request={"messages": []},
+        now=1,
+    )
+    journal.finish_model_invocation(
+        "inv-evidence", status="completed", response={"output": "done"}, now=2
+    )
+
+    journal.ensure_run(
+        run_id="run-3", project_id="project-3", status="pending"
+    )
+    strict_production_profile = replace(
+        DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+        profile_version="strict-production-v1",
+        capture_policy_ref=CAPTURE_POLICY_REQUIRED,
+        retention_policy_ref=RETENTION_POLICY_EVIDENCE_REQUIRED,
+    )
+    strict_production_attempt = journal.create_run_attempt(
+        "run-3",
+        request_id="strict-production",
+        reason="evidence",
+        workload_profile=strict_production_profile,
+    )
+    journal.start_model_invocation(
+        invocation_id="inv-strict-production",
+        run_id="run-3",
+        attempt_id=strict_production_attempt.attempt_id,
+        agent_id="agent-3",
+        logical_call_id="logical-strict-production",
+        provider="openai",
+        model="gpt-test",
+        transport="responses",
+        thinking_effort=None,
+        request={"messages": []},
+        now=1,
+    )
+    journal.finish_model_invocation(
+        "inv-strict-production",
+        status="completed",
+        response={"output": "done"},
+        now=2,
+    )
+
+    candidates = journal.list_model_invocation_retention_candidates(
+        now=PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS + 3
+    )
+
+    assert candidates == ("inv-product",)
+    # Candidate planning is read-only until destructive expiry is explicitly
+    # authorized by the product lifecycle policy.
+    retained = journal.get_model_invocation("inv-product")
+    assert retained is not None
+    assert retained.request["messages"][0]["content"] == "retain me"
+    assert retained.response == {"output": "done"}
+
+
+def test_model_document_retention_preserves_audit_and_records_gap_once(
+    tmp_path: Path,
+) -> None:
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-retention", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-retention", request_id="product", reason="initial"
+    )
+    journal.start_model_invocation(
+        invocation_id="inv-retention",
+        run_id="run-retention",
+        attempt_id=attempt.attempt_id,
+        agent_id="agent-1",
+        logical_call_id="logical-retention",
+        provider="openai",
+        model="gpt-test",
+        transport="responses",
+        thinking_effort="high",
+        request={"messages": [{"role": "user", "content": "large body"}]},
+        redaction_version="redaction-v1",
+        now=1,
+    )
+    original = journal.finish_model_invocation(
+        "inv-retention",
+        status="completed",
+        response={"output": "large response"},
+        prompt_tokens=17,
+        completion_tokens=9,
+        cache_read_tokens=3,
+        cache_write_tokens=2,
+        finish_reason="stop",
+        now=2,
+    )
+    run_before_retention = journal.get_run("run-retention")
+    events_before_retention = journal.list_events("run-retention")
+
+    result = journal.expire_model_invocation_documents(
+        now=PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS + 3
+    )
+
+    assert result.expired_invocation_ids == ("inv-retention",)
+    assert result.skipped_invocation_ids == ()
+    assert result.remaining_candidate_count == 0
+    retained = journal.get_model_invocation("inv-retention")
+    assert retained is not None
+    expected_tombstone = {
+        "_eigent_retention": {
+            "expired": True,
+            "policy_ref": RETENTION_POLICY_PRODUCT_DEFAULT,
+            "version": 1,
+        }
+    }
+    assert retained.request == expected_tombstone
+    assert retained.response == expected_tombstone
+    assert retained.request_digest == original.request_digest
+    assert retained.response_digest == original.response_digest
+    assert retained.prompt_tokens == 17
+    assert retained.completion_tokens == 9
+    assert retained.cache_read_tokens == 3
+    assert retained.cache_write_tokens == 2
+    assert retained.finish_reason == "stop"
+    assert retained.status == "completed"
+    assert retained.started_at == 1
+    assert retained.completed_at == 2
+    assert retained.redaction_version == "redaction-v1+retention-v1"
+
+    gaps = journal.list_attempt_evidence_gaps(attempt.attempt_id)
+    assert len(gaps) == 1
+    assert gaps[0].reason_code == "retention_expired"
+    assert gaps[0].dimension == "model_decisions"
+    # Retention is local lifecycle maintenance, not a late Run event. It must
+    # not advance the completed/pending Run timeline, history cursor or Cloud
+    # outbox merely because a document reached its retention age.
+    assert journal.list_events("run-retention") == events_before_retention
+    assert journal.get_run("run-retention") == run_before_retention
+
+    repeated = journal.expire_model_invocation_documents(
+        now=PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS + 4
+    )
+    assert repeated.expired_invocation_ids == ()
+    assert repeated.skipped_invocation_ids == ()
+    assert repeated.remaining_candidate_count == 0
+    assert (
+        journal.list_model_invocation_retention_candidates(
+            now=PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS + 4
+        )
+        == ()
+    )
+    assert len(journal.list_attempt_evidence_gaps(attempt.attempt_id)) == 1
+
+
+def test_model_document_retention_skips_poison_candidate_and_continues(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-retention", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-retention", request_id="product", reason="initial"
+    )
+    for index, invocation_id in enumerate(("inv-00-poison", "inv-01-good")):
+        journal.start_model_invocation(
+            invocation_id=invocation_id,
+            run_id="run-retention",
+            attempt_id=attempt.attempt_id,
+            agent_id="agent-1",
+            logical_call_id=f"logical-{index}",
+            provider="openai",
+            model="gpt-test",
+            transport="responses",
+            thinking_effort=None,
+            request={"messages": [{"content": invocation_id}]},
+            now=1 + index,
+        )
+        journal.finish_model_invocation(
+            invocation_id,
+            status="completed",
+            response={"output": invocation_id},
+            now=2 + index,
+        )
+
+    expire_one = journal._expire_model_invocation_document_in_transaction
+
+    def injected_failure(connection, *, invocation, timestamp):
+        if invocation["invocation_id"] == "inv-00-poison":
+            raise RuntimeError("injected retention poison")
+        return expire_one(
+            connection,
+            invocation=invocation,
+            timestamp=timestamp,
+        )
+
+    monkeypatch.setattr(
+        journal,
+        "_expire_model_invocation_document_in_transaction",
+        injected_failure,
+    )
+
+    with caplog.at_level("ERROR", logger="run_journal"):
+        result = journal.expire_model_invocation_documents(
+            now=PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS + 4
+        )
+
+    assert result.expired_invocation_ids == ("inv-01-good",)
+    assert result.skipped_invocation_ids == ("inv-00-poison",)
+    assert result.remaining_candidate_count == 1
+    poison = journal.get_model_invocation("inv-00-poison")
+    expired = journal.get_model_invocation("inv-01-good")
+    assert poison is not None
+    assert expired is not None
+    assert poison.request["messages"][0]["content"] == "inv-00-poison"
+    assert expired.request["_eigent_retention"]["expired"] is True
+    assert "Skipping model-document retention candidate" in caplog.text
+
+
+def test_model_document_retention_is_bounded_and_runs_after_recovery(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-retention", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-retention", request_id="product", reason="initial"
+    )
+    journal.start_model_invocation(
+        invocation_id="inv-retention",
+        run_id="run-retention",
+        attempt_id=attempt.attempt_id,
+        agent_id="agent-1",
+        logical_call_id="logical-retention",
+        provider="openai",
+        model="gpt-test",
+        transport="responses",
+        thinking_effort=None,
+        request={"messages": []},
+        now=1,
+    )
+    journal.finish_model_invocation(
+        "inv-retention",
+        status="completed",
+        response={"output": "done"},
+        now=2,
+    )
+
+    with pytest.raises(ValueError, match="between 1 and 100"):
+        journal.expire_model_invocation_documents(limit=101)
+
+    with caplog.at_level("INFO", logger="run_journal"):
+        journal.reconcile_startup(
+            now=PRODUCT_MODEL_DOCUMENT_RETENTION_SECONDS + 3
+        )
+
+    retained = journal.get_model_invocation("inv-retention")
+    assert retained is not None
+    assert retained.request["_eigent_retention"]["expired"] is True
+    assert "expired=1 skipped=0 remaining=0" in caplog.text
 
 
 def test_v29_database_adds_model_trajectory_tables(tmp_path: Path) -> None:

--- a/backend/tests/app/run_journal/test_otel_projection.py
+++ b/backend/tests/app/run_journal/test_otel_projection.py
@@ -1,0 +1,265 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from __future__ import annotations
+
+import os
+import re
+from urllib.request import Request, urlopen
+
+import pytest
+
+from app.run_journal.otel_projection import (
+    OTEL_GENAI_ATTRIBUTE_ALLOWLIST,
+    OTEL_GENAI_PROJECTOR_VERSION,
+    OTEL_GENAI_SCHEMA_URL,
+    OTEL_GENAI_SEMCONV_SOURCE_REF,
+    OTEL_GENAI_SEMCONV_VERSION,
+    project_attempt_span,
+    project_model_invocation_span,
+)
+from app.run_journal.store import SQLiteRunJournal
+from app.run_runtime.step_coordinator import step_event_draft
+
+
+def test_projection_contract_is_versioned_and_excludes_content(
+    tmp_path,
+) -> None:
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(
+            run_id="run-1", project_id="project-1", status="pending"
+        )
+        attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+        )
+        journal.append_event(
+            "run-1",
+            step_event_draft(
+                run_id="run-1",
+                attempt_id=attempt.attempt_id,
+                step_id="step-1",
+                plan_item_id="plan-item-1",
+                title="Call model",
+                summary=None,
+                ordinal=0,
+                agent_id="agent-1",
+                event="created",
+                status="pending",
+            ),
+        )
+        invocation = journal.start_model_invocation(
+            invocation_id="invocation-1",
+            run_id="run-1",
+            attempt_id=attempt.attempt_id,
+            step_id="step-1",
+            agent_id="agent-1",
+            logical_call_id="logical-1",
+            provider="openai",
+            model="gpt-test",
+            transport="responses",
+            thinking_effort="medium",
+            request={
+                "messages": [{"role": "user", "content": "secret"}],
+                "model_config_dict": {"stream": False},
+            },
+            now=2,
+        )
+        invocation = journal.finish_model_invocation(
+            invocation.invocation_id,
+            status="completed",
+            response={"id": "response-1", "model": "gpt-result"},
+            prompt_tokens=4,
+            completion_tokens=2,
+            cache_read_tokens=1,
+            cache_write_tokens=2,
+            finish_reason="stop",
+            now=3,
+        )
+
+        attempt_span = project_attempt_span(attempt)
+        model_span = project_model_invocation_span(invocation)
+
+        assert attempt_span.schema_url == OTEL_GENAI_SCHEMA_URL
+        assert attempt_span.semconv_version == OTEL_GENAI_SEMCONV_VERSION
+        assert attempt_span.semconv_source_ref == (
+            OTEL_GENAI_SEMCONV_SOURCE_REF
+        )
+        assert OTEL_GENAI_SEMCONV_VERSION is None
+        assert OTEL_GENAI_SCHEMA_URL is None
+        assert attempt_span.projector_version == OTEL_GENAI_PROJECTOR_VERSION
+        assert attempt_span.start_time_unix_seconds == attempt.started_at
+        assert attempt_span.end_time_unix_seconds is None
+        assert attempt_span.span_name == "run_attempt"
+        assert attempt_span.attributes["eigent.workload.kind"] == "production"
+        assert "gen_ai.operation.name" not in attempt_span.attributes
+        assert attempt_span.attributes["eigent.operation.name"] == (
+            "run_attempt"
+        )
+        assert model_span.span_kind == "CLIENT"
+        assert model_span.span_name == "chat gpt-test"
+        assert model_span.status_code == "UNSET"
+        assert model_span.start_time_unix_seconds == invocation.started_at
+        assert model_span.end_time_unix_seconds == invocation.completed_at
+        assert model_span.attributes["gen_ai.provider.name"] == "openai"
+        assert model_span.attributes["eigent.model.provider"] == "openai"
+        assert model_span.attributes["eigent.step.id"] == "step-1"
+        assert model_span.attributes["gen_ai.request.model"] == "gpt-test"
+        assert model_span.attributes["gen_ai.response.model"] == "gpt-result"
+        assert model_span.attributes["gen_ai.usage.input_tokens"] == 4
+        assert "gen_ai.request.stream" not in model_span.attributes
+        assert model_span.attributes["gen_ai.request.reasoning.level"] == (
+            "medium"
+        )
+        assert (
+            model_span.attributes["gen_ai.usage.cache_read.input_tokens"] == 1
+        )
+        assert (
+            model_span.attributes["gen_ai.usage.cache_write.input_tokens"] == 2
+        )
+        assert "gen_ai.input.messages" not in model_span.attributes
+        assert model_span.attributes["eigent.otel.content.mode"] == "excluded"
+        assert "secret" not in str(model_span.attributes)
+        assert {
+            key for key in model_span.attributes if key.startswith("gen_ai.")
+        } <= OTEL_GENAI_ATTRIBUTE_ALLOWLIST
+
+
+def test_projection_records_stream_only_when_enabled(tmp_path) -> None:
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(run_id="run-1", project_id="project-1")
+        invocation = journal.start_model_invocation(
+            invocation_id="invocation-1",
+            run_id="run-1",
+            attempt_id=None,
+            agent_id="agent-1",
+            logical_call_id="logical-1",
+            provider="openai",
+            model="gpt-test",
+            transport="responses",
+            thinking_effort=None,
+            request={"model_config_dict": {"stream": True}},
+        )
+
+        span = project_model_invocation_span(invocation)
+
+        assert span.attributes["gen_ai.request.stream"] is True
+
+
+def test_projection_v1_never_treats_canonical_rows_as_otel_messages(
+    tmp_path,
+) -> None:
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(run_id="run-1", project_id="project-1")
+        invocation = journal.start_model_invocation(
+            invocation_id="invocation-1",
+            run_id="run-1",
+            attempt_id=None,
+            agent_id="agent-1",
+            logical_call_id="logical-1",
+            provider="openai",
+            model="gpt-test",
+            transport="chat_completions",
+            thinking_effort=None,
+            request={"messages": [{"role": "user", "content": "hello"}]},
+        )
+        span = project_model_invocation_span(invocation)
+
+        assert "gen_ai.input.messages" not in span.attributes
+        assert "gen_ai.output.messages" not in span.attributes
+        assert "hello" not in str(span.attributes)
+
+
+def test_provider_projection_preserves_raw_value_and_maps_known_namespace(
+    tmp_path,
+) -> None:
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(run_id="run-1", project_id="project-1")
+        invocation = journal.start_model_invocation(
+            invocation_id="invocation-1",
+            run_id="run-1",
+            attempt_id=None,
+            agent_id="agent-1",
+            logical_call_id="logical-1",
+            provider="azure",
+            model="gpt-test",
+            transport="responses",
+            thinking_effort=None,
+            request={"messages": []},
+        )
+
+        span = project_model_invocation_span(invocation)
+
+        assert span.attributes["gen_ai.provider.name"] == "azure.ai.openai"
+        assert span.attributes["eigent.model.provider"] == "azure"
+
+
+def test_gemini_provider_uses_the_direct_api_otel_namespace(tmp_path) -> None:
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(run_id="run-1", project_id="project-1")
+        invocation = journal.start_model_invocation(
+            invocation_id="invocation-1",
+            run_id="run-1",
+            attempt_id=None,
+            agent_id="agent-1",
+            logical_call_id="logical-1",
+            provider="gemini",
+            model="gemini-test",
+            transport="generate_content",
+            thinking_effort=None,
+            request={"messages": []},
+        )
+
+        span = project_model_invocation_span(invocation)
+
+        assert span.attributes["gen_ai.provider.name"] == "gcp.gemini"
+
+
+@pytest.mark.skipif(
+    os.environ.get("OTEL_CONFORMANCE_CHECK", "").lower()
+    not in {"1", "true", "yes", "on"},
+    reason="set OTEL_CONFORMANCE_CHECK=1 to query upstream GenAI semconv",
+)
+def test_otel_genai_allowlist_conforms_to_current_upstream_registry() -> None:
+    """Opt-in network check for upstream registry and schema publication."""
+
+    registry = _read_otel_upstream(
+        "https://raw.githubusercontent.com/open-telemetry/"
+        "semantic-conventions-genai/main/model/gen-ai/registry.yaml"
+    )
+    upstream_keys = set(
+        re.findall(r"^\s*-\s+key:\s+([^\s#]+)", registry, re.MULTILINE)
+    )
+    assert OTEL_GENAI_ATTRIBUTE_ALLOWLIST <= upstream_keys
+
+    readme = _read_otel_upstream(
+        "https://raw.githubusercontent.com/open-telemetry/"
+        "semantic-conventions-genai/main/README.md"
+    )
+    schema_section = re.search(
+        r"^## Schema URL\s*\n+([^\n]+)", readme, re.MULTILINE
+    )
+    assert schema_section is not None
+    assert schema_section.group(1).strip() == "TODO", (
+        "upstream now publishes a GenAI schema URL; pin it and update this "
+        "projection contract"
+    )
+    assert OTEL_GENAI_SCHEMA_URL is None
+
+
+def _read_otel_upstream(url: str) -> str:
+    request = Request(url, headers={"User-Agent": "Eigent-OTel-Conformance"})
+    with urlopen(request, timeout=15) as response:  # nosec B310
+        return response.read().decode("utf-8")

--- a/backend/tests/app/run_journal/test_store.py
+++ b/backend/tests/app/run_journal/test_store.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+from unittest.mock import patch
 
 import pytest
 
@@ -36,7 +37,11 @@ from app.run_journal import (
 )
 from app.run_journal.cloud_projection import cloud_event_payload
 from app.run_policy import TimeoutOutcome, TimeoutScope, ToolSafetyClass
-from app.run_runtime.step_coordinator import PlanStepInput, RunStepCoordinator
+from app.run_runtime.step_coordinator import (
+    PlanStepInput,
+    RunStepCoordinator,
+    stable_step_id,
+)
 from app.workspace_config import (
     EnvironmentConfigResolver,
     LocalMaterialization,
@@ -75,6 +80,7 @@ def test_initializes_schema_and_durability_pragmas(journal):
         "run_event_sync_outbox",
         "model_invocations",
         "model_invocation_events",
+        "attempt_evidence_gaps",
         "tool_calls",
         "approvals",
         "workspace_config_revisions",
@@ -1921,6 +1927,260 @@ async def test_event_recorder_correlates_legacy_facts_to_running_step(journal):
 
 
 @pytest.mark.asyncio
+async def test_event_recorder_projects_workforce_subtask_lifecycle_to_step(
+    journal,
+):
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        activate=True,
+    )
+    recorder = EventRecorder(journal)
+
+    await recorder.record_legacy_step(
+        project_id="project-1",
+        run_id="run-1",
+        step="assign_task",
+        data={
+            "task_id": "run-1.1",
+            "assignee_id": "worker-1",
+            "content": "Inspect the generated report",
+            "state": "RUNNING",
+        },
+    )
+
+    coordinator = RunStepCoordinator(journal)
+    steps = list(coordinator.replay("run-1").values())
+    assert len(steps) == 1
+    assert steps[0].status == "running"
+    assert steps[0].agent_id == "worker-1"
+    assert steps[0].owner_kind == "workforce"
+    assert steps[0].source == "workforce"
+    assert (
+        coordinator.current_running_step_id("run-1", agent_id="worker-1")
+        == steps[0].step_id
+    )
+
+    # Workforce can emit a stale queued projection after started; it must not
+    # move the durable Step backwards.
+    await recorder.record_legacy_step(
+        project_id="project-1",
+        run_id="run-1",
+        step="assign_task",
+        data={
+            "task_id": "run-1.1",
+            "assignee_id": "worker-1",
+            "content": "Inspect the generated report",
+            "state": "OPEN",
+        },
+    )
+    assert coordinator.replay("run-1")[steps[0].step_id].status == "running"
+
+    await recorder.record_legacy_step(
+        project_id="project-1",
+        run_id="run-1",
+        step="task_state",
+        data={
+            "task_id": "run-1.1",
+            "content": "Inspect the generated report",
+            "state": "DONE",
+        },
+    )
+    assert coordinator.replay("run-1")[steps[0].step_id].status == (
+        "completed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_workforce_subtask_never_inherits_running_sibling_step(journal):
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        activate=True,
+    )
+    coordinator = RunStepCoordinator(journal)
+    first_step_id = coordinator.create_child_step(
+        project_id="project-1",
+        run_id="run-1",
+        parent_step_id=None,
+        task_identity="task-one",
+        title="First task",
+        agent_id="worker-1",
+        start=True,
+    )
+
+    committed = await EventRecorder(journal).record_legacy_step(
+        project_id="project-1",
+        run_id="run-1",
+        step="assign_task",
+        data={
+            "task_id": "task-two",
+            "assignee_id": "worker-2",
+            "content": "Second task",
+            "state": "OPEN",
+        },
+    )
+
+    second_step_id = stable_step_id("run-1", "subtask:task-two")
+    assert committed.payload["step_id"] == second_step_id
+    assert committed.payload["step_id"] != first_step_id
+    steps = coordinator.replay("run-1")
+    assert steps[first_step_id].status == "running"
+    assert steps[second_step_id].status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_workforce_projection_failure_commits_fact_and_durable_gap(
+    journal,
+):
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        activate=True,
+    )
+    original = journal._append_event_in_transaction
+
+    def fail_step_projection(connection, run_id, draft, **kwargs):
+        if draft.event_type.startswith("step."):
+            raise RuntimeError("step projection failed")
+        return original(connection, run_id, draft, **kwargs)
+
+    with patch.object(
+        journal,
+        "_append_event_in_transaction",
+        side_effect=fail_step_projection,
+    ):
+        committed = await EventRecorder(journal).record_legacy_step(
+            project_id="project-1",
+            run_id="run-1",
+            step="assign_task",
+            data={
+                "task_id": "task-one",
+                "assignee_id": "worker-1",
+                "content": "First task",
+                "state": "OPEN",
+            },
+        )
+
+    events = journal.list_events("run-1")
+    assert committed.event_type == "subtask.queued"
+    assert events[-2].event_id == committed.event_id
+    assert events[-1].event_type == "projection.workforce_step_failed"
+    assert events[-1].payload["source_event_id"] == committed.event_id
+    assert events[-1].payload["error_type"] == "RuntimeError"
+    assert RunStepCoordinator(journal).replay("run-1") == {}
+
+
+def test_workforce_producer_transition_is_idempotent_and_single_transaction(
+    journal,
+):
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        activate=True,
+    )
+
+    first = journal.persist_workforce_subtask_step(
+        run_id="run-1",
+        expected_project_id="project-1",
+        task_id="task-one",
+        title="First task",
+        agent_id="worker-1",
+        phase="running",
+    )
+    replay = journal.persist_workforce_subtask_step(
+        run_id="run-1",
+        expected_project_id="project-1",
+        task_id="task-one",
+        title="First task",
+        agent_id="worker-1",
+        phase="running",
+    )
+
+    assert replay == first
+    step_events = journal.list_events("run-1", event_type_prefix="step.")
+    assert [event.event_type for event in step_events] == [
+        "step.created",
+        "step.started",
+    ]
+
+
+def test_workforce_terminal_without_precursor_does_not_invent_step(journal):
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        activate=True,
+    )
+
+    step_id = journal.persist_workforce_subtask_step(
+        run_id="run-1",
+        expected_project_id="project-1",
+        task_id="task-one",
+        title="First task",
+        agent_id="worker-1",
+        phase="completed",
+    )
+
+    assert step_id == stable_step_id("run-1", "subtask:task-one")
+    assert journal.list_events("run-1", event_type_prefix="step.") == []
+
+
+def test_run_terminal_preserves_workforce_step_ownership(journal):
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        activate=True,
+    )
+    step_id = journal.persist_workforce_subtask_step(
+        run_id="run-1",
+        expected_project_id="project-1",
+        task_id="task-one",
+        title="First task",
+        agent_id="worker-1",
+        phase="running",
+    )
+
+    journal.append_event(
+        "run-1",
+        RunEventDraft(
+            event_id="run-failed:run-1",
+            event_type="run.failed",
+            payload={"reason": "test_failure"},
+        ),
+        expected_project_id="project-1",
+    )
+
+    step = RunStepCoordinator(journal).replay("run-1")[step_id]
+    assert step.status == "failed"
+    assert step.owner_kind == "workforce"
+    assert step.source == "workforce"
+
+
+@pytest.mark.asyncio
 async def test_event_recorder_rejects_cross_project_attribution(journal):
     journal.ensure_run(run_id="run-1", project_id="project-1")
     recorder = EventRecorder(journal)
@@ -2154,6 +2414,63 @@ def test_successful_completion_allows_legacy_safe_read_outcome_unknown(
 
     assert terminal.event_type == "run.completed"
     assert journal.get_run("run-1").status == "completed"
+
+
+def test_successful_completion_closes_unfinalized_model_capture_with_gap(
+    journal,
+):
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    attempt = journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+    )
+    journal.start_model_invocation(
+        invocation_id="model-1",
+        run_id="run-1",
+        attempt_id=attempt.attempt_id,
+        agent_id="agent-1",
+        logical_call_id="logical-1",
+        provider="openai",
+        model="gpt-test",
+        transport="responses",
+        thinking_effort=None,
+        request={"messages": []},
+        now=1,
+    )
+    manifest = _test_artifact_manifest(journal, "run-1")
+
+    journal.complete_successful_run(
+        "run-1",
+        assistant_final=RunEventDraft(
+            event_id="assistant-final:run-1",
+            event_type="assistant.final",
+            payload={"message": "Done"},
+            created_at=3,
+        ),
+        terminal=RunEventDraft(
+            event_id="run-completed:run-1",
+            event_type="run.completed",
+            payload={"reason": "success"},
+            created_at=3,
+        ),
+        artifact_manifest=manifest,
+        expected_project_id="project-1",
+    )
+
+    invocation = journal.get_model_invocation("model-1")
+    assert invocation is not None
+    assert invocation.status == "outcome_unknown"
+    assert invocation.completed_at == 3
+    gaps = journal.list_attempt_evidence_gaps(attempt.attempt_id)
+    assert len(gaps) == 1
+    assert gaps[0].dimension == "model_decisions"
+    assert gaps[0].reason_code == "outcome_unknown"
+    event_types = [event.event_type for event in journal.list_events("run-1")]
+    assert "model.invocation.outcome_unknown" in event_types
+    assert "attempt.evidence_gap_recorded" in event_types
 
 
 def test_cancel_marks_dispatched_tool_outcome_unknown_before_terminal(journal):

--- a/backend/tests/app/run_journal/test_workload_evidence.py
+++ b/backend/tests/app/run_journal/test_workload_evidence.py
@@ -1,0 +1,426 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from __future__ import annotations
+
+import inspect
+import sqlite3
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+
+import app.run_journal.store as store_module
+from app.run_journal.models import RunEventDraft
+from app.run_journal.store import (
+    SCHEMA_VERSION,
+    IdempotencyConflictError,
+    RunJournalError,
+    SQLiteRunJournal,
+)
+from app.run_runtime.step_coordinator import step_event_draft
+from app.workload import (
+    CAPTURE_POLICY_REQUIRED,
+    DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+    RETENTION_POLICY_EVIDENCE_REQUIRED,
+    WORKLOAD_PROFILE_SCHEMA_VERSION,
+    validate_workload_profile,
+    workload_profile_digest,
+)
+
+
+def test_attempt_binds_default_production_workload_and_emits_digest(
+    tmp_path,
+) -> None:
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(
+            run_id="run-1", project_id="project-1", status="pending"
+        )
+        attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+        )
+
+        assert attempt.workload_profile == DEFAULT_PRODUCTION_WORKLOAD_PROFILE
+        assert attempt.workload_profile_digest == workload_profile_digest(
+            DEFAULT_PRODUCTION_WORKLOAD_PROFILE
+        )
+        event = journal.list_events("run-1")[-1]
+        assert event.event_type == "run.attempt_created"
+        assert event.payload["workload_profile"]["workload_kind"] == (
+            "production"
+        )
+        assert event.payload["workload_profile_digest"] == (
+            attempt.workload_profile_digest
+        )
+
+
+def test_attempt_admission_freezes_required_capture_environment(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EIGENT_MODEL_CAPTURE_REQUIRED", "true")
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(
+            run_id="run-1", project_id="project-1", status="pending"
+        )
+        attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+        )
+
+        assert attempt.workload_profile.capture_policy_ref == (
+            CAPTURE_POLICY_REQUIRED
+        )
+        event = journal.list_events("run-1")[-1]
+        assert event.payload["workload_profile"]["capture_policy_ref"] == (
+            CAPTURE_POLICY_REQUIRED
+        )
+
+
+def test_attempt_workload_is_part_of_idempotent_execution_identity(
+    tmp_path,
+) -> None:
+    strict = replace(
+        DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+        workload_kind="test",
+        profile_version="test-v1",
+        capture_policy_ref=CAPTURE_POLICY_REQUIRED,
+        retention_policy_ref=RETENTION_POLICY_EVIDENCE_REQUIRED,
+    )
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(
+            run_id="run-1", project_id="project-1", status="pending"
+        )
+        first = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+            workload_profile=strict,
+        )
+        replay = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+            workload_profile=strict,
+        )
+
+        assert replay == first
+        with pytest.raises(
+            IdempotencyConflictError, match="different workload profile"
+        ):
+            journal.create_run_attempt(
+                "run-1",
+                request_id="initial",
+                reason="initial_execution",
+            )
+
+
+def test_unknown_capture_policy_cannot_silently_degrade_to_best_effort() -> (
+    None
+):
+    profile = replace(
+        DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+        capture_policy_ref="capture.unknown.v1",
+    )
+
+    with pytest.raises(ValueError, match="unsupported capture policy"):
+        validate_workload_profile(profile)
+
+
+def test_workload_profile_rejects_only_versions_outside_supported_window() -> (
+    None
+):
+    assert WORKLOAD_PROFILE_SCHEMA_VERSION == 1
+    assert (
+        validate_workload_profile(DEFAULT_PRODUCTION_WORKLOAD_PROFILE)
+        == DEFAULT_PRODUCTION_WORKLOAD_PROFILE
+    )
+    for unsupported in (0, WORKLOAD_PROFILE_SCHEMA_VERSION + 1):
+        with pytest.raises(ValueError, match="unsupported WorkloadProfile"):
+            validate_workload_profile(
+                replace(
+                    DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+                    schema_version=unsupported,
+                )
+            )
+
+
+def test_legacy_evidence_workload_profile_remains_readable() -> None:
+    legacy = replace(
+        DEFAULT_PRODUCTION_WORKLOAD_PROFILE,
+        workload_kind="test",
+        profile_version="test-v1",
+    )
+
+    assert validate_workload_profile(legacy) == legacy
+
+
+def test_capture_gap_is_idempotent_and_durable(tmp_path) -> None:
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(
+            run_id="run-1", project_id="project-1", status="pending"
+        )
+        attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+        )
+        first = journal.record_attempt_evidence_gap(
+            gap_id="gap-1",
+            run_id="run-1",
+            attempt_id=attempt.attempt_id,
+            dimension="model_decisions",
+            reason_code="capture_failed",
+            source="model_capture",
+            detail_code="RuntimeError",
+            now=2,
+        )
+        replay = journal.record_attempt_evidence_gap(
+            gap_id="gap-1",
+            run_id="run-1",
+            attempt_id=attempt.attempt_id,
+            dimension="model_decisions",
+            reason_code="capture_failed",
+            source="model_capture",
+            detail_code="RuntimeError",
+            now=3,
+        )
+
+        assert replay == first
+        assert journal.list_attempt_evidence_gaps(attempt.attempt_id) == (
+            first,
+        )
+        events = [
+            event
+            for event in journal.list_events("run-1")
+            if event.event_type == "attempt.evidence_gap_recorded"
+        ]
+        assert len(events) == 1
+        assert events[0].payload["reason_code"] == ("capture_failed")
+
+
+def test_capture_gap_can_bind_to_authored_step(tmp_path) -> None:
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(
+            run_id="run-1", project_id="project-1", status="pending"
+        )
+        attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+        )
+        journal.append_event(
+            "run-1",
+            step_event_draft(
+                run_id="run-1",
+                attempt_id=attempt.attempt_id,
+                step_id="step-1",
+                plan_item_id="plan-item-1",
+                title="Inspect evidence",
+                summary=None,
+                ordinal=0,
+                agent_id="agent-1",
+                event="created",
+                status="pending",
+            ),
+        )
+
+        gap = journal.record_attempt_evidence_gap(
+            gap_id="gap-1",
+            run_id="run-1",
+            attempt_id=attempt.attempt_id,
+            step_id="step-1",
+            dimension="model_decisions",
+            reason_code="capture_failed",
+            source="model_capture",
+        )
+
+        assert gap.step_id == "step-1"
+        assert journal.list_events("run-1")[-1].payload["step_id"] == (
+            "step-1"
+        )
+
+
+def test_capture_gap_rejects_step_from_another_attempt(tmp_path) -> None:
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(
+            run_id="run-1", project_id="project-1", status="pending"
+        )
+        first_attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+        )
+        journal.append_event(
+            "run-1",
+            step_event_draft(
+                run_id="run-1",
+                attempt_id=first_attempt.attempt_id,
+                step_id="step-1",
+                plan_item_id="plan-item-1",
+                title="Inspect evidence",
+                summary=None,
+                ordinal=0,
+                agent_id="agent-1",
+                event="created",
+                status="pending",
+            ),
+        )
+        journal.append_event(
+            "run-1",
+            RunEventDraft(
+                event_id="run-1:first-attempt-interrupted",
+                event_type="run.interrupted",
+                payload={"reason_code": "test_retry"},
+            ),
+        )
+        second_attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="retry",
+            reason="manual_retry",
+        )
+
+        with pytest.raises(
+            IdempotencyConflictError,
+            match="Step does not belong to the Run",
+        ):
+            journal.record_attempt_evidence_gap(
+                gap_id="gap-1",
+                run_id="run-1",
+                attempt_id=second_attempt.attempt_id,
+                step_id="step-1",
+                dimension="model_decisions",
+                reason_code="capture_failed",
+                source="model_capture",
+            )
+
+
+def test_capture_gap_and_event_roll_back_as_one_transaction(tmp_path) -> None:
+    with SQLiteRunJournal(tmp_path / "journal.sqlite3") as journal:
+        journal.ensure_run(
+            run_id="run-1", project_id="project-1", status="pending"
+        )
+        attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+        )
+
+        with (
+            patch.object(
+                journal,
+                "_append_event_in_transaction",
+                side_effect=RuntimeError("event write failed"),
+            ),
+            pytest.raises(RuntimeError, match="event write failed"),
+        ):
+            journal.record_attempt_evidence_gap(
+                gap_id="gap-1",
+                run_id="run-1",
+                attempt_id=attempt.attempt_id,
+                dimension="model_decisions",
+                reason_code="capture_failed",
+                source="model_capture",
+            )
+
+        assert journal.list_attempt_evidence_gaps(attempt.attempt_id) == ()
+
+
+def test_v33_database_backfills_default_workload_without_losing_attempt(
+    tmp_path,
+) -> None:
+    path = tmp_path / "journal.sqlite3"
+    with SQLiteRunJournal(path) as current:
+        current.ensure_run(
+            run_id="run-1", project_id="project-1", status="pending"
+        )
+        attempt = current.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+        )
+
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TABLE attempt_evidence_gaps")
+        connection.execute("DROP INDEX model_invocations_step_idx")
+        connection.execute("ALTER TABLE model_invocations DROP COLUMN step_id")
+        connection.execute("DROP INDEX run_attempts_workload_kind_idx")
+        connection.execute(
+            "ALTER TABLE run_attempts DROP COLUMN workload_profile_digest"
+        )
+        connection.execute(
+            "ALTER TABLE run_attempts DROP COLUMN workload_profile_json"
+        )
+        connection.execute(
+            "ALTER TABLE run_attempts DROP COLUMN workload_kind"
+        )
+        connection.execute(
+            "DELETE FROM run_journal_migrations WHERE version = 34"
+        )
+        connection.execute("PRAGMA user_version = 33")
+
+    with SQLiteRunJournal(path) as upgraded:
+        restored = upgraded.get_run_attempt(attempt.attempt_id)
+        assert upgraded.schema_version == SCHEMA_VERSION
+        assert restored is not None
+        assert restored.workload_profile == DEFAULT_PRODUCTION_WORKLOAD_PROFILE
+        assert restored.workload_profile_digest == workload_profile_digest(
+            DEFAULT_PRODUCTION_WORKLOAD_PROFILE
+        )
+        assert upgraded.list_attempt_evidence_gaps(attempt.attempt_id) == ()
+
+
+def test_v34_migration_defaults_are_frozen_historical_literals() -> None:
+    from app.run_journal.store import _MIGRATION_V34
+
+    source = inspect.getsource(store_module)
+    assert '_MIGRATION_V34 = """' in source
+    assert '_MIGRATION_V34 = f"""' not in source
+    assert (
+        "4786bb51388abddfbbe18decc88ada3e3e896b4aa9967970c2b99865d4999302"
+        in _MIGRATION_V34
+    )
+    assert (
+        '"retention_policy_ref":"retention.product-default.v1"'
+        in _MIGRATION_V34
+    )
+
+
+def test_attempt_read_rejects_redundant_workload_kind_mismatch(
+    tmp_path,
+) -> None:
+    path = tmp_path / "journal.sqlite3"
+    with SQLiteRunJournal(path) as journal:
+        journal.ensure_run(
+            run_id="run-1", project_id="project-1", status="pending"
+        )
+        attempt = journal.create_run_attempt(
+            "run-1",
+            request_id="initial",
+            reason="initial_execution",
+        )
+
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "UPDATE run_attempts SET workload_kind = 'test' "
+            "WHERE attempt_id = ?",
+            (attempt.attempt_id,),
+        )
+
+    with SQLiteRunJournal(path) as journal:
+        with pytest.raises(RunJournalError, match="kind mismatch"):
+            journal.get_run_attempt(attempt.attempt_id)

--- a/backend/tests/app/run_runtime/test_step_coordinator.py
+++ b/backend/tests/app/run_runtime/test_step_coordinator.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
 
@@ -53,6 +54,27 @@ def _item(
         status=status,  # type: ignore[arg-type]
         ordinal=ordinal,
     )
+
+
+@pytest.mark.unit
+def test_step_replay_filters_at_sql_boundary(tmp_path):
+    with _journal(tmp_path) as journal:
+        journal.append_event(
+            "run-1",
+            RunEventDraft(
+                event_id="unrelated",
+                event_type="tool.completed",
+                payload={"tool_call_id": "tool-1"},
+            ),
+        )
+        coordinator = RunStepCoordinator(journal)
+
+        with patch.object(
+            journal, "list_events", wraps=journal.list_events
+        ) as list_events:
+            assert coordinator.replay("run-1") == {}
+
+        list_events.assert_called_once_with("run-1", event_type_prefix="step.")
 
 
 @pytest.mark.unit

--- a/backend/tests/app/utils/test_workforce.py
+++ b/backend/tests/app/utils/test_workforce.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -30,7 +31,9 @@ from camel.tasks.task import TaskState
 
 from app.agent.listen_chat_agent import ListenChatAgent
 from app.exception.exception import UserException
+from app.run_journal.store import SQLiteRunJournal
 from app.run_runtime.active_timeout import pause_active_execution_timeout
+from app.run_runtime.step_coordinator import RunStepCoordinator, stable_step_id
 from app.service.task import (
     ActionAssignTaskData,
     ActionTaskStateData,
@@ -40,9 +43,87 @@ from app.service.task import (
 from app.utils.workforce import (
     _ANALYZE_TASK_MAX_RETRIES,
     Workforce,
+    _persist_workforce_subtask_step,
     default_workforce_stall_timeout,
     default_workforce_task_timeout,
 )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_workforce_persists_running_step_before_dispatch(tmp_path):
+    journal = SQLiteRunJournal(tmp_path / "journal.sqlite3")
+    journal.ensure_run(
+        run_id="run-1", project_id="project-1", status="pending"
+    )
+    journal.create_run_attempt(
+        "run-1",
+        request_id="initial",
+        reason="initial_execution",
+        activate=True,
+    )
+    task_lock = MagicMock()
+    task_lock.run_context = SimpleNamespace(
+        run_id="run-1",
+        project_id="project-1",
+    )
+
+    with patch(
+        "app.utils.workforce.get_default_run_journal",
+        return_value=journal,
+    ):
+        step_id = await _persist_workforce_subtask_step(
+            task_lock,
+            task_id="task-1",
+            title="Build report",
+            agent_id="agent-1",
+            phase="running",
+        )
+
+    assert step_id == stable_step_id("run-1", "subtask:task-1")
+    snapshot = RunStepCoordinator(journal).replay("run-1")[step_id]
+    assert snapshot.status == "running"
+    assert snapshot.owner_kind == "workforce"
+    assert snapshot.source == "workforce"
+    task_lock.mark_local_history_degraded.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_workforce_post_orders_step_before_queue_and_dispatch():
+    workforce = Workforce(api_task_id="project-1", description="Workforce")
+    workforce._task = Task(content="Main task", id="main-task")
+    subtask = Task(content="Build report", id="task-1")
+    order: list[str] = []
+    task_lock = MagicMock()
+
+    async def persist(*_args, **_kwargs):
+        order.append("persist")
+        return "step-1"
+
+    async def put_queue(_data):
+        order.append("queue")
+
+    async def dispatch(_self, _task, _assignee_id):
+        order.append("dispatch")
+
+    task_lock.put_queue.side_effect = put_queue
+    with (
+        patch("app.utils.workforce.get_task_lock", return_value=task_lock),
+        patch.object(
+            workforce,
+            "_get_agent_id_from_node_id",
+            return_value="agent-1",
+        ),
+        patch(
+            "app.utils.workforce._persist_workforce_subtask_step",
+            side_effect=persist,
+        ),
+        patch.object(BaseWorkforce, "_post_task", new=dispatch),
+    ):
+        await workforce._post_task(subtask, "worker-node-1")
+
+    assert order == ["persist", "queue", "dispatch"]
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

- add immutable workload profiles, attempt evidence gaps, and model invocation evidence to the desktop Run Journal
- capture model request, response, usage, latency, retry, and outcome data with best-effort product defaults and policy-driven retention
- author Workforce subtasks as canonical Steps before UI publication, while retaining an isolated compatibility projection for restored legacy streams
- add a pure Run Journal to OpenTelemetry GenAI projection contract pinned to a reviewed upstream semantic-convention source
- preserve Workforce ownership across replay, interaction, tool, and terminal transitions

## Safety and compatibility

- keeps the complete v1 through v34 SQLite migration chain
- keeps model capture non-blocking for normal product workloads
- isolates retention poison rows with per-candidate savepoints and does not mutate completed Run timelines
- leaves the OpenTelemetry schema URL unset until upstream publishes a resolvable GenAI schema URL

## Verification

- uv run pytest tests/app -q: 1672 passed, 12 skipped
- full backend pre-commit hooks passed twice without further modifications
- opt-in OpenTelemetry upstream conformance test passed

Base includes feat/polished review change ux (#1869).