### PR TITLE
feat: add self-hosted remote command control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,8 @@ nul
 
 backend/benchmark/jobs/
 
+# Local Celery beat scheduler state
+server/celerybeat-schedule*
+
 # TypeScript incremental build info
 *.tsbuildinfo

--- a/backend/app/run_sync/command_sync.py
+++ b/backend/app/run_sync/command_sync.py
@@ -145,7 +145,7 @@ class HttpCommandSyncTransport:
                     configuration,
                     payload={
                         "capabilities": {
-                            "run_event_sync": 1,
+                            "durable_command_control": 1,
                             "command_inbox": 1,
                             "command_result_sync": 1,
                         }

--- a/backend/app/run_sync/middleware.py
+++ b/backend/app/run_sync/middleware.py
@@ -28,5 +28,7 @@ async def cloud_sync_configuration_middleware(
         except Exception:
             # Replication freshness is never allowed to break a local Brain API
             # request. The durable outbox will be retried on later traffic.
-            logger.exception("Failed to refresh Run sync configuration")
+            logger.exception(
+                "Failed to refresh background service configuration"
+            )
     return await call_next(request)

--- a/backend/app/run_sync/runtime.py
+++ b/backend/app/run_sync/runtime.py
@@ -44,7 +44,7 @@ def _sync_endpoint(server_url: str | None) -> str:
         return ""
     parsed = urlparse(value)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        logger.warning("Ignoring invalid Run sync SERVER_URL: %s", value)
+        logger.warning("Ignoring invalid SERVER_URL: %s", value)
         return ""
     if value.endswith("/api/v1"):
         base = value
@@ -53,6 +53,14 @@ def _sync_endpoint(server_url: str | None) -> str:
     else:
         base = f"{value}/api/v1"
     return f"{base}/sync/events:ingest"
+
+
+def _uses_eigent_hosted_control_plane(server_url: str | None) -> bool:
+    """Identify Eigent-operated services without exposing a product switch."""
+
+    value = str(server_url or env("SERVER_URL", "")).strip()
+    hostname = (urlparse(value).hostname or "").lower()
+    return hostname == "eigent.ai" or hostname.endswith(".eigent.ai")
 
 
 def configure_default_cloud_sync_worker(
@@ -72,9 +80,27 @@ def configure_default_cloud_sync_worker(
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
-        logger.warning("Run sync configuration requires a running event loop")
+        logger.warning(
+            "Background service configuration requires a running event loop"
+        )
         return False
-    if _default_worker is None:
+    uses_hosted_control_plane = _uses_eigent_hosted_control_plane(server_url)
+    if (
+        _default_worker is not None or _default_command_worker is not None
+    ) and _worker_loop is not loop:
+        logger.error("Refusing to move background workers across event loops")
+        return False
+    if _default_command_worker is None:
+        from app.run_journal.runtime import get_default_run_journal
+
+        journal = get_default_run_journal()
+        _worker_loop = loop
+        _default_command_worker = CommandControlWorker(
+            journal,
+            HttpCommandSyncTransport(),
+        )
+        _default_command_worker.start()
+    if uses_hosted_control_plane and _default_worker is None:
         from app.run_journal.runtime import get_default_run_journal
 
         _default_worker = CloudSyncWorker(
@@ -83,20 +109,13 @@ def configure_default_cloud_sync_worker(
         )
         _worker_loop = loop
         _default_worker.start()
-        _default_command_worker = CommandControlWorker(
-            get_default_run_journal(),
-            HttpCommandSyncTransport(),
-        )
-        _default_command_worker.start()
-    elif _worker_loop is not loop:
-        logger.error("Refusing to move CloudSyncWorker across event loops")
-        return False
     configuration = CloudSyncConfiguration(
         endpoint_url=endpoint,
         authorization=auth,
         desktop_instance_id=instance_id,
     )
-    _default_worker.configure(configuration)
+    if uses_hosted_control_plane and _default_worker is not None:
+        _default_worker.configure(configuration)
     if _default_command_worker is not None:
         _default_command_worker.configure(configuration)
     return True
@@ -105,9 +124,10 @@ def configure_default_cloud_sync_worker(
 def notify_default_cloud_sync_worker() -> None:
     worker = _default_worker
     loop = _worker_loop
-    if worker is None or loop is None or loop.is_closed():
+    if loop is None or loop.is_closed():
         return
-    loop.call_soon_threadsafe(worker.notify)
+    if worker is not None:
+        loop.call_soon_threadsafe(worker.notify)
     if _default_command_worker is not None:
         loop.call_soon_threadsafe(_default_command_worker.notify)
 

--- a/backend/app/utils/server/sync_step.py
+++ b/backend/app/utils/server/sync_step.py
@@ -32,6 +32,7 @@ import httpx
 from app.component.environment import env
 from app.run_context import get_current_run_context
 from app.run_journal.runtime import get_default_event_recorder
+from app.run_sync.runtime import _uses_eigent_hosted_control_plane
 from app.service.task import get_task_lock_if_exists
 
 logger = logging.getLogger("sync_step")
@@ -70,7 +71,7 @@ def _normalize_server_url(server_url: str | None) -> str:
     return f"{trimmed}/api/v1"
 
 
-def _get_config(args):
+def _get_server_url(args) -> str:
     server_url = (
         getattr(args[0], "server_url", None)
         if args and hasattr(args[0], "server_url")
@@ -80,21 +81,27 @@ def _get_config(args):
     if not server_url:
         server_url = env("SERVER_URL", "")
 
-    server_url = _normalize_server_url(server_url)
+    return str(server_url or "").strip()
 
-    if not server_url:
+
+def _get_config(args):
+    server_url = _get_server_url(args)
+
+    # Local/self-hosted servers already own the full Run history in SQLite.
+    # The legacy step projection exists only for Eigent-operated Cloud APIs.
+    if not _uses_eigent_hosted_control_plane(server_url):
         return None
 
-    return f"{server_url}/chat/steps"
+    return f"{_normalize_server_url(server_url)}/chat/steps"
 
 
 def sync_step(func):
     async def wrapper(*args, **kwargs):
         config = _get_config(args)
 
-        if not config:
+        if not config and not _get_server_url(args):
             _warn_missing_server_url(args)
-        elif config not in _logged_sync_targets:
+        elif config and config not in _logged_sync_targets:
             _logged_sync_targets.add(config)
             logger.info("Cloud step sync enabled: %s", config)
 
@@ -142,9 +149,13 @@ async def sync_step_event(
             error=exc,
         )
 
-    sync_base = _normalize_server_url(server_url or env("SERVER_URL", ""))
-    if not sync_base or not authorization:
+    raw_server_url = str(server_url or env("SERVER_URL", "")).strip()
+    if (
+        not _uses_eigent_hosted_control_plane(raw_server_url)
+        or not authorization
+    ):
         return
+    sync_base = _normalize_server_url(raw_server_url)
 
     payload = {
         "task_id": task_id,

--- a/backend/tests/app/run_sync/test_command_sync.py
+++ b/backend/tests/app/run_sync/test_command_sync.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
@@ -224,10 +225,12 @@ async def test_device_registration_error_retries_command_lane(tmp_path):
 @pytest.mark.asyncio
 async def test_transport_reregisters_when_authenticated_credential_changes():
     registrations: list[str] = []
+    capabilities: list[dict[str, int]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path.endswith("/devices/register"):
             registrations.append(request.headers["authorization"])
+            capabilities.append(json.loads(request.content)["capabilities"])
             return httpx.Response(200, json={})
         assert request.url.path.endswith("/commands/pending")
         return httpx.Response(200, json={"items": []})
@@ -247,6 +250,18 @@ async def test_transport_reregisters_when_authenticated_credential_changes():
     assert await transport.pull_pending(second, limit=1) == []
 
     assert registrations == ["Bearer token", "Bearer another-account-token"]
+    assert capabilities == [
+        {
+            "durable_command_control": 1,
+            "command_inbox": 1,
+            "command_result_sync": 1,
+        },
+        {
+            "durable_command_control": 1,
+            "command_inbox": 1,
+            "command_result_sync": 1,
+        },
+    ]
     await transport.close()
 
 

--- a/backend/tests/app/run_sync/test_middleware.py
+++ b/backend/tests/app/run_sync/test_middleware.py
@@ -66,7 +66,7 @@ async def test_runtime_falls_back_to_process_owned_desktop_identity(
     )
 
     configured = runtime.configure_default_cloud_sync_worker(
-        server_url="https://cloud.example.test",
+        server_url="https://dev.eigent.ai",
         authorization="Bearer cloud-token",
         desktop_instance_id=None,
     )
@@ -75,3 +75,59 @@ async def test_runtime_falls_back_to_process_owned_desktop_identity(
     configuration = event_worker.configure.call_args.args[0]
     assert configuration.desktop_instance_id == "desk_process_owned_identity"
     command_worker.configure.assert_called_once_with(configuration)
+
+
+@pytest.mark.parametrize(
+    ("server_url", "expected"),
+    [
+        ("http://localhost:3001", False),
+        ("http://127.0.0.1:3001/api/v1", False),
+        ("http://host.docker.internal:3001", False),
+        ("https://self-host.example.test", False),
+        ("https://eigent.ai", True),
+        ("https://dev.eigent.ai/api/v1", True),
+    ],
+)
+def test_only_eigent_operated_servers_use_hosted_control_plane(
+    monkeypatch, server_url, expected
+):
+    monkeypatch.setattr(
+        runtime,
+        "env",
+        lambda _key, default="": default,
+    )
+
+    assert runtime._uses_eigent_hosted_control_plane(server_url) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "server_url",
+    ["http://localhost:3001", "https://self-host.example.test"],
+)
+async def test_self_host_configures_command_worker_only(
+    monkeypatch, server_url
+):
+    command_worker = SimpleNamespace(configure=Mock())
+    monkeypatch.setattr(runtime, "_default_worker", None)
+    monkeypatch.setattr(runtime, "_default_command_worker", command_worker)
+    monkeypatch.setattr(runtime, "_worker_loop", asyncio.get_running_loop())
+    monkeypatch.setattr(
+        runtime,
+        "env",
+        lambda key, default="": (
+            "desk-local" if key == "EIGENT_DESKTOP_INSTANCE_ID" else default
+        ),
+    )
+
+    configured = runtime.configure_default_cloud_sync_worker(
+        server_url=server_url,
+        authorization="Bearer local-token",
+        desktop_instance_id=None,
+    )
+
+    assert configured is True
+    assert runtime._default_worker is None
+    configuration = command_worker.configure.call_args.args[0]
+    assert configuration.desktop_instance_id == "desk-local"
+    assert configuration.endpoint_url.endswith("/sync/events:ingest")

--- a/backend/tests/app/utils/server/test_sync_step_journal.py
+++ b/backend/tests/app/utils/server/test_sync_step_journal.py
@@ -32,6 +32,35 @@ def clear_step_buffers():
     sync_step_module._local_text_buffers.clear()
 
 
+@pytest.mark.parametrize(
+    "server_url",
+    [
+        "http://localhost:3001",
+        "http://127.0.0.1:3001/api/v1",
+        "https://self-host.example.test",
+    ],
+)
+def test_self_hosted_server_does_not_enable_cloud_step_projection(
+    monkeypatch, server_url
+):
+    monkeypatch.setattr(sync_step_module, "env", lambda *_args: "")
+
+    chat = SimpleNamespace(server_url=server_url)
+
+    assert sync_step_module._get_config((chat,)) is None
+
+
+def test_eigent_hosted_server_enables_cloud_step_projection(monkeypatch):
+    monkeypatch.setattr(sync_step_module, "env", lambda *_args: "")
+
+    chat = SimpleNamespace(server_url="https://dev.eigent.ai")
+
+    assert (
+        sync_step_module._get_config((chat,))
+        == "https://dev.eigent.ai/api/v1/chat/steps"
+    )
+
+
 @pytest.mark.asyncio
 async def test_sse_step_is_committed_before_it_is_yielded(monkeypatch):
     order: list[str] = []
@@ -333,6 +362,31 @@ async def test_explicit_step_is_persisted_without_cloud_configuration(
     assert kwargs["run_id"] == "run-1"
     assert kwargs["step"] == "human_reply"
     assert kwargs["data"] == {"reply": "yes"}
+
+
+@pytest.mark.asyncio
+async def test_explicit_step_does_not_project_to_self_hosted_server(
+    monkeypatch,
+):
+    recorder = SimpleNamespace(record_legacy_step=AsyncMock())
+    send = AsyncMock()
+    monkeypatch.setattr(
+        sync_step_module, "get_default_event_recorder", lambda: recorder
+    )
+    monkeypatch.setattr(sync_step_module, "_send", send)
+
+    await sync_step_module.sync_step_event(
+        project_id="project-1",
+        task_id="run-1",
+        run_id="run-1",
+        step="human_reply",
+        data={"reply": "yes"},
+        authorization="Bearer local-token",
+        server_url="http://localhost:3001",
+    )
+
+    recorder.record_legacy_step.assert_awaited_once()
+    send.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,6 @@
+# Copy this file to server/.env before running ./start_server.sh.
+# The repository-root .env.development file is only for Vite/Electron and is
+# intentionally not loaded by the standalone server.
 debug=false
 url_prefix=/api
 secret_key=postgres
@@ -47,12 +50,26 @@ REMOTE_CONTROL_TRUSTED_PROXY_HOSTS=127.0.0.1,::1
 # Only set true for local/dev diagnostics; it intentionally allows wildcard CORS/WS origins.
 REMOTE_CONTROL_ALLOW_UNSAFE_ORIGINS=false
 
-# Configuration if not running in docker
-# database_url=postgresql://postgres:123456@localhost:5432/eigent
-# redis_url=redis://localhost:6379/0
-# celery_broker_url=redis://localhost:6379/0
-# celery_result_url=redis://localhost:6379/0
-# SESSION_REDIS_URL=redis://localhost:6379/1
+# Configuration when running the server directly on the host. Docker Compose
+# overrides these values with its service-network addresses.
+database_url=postgresql://postgres:123456@localhost:5432/eigent
+# PostgreSQL safety rails. Defaults are active even when omitted. These bound
+# connection, statement and lock waits; they do not limit agent task duration.
+DB_CONNECT_TIMEOUT_SECONDS=10
+DB_LOCK_TIMEOUT_MS=5000
+DB_STATEMENT_TIMEOUT_MS=120000
+DB_IDLE_IN_TRANSACTION_TIMEOUT_MS=60000
+# Pool sizing is per API process.
+DB_POOL_SIZE=10
+DB_MAX_OVERFLOW=10
+DB_POOL_TIMEOUT=10
+DB_POOL_RECYCLE=300
+redis_url=redis://localhost:6379/0
+SESSION_REDIS_URL=redis://localhost:6379/1
+# Keep local Celery traffic isolated from other Eigent/Docker workers that may
+# already use Redis DB 0. Docker Compose supplies its own explicit URLs.
+celery_broker_url=redis://localhost:6379/2
+celery_result_url=redis://localhost:6379/3
 
 # Trigger Schedule Poller Configuration
 # ENABLE_TRIGGER_SCHEDULE_POLLER_TASK: Enable/disable scheduled trigger polling

--- a/server/alembic/env.py
+++ b/server/alembic/env.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import logging
+import os
 import pathlib
 import sys
 from logging.config import fileConfig
@@ -25,16 +27,31 @@ from sqlalchemy import engine_from_config, pool
 from sqlmodel import SQLModel
 
 from alembic import context
-from app.core.environment import auto_import, env_not_empty
+from app.core.environment import auto_import, env
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
 
+
+def _resolve_database_url() -> str:
+    configured_environment_url = str(env("database_url", "")).strip()
+    if configured_environment_url:
+        return configured_environment_url
+    configured_alembic_url = str(config.get_main_option("sqlalchemy.url") or "").strip()
+    if not configured_alembic_url:
+        raise RuntimeError("database_url is not set and alembic.ini has no sqlalchemy.url")
+    logging.getLogger("alembic.env").warning("database_url is not set; using sqlalchemy.url from alembic.ini")
+    os.environ["database_url"] = configured_alembic_url
+    return configured_alembic_url
+
+
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+
+database_url = _resolve_database_url()
 
 # add your model's MetaData object here
 # for 'autogenerate' support
@@ -103,7 +120,7 @@ def run_migrations_offline() -> None:
     script output.
 
     """
-    url = env_not_empty("database_url")
+    url = database_url
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -130,7 +147,7 @@ def run_migrations_online() -> None:
 
     """
     options = config.get_section(config.config_ini_section, {})
-    options["sqlalchemy.url"] = env_not_empty("database_url")
+    options["sqlalchemy.url"] = database_url
     connectable = engine_from_config(
         options,
         prefix="sqlalchemy.",

--- a/server/alembic/versions/2026_06_10_1200-hosted_schema_compatibility_marker.py
+++ b/server/alembic/versions/2026_06_10_1200-hosted_schema_compatibility_marker.py
@@ -1,0 +1,30 @@
+"""preserve the shared-to-hosted migration boundary
+
+Revision ID: add_cloud_model_table
+Revises: add_rc_space_scope
+Create Date: 2026-06-10 12:00:00
+
+The Eigent-hosted distribution used this revision ID immediately after the
+last schema revision shared with the self-hosted server.  Some development
+databases therefore record it as their current Alembic revision.
+
+This self-hosted compatibility marker intentionally performs no DDL.  It lets
+those databases rejoin the self-hosted migration chain without importing the
+hosted-only model registry or mutating any hosted-only tables that may already
+exist.
+"""
+
+from collections.abc import Sequence
+
+revision: str = "add_cloud_model_table"
+down_revision: str | None = "add_rc_space_scope"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/server/alembic/versions/2026_08_27_1200-add_self_hosted_remote_command_control.py
+++ b/server/alembic/versions/2026_08_27_1200-add_self_hosted_remote_command_control.py
@@ -1,0 +1,427 @@
+"""add self-hosted durable remote command control
+
+Revision ID: add_self_hosted_rc_control
+Revises: add_rc_space_scope
+Create Date: 2026-08-27 12:00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "add_self_hosted_rc_control"
+down_revision: str | None = "add_rc_space_scope"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "remote_control_command",
+        sa.Column("client_request_id", sa.String(length=128), nullable=True),
+    )
+    op.add_column(
+        "remote_control_command",
+        sa.Column("request_fingerprint", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "remote_control_command",
+        sa.Column("interaction_decision_key", sa.String(length=64), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_remote_control_command_session_request",
+        "remote_control_command",
+        ["session_id", "client_request_id"],
+    )
+    op.create_index(
+        "uq_remote_control_command_interaction_decision_key",
+        "remote_control_command",
+        ["interaction_decision_key"],
+        unique=True,
+    )
+
+    op.create_table(
+        "desktop_device",
+        sa.Column("id", sa.String(length=128), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("install_public_key", sa.Text(), nullable=True),
+        sa.Column(
+            "credential_version",
+            sa.Integer(),
+            server_default=sa.text("1"),
+            nullable=False,
+        ),
+        sa.Column("app_version", sa.String(length=64), nullable=True),
+        sa.Column(
+            "capabilities",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_desktop_device_user_active",
+        "desktop_device",
+        ["user_id", "revoked_at"],
+    )
+
+    op.create_table(
+        "project_execution_route",
+        sa.Column("project_id", sa.String(length=128), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "owner_kind",
+            sa.String(length=32),
+            server_default="desktop_device",
+            nullable=False,
+        ),
+        sa.Column("target_device_id", sa.String(length=128), nullable=False),
+        sa.Column(
+            "route_version",
+            sa.BigInteger(),
+            server_default=sa.text("1"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "owner_kind IN ('desktop_device')",
+            name="ck_project_execution_route_owner_kind_valid",
+        ),
+        sa.CheckConstraint(
+            "route_version >= 1",
+            name="ck_project_execution_route_version_positive",
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["target_device_id"], ["desktop_device.id"]),
+        sa.PrimaryKeyConstraint("project_id"),
+    )
+    op.create_index(
+        "ix_project_execution_route_device",
+        "project_execution_route",
+        ["target_device_id", "updated_at"],
+    )
+
+    op.create_table(
+        "remote_command_state",
+        sa.Column("command_id", sa.String(length=64), nullable=False),
+        sa.Column("session_id", sa.String(length=64), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("project_id", sa.String(length=128), nullable=False),
+        sa.Column("run_id", sa.String(length=128), nullable=True),
+        sa.Column("route_device_id", sa.String(length=128), nullable=False),
+        sa.Column("route_version", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "receipt_state",
+            sa.String(length=32),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column(
+            "admission_state",
+            sa.String(length=32),
+            server_default="unknown",
+            nullable=False,
+        ),
+        sa.Column(
+            "execution_state",
+            sa.String(length=32),
+            server_default="not_started",
+            nullable=False,
+        ),
+        sa.Column("actual_execution_state", sa.String(length=32), nullable=True),
+        sa.Column(
+            "expected_next_desktop_event_sequence",
+            sa.BigInteger(),
+            server_default=sa.text("1"),
+            nullable=False,
+        ),
+        sa.Column(
+            "server_recorded_version",
+            sa.BigInteger(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("receipt_grace_until", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "next_delivery_attempt_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "delivery_attempt_count",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column("delivery_lease_owner", sa.String(length=128), nullable=True),
+        sa.Column("lease_token", sa.String(length=64), nullable=True),
+        sa.Column("lease_until", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("durably_received_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("admitted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expired_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "late_result",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column("integrity_alert", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "receipt_state IN ('pending', 'durably_received', 'expired')",
+            name="ck_remote_command_receipt_state_valid",
+        ),
+        sa.CheckConstraint(
+            "admission_state IN ('unknown', 'accepted', 'rejected')",
+            name="ck_remote_command_admission_state_valid",
+        ),
+        sa.CheckConstraint(
+            "execution_state IN ('not_started', 'running', 'completed', 'failed')",
+            name="ck_remote_command_execution_state_valid",
+        ),
+        sa.CheckConstraint(
+            "expected_next_desktop_event_sequence >= 1",
+            name="ck_remote_command_next_desktop_sequence_positive",
+        ),
+        sa.CheckConstraint(
+            "server_recorded_version >= 0",
+            name="ck_remote_command_server_version_non_negative",
+        ),
+        sa.CheckConstraint(
+            "delivery_attempt_count >= 0",
+            name="ck_remote_command_delivery_attempt_non_negative",
+        ),
+        sa.CheckConstraint(
+            "receipt_grace_until >= expires_at",
+            name="ck_remote_command_receipt_grace_order",
+        ),
+        sa.ForeignKeyConstraint(
+            ["command_id"],
+            ["remote_control_command.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("command_id"),
+    )
+    op.create_index(
+        "ix_remote_command_delivery_pending",
+        "remote_command_state",
+        [
+            "route_device_id",
+            "next_delivery_attempt_at",
+            "lease_until",
+            "expires_at",
+        ],
+        postgresql_where=sa.text("receipt_state = 'pending'"),
+    )
+    op.create_index(
+        "ix_remote_command_receipt_expiry",
+        "remote_command_state",
+        ["receipt_grace_until", "lease_until"],
+        postgresql_where=sa.text("receipt_state = 'pending'"),
+    )
+    op.create_index(
+        "ix_remote_command_state_project_created",
+        "remote_command_state",
+        ["project_id", "created_at"],
+    )
+
+    op.create_table(
+        "remote_command_lifecycle_event",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("command_id", sa.String(length=64), nullable=False),
+        sa.Column("producer", sa.String(length=16), nullable=False),
+        sa.Column("desktop_event_sequence", sa.BigInteger(), nullable=True),
+        sa.Column("server_recorded_version", sa.BigInteger(), nullable=True),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "producer IN ('desktop', 'server')",
+            name="ck_remote_command_event_producer_valid",
+        ),
+        sa.CheckConstraint(
+            "(producer = 'desktop' AND desktop_event_sequence IS NOT NULL "
+            "AND server_recorded_version IS NULL) OR "
+            "(producer = 'server' AND desktop_event_sequence IS NULL "
+            "AND server_recorded_version IS NOT NULL)",
+            name="ck_remote_command_event_version_lane",
+        ),
+        sa.ForeignKeyConstraint(
+            ["command_id"],
+            ["remote_command_state.command_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "command_id",
+            "desktop_event_sequence",
+            name="uq_remote_command_event_desktop_sequence",
+        ),
+        sa.UniqueConstraint(
+            "command_id",
+            "server_recorded_version",
+            name="uq_remote_command_event_server_version",
+        ),
+    )
+    op.create_index(
+        "ix_remote_command_event_command_created",
+        "remote_command_lifecycle_event",
+        ["command_id", "created_at"],
+    )
+
+    op.create_table(
+        "remote_command_notification_outbox",
+        sa.Column("event_id", sa.String(length=64), nullable=False),
+        sa.Column("command_id", sa.String(length=64), nullable=False),
+        sa.Column("session_id", sa.String(length=64), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=16),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column(
+            "attempt_count",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column(
+            "available_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("lease_token", sa.String(length=64), nullable=True),
+        sa.Column("lease_until", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('pending', 'published')",
+            name="ck_remote_command_notification_status_valid",
+        ),
+        sa.CheckConstraint(
+            "attempt_count >= 0",
+            name="ck_remote_command_notification_attempt_non_negative",
+        ),
+        sa.ForeignKeyConstraint(
+            ["event_id"],
+            ["remote_command_lifecycle_event.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("event_id"),
+    )
+    op.create_index(
+        "ix_remote_command_notification_pending",
+        "remote_command_notification_outbox",
+        ["available_at", "lease_until", "session_id"],
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+    op.create_index(
+        "ix_remote_command_notification_published",
+        "remote_command_notification_outbox",
+        ["published_at"],
+        postgresql_where=sa.text("status = 'published'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_remote_command_notification_published",
+        table_name="remote_command_notification_outbox",
+    )
+    op.drop_index(
+        "ix_remote_command_notification_pending",
+        table_name="remote_command_notification_outbox",
+    )
+    op.drop_table("remote_command_notification_outbox")
+    op.drop_index(
+        "ix_remote_command_event_command_created",
+        table_name="remote_command_lifecycle_event",
+    )
+    op.drop_table("remote_command_lifecycle_event")
+    op.drop_index(
+        "ix_remote_command_state_project_created",
+        table_name="remote_command_state",
+    )
+    op.drop_index(
+        "ix_remote_command_receipt_expiry",
+        table_name="remote_command_state",
+    )
+    op.drop_index(
+        "ix_remote_command_delivery_pending",
+        table_name="remote_command_state",
+    )
+    op.drop_table("remote_command_state")
+    op.drop_index(
+        "ix_project_execution_route_device",
+        table_name="project_execution_route",
+    )
+    op.drop_table("project_execution_route")
+    op.drop_index("ix_desktop_device_user_active", table_name="desktop_device")
+    op.drop_table("desktop_device")
+    op.drop_index(
+        "uq_remote_control_command_interaction_decision_key",
+        table_name="remote_control_command",
+    )
+    op.drop_constraint(
+        "uq_remote_control_command_session_request",
+        "remote_control_command",
+        type_="unique",
+    )
+    op.drop_column("remote_control_command", "interaction_decision_key")
+    op.drop_column("remote_control_command", "request_fingerprint")
+    op.drop_column("remote_control_command", "client_request_id")

--- a/server/alembic/versions/2026_08_27_1230-merge_self_hosted_remote_command_lineages.py
+++ b/server/alembic/versions/2026_08_27_1230-merge_self_hosted_remote_command_lineages.py
@@ -1,0 +1,24 @@
+"""merge hosted compatibility and self-hosted command lineages
+
+Revision ID: merge_self_hosted_rc_lineages
+Revises: add_cloud_model_table, add_self_hosted_rc_control
+Create Date: 2026-08-27 12:30:00
+"""
+
+from collections.abc import Sequence
+
+revision: str = "merge_self_hosted_rc_lineages"
+down_revision: tuple[str, str] = (
+    "add_cloud_model_table",
+    "add_self_hosted_rc_control",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/server/app/core/database.py
+++ b/server/app/core/database.py
@@ -12,27 +12,74 @@
 # limitations under the License.
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import asyncio
 import logging
+from collections.abc import Callable
 
+from sqlalchemy.engine import make_url
 from sqlmodel import Session, create_engine
 
 from app.core.environment import env, env_or_fail
 
 logger = logging.getLogger("database")
 
+
+def _env_int(name: str, default: int, *, min_value: int = 0) -> int:
+    raw_value = env(name)
+    try:
+        value = int(raw_value) if raw_value not in {None, ""} else default
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid integer environment value; using default",
+            extra={"name": name, "value": raw_value, "default": default},
+        )
+        value = default
+    return max(min_value, value)
+
+
+def _database_connect_args(database_url: str) -> dict[str, object]:
+    """Bound PostgreSQL waits without limiting a long-running agent task."""
+
+    if make_url(database_url).get_backend_name() != "postgresql":
+        return {}
+
+    connect_timeout_seconds = _env_int("DB_CONNECT_TIMEOUT_SECONDS", 10, min_value=1)
+    lock_timeout_ms = _env_int("DB_LOCK_TIMEOUT_MS", 5_000, min_value=1)
+    statement_timeout_ms = _env_int("DB_STATEMENT_TIMEOUT_MS", 120_000, min_value=1)
+    idle_transaction_timeout_ms = _env_int("DB_IDLE_IN_TRANSACTION_TIMEOUT_MS", 60_000, min_value=1)
+    return {
+        "connect_timeout": connect_timeout_seconds,
+        "options": " ".join(
+            (
+                f"-c lock_timeout={lock_timeout_ms}",
+                f"-c statement_timeout={statement_timeout_ms}",
+                f"-c idle_in_transaction_session_timeout={idle_transaction_timeout_ms}",
+            )
+        ),
+    }
+
+
+database_url = env_or_fail("database_url")
+
 logger.info(
     "Initializing database engine",
     extra={
-        "database_url_prefix": env_or_fail("database_url")[:20] + "...",
+        "database_url_prefix": database_url[:20] + "...",
         "debug_mode": env("debug") == "on",
-        "pool_size": 36,
+        "pool_size": _env_int("DB_POOL_SIZE", 10, min_value=1),
     },
 )
 
 engine = create_engine(
-    env_or_fail("database_url"),
+    database_url,
     echo=True if env("debug") == "on" else False,
-    pool_size=36,
+    pool_size=_env_int("DB_POOL_SIZE", 10, min_value=1),
+    max_overflow=_env_int("DB_MAX_OVERFLOW", 10),
+    pool_pre_ping=True,
+    pool_recycle=_env_int("DB_POOL_RECYCLE", 300, min_value=1),
+    pool_timeout=_env_int("DB_POOL_TIMEOUT", 10, min_value=1),
+    pool_reset_on_return="rollback",
+    connect_args=_database_connect_args(database_url),
 )
 
 logger.info("Database engine initialized successfully")
@@ -47,7 +94,40 @@ def session_make():
 
 def session():
     logger.debug("Creating database session context")
-    with Session(engine) as session:
+    with Session(engine) as db:
         logger.debug("Database session context established")
-        yield session
-        logger.debug("Database session context closed")
+        try:
+            yield db
+        finally:
+            db.rollback()
+            logger.debug("Database session context closed")
+
+
+def run_in_session[T](
+    operation: Callable[[Session], T],
+    *,
+    commit: bool = False,
+) -> T:
+    """Run one bounded unit of database work in a fresh, closed session."""
+
+    with session_make() as db:
+        try:
+            result = operation(db)
+            if commit:
+                db.commit()
+            else:
+                db.rollback()
+            return result
+        except Exception:
+            db.rollback()
+            raise
+
+
+async def run_in_session_async[T](
+    operation: Callable[[Session], T],
+    *,
+    commit: bool = False,
+) -> T:
+    """Run synchronous SQLModel work outside the asyncio event-loop thread."""
+
+    return await asyncio.to_thread(run_in_session, operation, commit=commit)

--- a/server/app/domains/remote_control/api/command_control_controller.py
+++ b/server/app/domains/remote_control/api/command_control_controller.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, Query
+from sqlmodel import Session
+
+from app.core.database import session
+from app.domains.remote_control.schema import (
+    CommandEventsIn,
+    CommandEventsOut,
+    ConfirmCommandReceiptIn,
+    ConfirmCommandReceiptOut,
+    DeviceRegistrationIn,
+    DeviceRegistrationOut,
+    PendingCommandsOut,
+    ProjectRouteClaimIn,
+    ProjectRouteOut,
+)
+from app.domains.remote_control.service.command_control_service import (
+    CommandControlService,
+)
+from app.shared.auth import auth_must
+from app.shared.auth.user_auth import V1UserAuth
+
+router = APIRouter(prefix="/sync", tags=["Remote Command Control"])
+
+
+class DevicePrincipal:
+    __slots__ = ("desktop_instance_id", "user_id")
+
+    def __init__(self, user_id: int, desktop_instance_id: str) -> None:
+        self.user_id = user_id
+        self.desktop_instance_id = desktop_instance_id
+
+
+async def device_principal_must(
+    auth: Annotated[V1UserAuth, Depends(auth_must)],
+    desktop_instance_id: Annotated[str | None, Header(alias="X-Desktop-Instance-ID")] = None,
+) -> DevicePrincipal:
+    value = (desktop_instance_id or "").strip()
+    if not value or len(value) > 128:
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "desktop_instance_id_required"},
+        )
+    return DevicePrincipal(user_id=auth.id, desktop_instance_id=value)
+
+
+@router.post("/devices/register", response_model=DeviceRegistrationOut)
+def register_device(
+    body: DeviceRegistrationIn,
+    principal: Annotated[DevicePrincipal, Depends(device_principal_must)],
+    db: Annotated[Session, Depends(session)],
+) -> DeviceRegistrationOut:
+    result = CommandControlService.register_device(
+        principal.desktop_instance_id,
+        principal.user_id,
+        body,
+        db,
+    )
+    db.commit()
+    return result
+
+
+@router.put(
+    "/projects/{project_id}/execution-route",
+    response_model=ProjectRouteOut,
+)
+def claim_project_execution_route(
+    project_id: str,
+    body: ProjectRouteClaimIn,
+    principal: Annotated[DevicePrincipal, Depends(device_principal_must)],
+    db: Annotated[Session, Depends(session)],
+) -> ProjectRouteOut:
+    result = CommandControlService.claim_project_route(
+        project_id,
+        principal.desktop_instance_id,
+        principal.user_id,
+        body.expected_route_version,
+        db,
+    )
+    db.commit()
+    return result
+
+
+@router.get("/commands/pending", response_model=PendingCommandsOut)
+def pending_commands(
+    principal: Annotated[DevicePrincipal, Depends(device_principal_must)],
+    db: Annotated[Session, Depends(session)],
+    limit: int = Query(default=50, ge=1, le=200),
+) -> PendingCommandsOut:
+    result = CommandControlService.claim_pending_commands(
+        principal.desktop_instance_id,
+        principal.user_id,
+        limit,
+        db,
+    )
+    db.commit()
+    return result
+
+
+@router.post(
+    "/commands/{command_id}/confirm-receipt",
+    response_model=ConfirmCommandReceiptOut,
+)
+def confirm_command_receipt(
+    command_id: str,
+    body: ConfirmCommandReceiptIn,
+    principal: Annotated[DevicePrincipal, Depends(device_principal_must)],
+    db: Annotated[Session, Depends(session)],
+) -> ConfirmCommandReceiptOut:
+    result = CommandControlService.confirm_receipt(
+        command_id,
+        principal.desktop_instance_id,
+        principal.user_id,
+        body,
+        db,
+    )
+    db.commit()
+    return result
+
+
+@router.post("/commands/{command_id}/events", response_model=CommandEventsOut)
+def ingest_command_events(
+    command_id: str,
+    body: CommandEventsIn,
+    principal: Annotated[DevicePrincipal, Depends(device_principal_must)],
+    db: Annotated[Session, Depends(session)],
+) -> CommandEventsOut:
+    result = CommandControlService.ingest_command_events(
+        command_id,
+        principal.desktop_instance_id,
+        principal.user_id,
+        body,
+        db,
+    )
+    db.commit()
+    return result

--- a/server/app/domains/remote_control/api/remote_control_controller.py
+++ b/server/app/domains/remote_control/api/remote_control_controller.py
@@ -33,6 +33,8 @@ from app.core.database import session, session_make
 from app.core.environment import env
 from app.core.redis_utils import get_redis_manager
 from app.domains.remote_control.schema import (
+    CommandStateOut,
+    DeviceRegistrationIn,
     RemoteControlCommandIn,
     RemoteControlCommandOut,
     RemoteControlCreateProjectIn,
@@ -50,8 +52,13 @@ from app.domains.remote_control.schema import (
     RemoteControlSessionOut,
     RemoteControlStepsOut,
 )
-from app.model.project.project import ProjectOut
-from app.model.space.apply import SpaceOverlayListResponse
+from app.domains.remote_control.service.command_control_service import (
+    CommandControlService,
+)
+from app.domains.remote_control.service.command_notifier import (
+    cleanup_published_command_outbox,
+    drain_command_notification_outbox,
+)
 from app.domains.remote_control.service.remote_control_service import (
     COMMAND_ACKNOWLEDGED,
     COMMAND_FAILED,
@@ -59,18 +66,24 @@ from app.domains.remote_control.service.remote_control_service import (
     RemoteControlRedis,
     RemoteControlService,
 )
-from app.model.remote_control import RemoteControlCommand, RemoteControlSession
+from app.model.project.project import ProjectOut
+from app.model.remote_control import (
+    RemoteCommandState,
+    RemoteControlCommand,
+    RemoteControlSession,
+)
+from app.model.space.apply import SpaceOverlayListResponse
 from app.model.user.user import User
 from app.shared.auth import auth_must
 from app.shared.auth.token_blacklist import BLACKLIST_PUBSUB_PREFIX, is_blacklisted
 from app.shared.auth.user_auth import V1UserAuth, _get_jti
-from app.shared.middleware.rate_limit import rate_limiter_factory
 from app.shared.middleware.origins import (
     configured_remote_origins,
     csv_values,
     is_local_dev_origin,
     truthy,
 )
+from app.shared.middleware.rate_limit import rate_limiter_factory
 
 router = APIRouter(prefix="/remote-control", tags=["Remote Control"])
 
@@ -377,13 +390,54 @@ async def _auth_token(token: str | None, db: Session) -> V1UserAuth:
     return auth
 
 
+async def _send_bridge_http_error(websocket: WebSocket, exc: HTTPException) -> None:
+    detail = exc.detail
+    if isinstance(detail, dict):
+        error_code = str(detail.get("code") or "bridge_rejected")
+        message = str(detail.get("message") or error_code)
+    else:
+        error_code = "bridge_rejected"
+        message = detail if isinstance(detail, str) else str(detail)
+    if exc.status_code == 401:
+        await websocket.send_json({"type": "auth_expired", "message": message})
+        await websocket.close(code=4401)
+        return
+    if exc.status_code == 429:
+        await websocket.send_json(
+            {
+                "type": "error",
+                "code": error_code,
+                "message": message,
+                "retryable": True,
+            }
+        )
+        await websocket.close(code=1013)
+        return
+    retryable = exc.status_code >= 500
+    await websocket.send_json(
+        {
+            "type": "error",
+            "code": error_code,
+            "message": message,
+            "retryable": retryable,
+        }
+    )
+    await websocket.close(code=1011 if retryable else 1008)
+
+
 def _pending_bridge_commands(
     desktop_instance_id: str,
     user_id: int,
     db: Session,
     *,
     limit: int = 50,
-) -> list[tuple[RemoteControlSession, RemoteControlCommand]]:
+) -> list[
+    tuple[
+        RemoteControlSession,
+        RemoteControlCommand,
+        RemoteCommandState | None,
+    ]
+]:
     sessions = db.exec(
         select(RemoteControlSession).where(
             RemoteControlSession.user_id == user_id,
@@ -395,36 +449,72 @@ def _pending_bridge_commands(
         return []
 
     sessions_by_id = {rc_session.id: rc_session for rc_session in sessions}
-    commands = db.exec(
-        select(RemoteControlCommand)
-        .where(
-            RemoteControlCommand.session_id.in_(sessions_by_id.keys()),
-            RemoteControlCommand.status == COMMAND_PENDING,
-        )
-        .order_by(RemoteControlCommand.created_at)
-        .limit(limit)
-    ).all()
-    return [
-        (sessions_by_id[command.session_id], command)
-        for command in commands
-        if command.session_id in sessions_by_id
-    ]
+    claimed = CommandControlService.claim_pending_commands(
+        desktop_instance_id,
+        user_id,
+        limit,
+        db,
+    )
+    rows: list[
+        tuple[
+            RemoteControlSession,
+            RemoteControlCommand,
+            RemoteCommandState | None,
+        ]
+    ] = []
+    claimed_ids: set[str] = set()
+    for item in claimed.items:
+        command = db.get(RemoteControlCommand, item.command_id)
+        state = db.get(RemoteCommandState, item.command_id)
+        rc_session = sessions_by_id.get(item.session_id)
+        if command is not None and state is not None and rc_session is not None:
+            rows.append((rc_session, command, state))
+            claimed_ids.add(command.id)
+
+    # Preserve the pre-migration delivery lane for old pending rows and for
+    # existing commands that intentionally remain outside the new durable
+    # control plane. They keep their legacy at-most-once semantics; new remote
+    # commands always have a RemoteCommandState.
+    remaining = max(0, limit - len(rows))
+    if remaining:
+        legacy_commands = db.exec(
+            select(RemoteControlCommand)
+            .where(
+                RemoteControlCommand.session_id.in_(tuple(sessions_by_id)),
+                RemoteControlCommand.status == COMMAND_PENDING,
+            )
+            .order_by(RemoteControlCommand.created_at)
+            .limit(limit)
+        ).all()
+        for command in legacy_commands:
+            if command.id in claimed_ids:
+                continue
+            if db.get(RemoteCommandState, command.id) is not None:
+                continue
+            rc_session = sessions_by_id.get(command.session_id)
+            if rc_session is not None:
+                rows.append((rc_session, command, None))
+                remaining -= 1
+                if remaining == 0:
+                    break
+    return rows
 
 
 async def _send_bridge_command(
     websocket: WebSocket,
-    rc_session: RemoteControlSession,
-    command: RemoteControlCommand,
+    payload: dict[str, Any],
+    desktop_instance_id: str,
+    command_id: str,
 ) -> bool:
     try:
-        await websocket.send_json(RemoteControlService.command_payload(rc_session, command))
+        await websocket.send_json(payload)
         return True
     except Exception as exc:
         logger.warning(
             "Failed to send remote-control command to desktop bridge",
             extra={
-                "desktop_instance_id": rc_session.desktop_instance_id,
-                "command_id": command.id,
+                "desktop_instance_id": desktop_instance_id,
+                "command_id": command_id,
                 "error": str(exc),
             },
         )
@@ -444,9 +534,21 @@ async def _flush_pending_bridge_commands(
     if websocket is None and bridge_users.get(desktop_instance_id) != user_id:
         return 0
 
+    pending = _pending_bridge_commands(desktop_instance_id, user_id, db)
+    pending_payloads = [
+        (
+            RemoteControlService.command_payload(rc_session, command, state),
+            rc_session.desktop_instance_id,
+            command.id,
+        )
+        for rc_session, command, state in pending
+    ]
+    # Leases must be durable before Desktop is notified.
+    db.commit()
+
     delivered_count = 0
-    for rc_session, command in _pending_bridge_commands(desktop_instance_id, user_id, db):
-        if await _send_bridge_command(target_ws, rc_session, command):
+    for payload, target_desktop_id, command_id in pending_payloads:
+        if await _send_bridge_command(target_ws, payload, target_desktop_id, command_id):
             delivered_count += 1
     return delivered_count
 
@@ -646,6 +748,29 @@ async def send_command(
     )
     await _flush_pending_for_session(rc_session, db_session)
     return result
+
+
+@router.get(
+    "/sessions/{session_id}/commands/{command_id}",
+    response_model=CommandStateOut,
+)
+def get_command_state(
+    session_id: str,
+    command_id: str,
+    t: str | None = Query(None),
+    x_remote_control_token: str | None = Header(None, alias="X-Remote-Control-Token"),
+    db_session: Session = Depends(session),
+):
+    rc_session = RemoteControlService.verify_link(
+        session_id,
+        _remote_link_token(t, x_remote_control_token),
+        None,
+        db_session,
+    )
+    command = db_session.get(RemoteControlCommand, command_id)
+    if command is None or command.session_id != session_id:
+        raise HTTPException(status_code=404, detail="Command not found")
+    return CommandControlService.get_command_state(command_id, rc_session.user_id, db_session)
 
 
 @router.get(
@@ -849,7 +974,7 @@ async def bridge_subscribe(websocket: WebSocket):
                 websocket.receive_json(),
                 timeout=WS_SUBSCRIBE_TIMEOUT_SECONDS,
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             await websocket.close(code=1008)
             return
 
@@ -877,7 +1002,9 @@ async def bridge_subscribe(websocket: WebSocket):
             await websocket.send_json(
                 {
                     "type": "error",
+                    "code": "device_owner_mismatch",
                     "message": "Desktop instance is already registered to another user",
+                    "retryable": False,
                 }
             )
             await websocket.close(code=1008)
@@ -891,9 +1018,27 @@ async def bridge_subscribe(websocket: WebSocket):
                 capabilities=data.get("capabilities"),
             )
         except ValueError as exc:
-            await websocket.send_json({"type": "error", "message": str(exc)})
+            await websocket.send_json(
+                {
+                    "type": "error",
+                    "code": "bridge_registration_conflict",
+                    "message": str(exc),
+                    "retryable": False,
+                }
+            )
             await websocket.close(code=1008)
             return
+
+        CommandControlService.register_device(
+            desktop_instance_id,
+            user_id,
+            DeviceRegistrationIn(
+                app_version=data.get("app_version"),
+                capabilities=data.get("capabilities") or {},
+            ),
+            db,
+        )
+        db.commit()
 
         bridge_websockets[desktop_instance_id] = websocket
         bridge_users[desktop_instance_id] = user_id
@@ -908,6 +1053,25 @@ async def bridge_subscribe(websocket: WebSocket):
             )
         ).all()
         for rc_session in sessions:
+            active_project_id = rc_session.current_project_id or rc_session.project_id
+            if active_project_id:
+                try:
+                    CommandControlService.claim_project_route(
+                        active_project_id,
+                        desktop_instance_id,
+                        user_id,
+                        None,
+                        db,
+                    )
+                except HTTPException as exc:
+                    logger.warning(
+                        "Skipping stale remote-control execution route",
+                        extra={
+                            "session_id": rc_session.id,
+                            "project_id": active_project_id,
+                            "detail": exc.detail,
+                        },
+                    )
             rc_session.bridge_status = "online"
             rc_session.last_bridge_seen_at = now
             db.add(rc_session)
@@ -958,10 +1122,7 @@ async def bridge_subscribe(websocket: WebSocket):
                 # validate that first before checking the cached expiry.
                 now = datetime.utcnow()
                 next_token_raw = _strip_bearer(msg.get("auth_token"))
-                if (
-                    next_token_raw
-                    and (not token_raw or not secrets.compare_digest(next_token_raw, token_raw))
-                ):
+                if next_token_raw and (not token_raw or not secrets.compare_digest(next_token_raw, token_raw)):
                     try:
                         new_auth, new_exp, new_jti = await _validate_bridge_token(
                             next_token_raw, db, user_id, token_is_stripped=True
@@ -972,9 +1133,7 @@ async def bridge_subscribe(websocket: WebSocket):
                         _remember_bridge_token_jti(desktop_instance_id, token_jti)
                         next_blacklist_check_at = now + timedelta(seconds=blacklist_check_interval)
                     except HTTPException as exc:
-                        await websocket.send_json(
-                            {"type": "auth_expired", "message": exc.detail}
-                        )
+                        await websocket.send_json({"type": "auth_expired", "message": exc.detail})
                         await websocket.close(code=4401)
                         return
                 if token_expires_at <= now:
@@ -1008,9 +1167,7 @@ async def bridge_subscribe(websocket: WebSocket):
                     next_blacklist_check_at = datetime.utcnow() + timedelta(seconds=blacklist_check_interval)
                     await websocket.send_json({"type": "reauth_ok"})
                 except HTTPException as exc:
-                    await websocket.send_json(
-                        {"type": "auth_expired", "message": exc.detail}
-                    )
+                    await websocket.send_json({"type": "auth_expired", "message": exc.detail})
                     await websocket.close(code=4401)
                     return
             elif msg_type == "command_delivered" and msg.get("command_id"):
@@ -1045,8 +1202,7 @@ async def bridge_subscribe(websocket: WebSocket):
     except WebSocketDisconnect:
         logger.info("Remote-control bridge disconnected", extra={"desktop_instance_id": desktop_instance_id})
     except HTTPException as exc:
-        await websocket.send_json({"type": "error", "message": exc.detail})
-        await websocket.close()
+        await _send_bridge_http_error(websocket, exc)
     except Exception as exc:
         logger.error("Remote-control bridge websocket failed", extra={"error": str(exc)}, exc_info=True)
     finally:
@@ -1113,7 +1269,7 @@ async def events_subscribe(websocket: WebSocket, session_id: str):
                 websocket.receive_json(),
                 timeout=WS_SUBSCRIBE_TIMEOUT_SECONDS,
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             await websocket.close(code=1008)
             return
 
@@ -1388,16 +1544,34 @@ async def _run_scanners() -> None:
     logger.info("Remote-control retry/TTL scanner started")
     while True:
         await asyncio.sleep(10)
-        db = session_make()
+        now = datetime.utcnow()
+        scan_stale_bridges = _last_bridge_ttl_scan_at is None or now - _last_bridge_ttl_scan_at >= timedelta(seconds=30)
+        if scan_stale_bridges:
+            _last_bridge_ttl_scan_at = now
+        try:
+            await asyncio.to_thread(_run_scanner_iteration, scan_stale_bridges)
+        except Exception as exc:
+            logger.warning(
+                "Remote-control scanner iteration failed",
+                extra={"error": str(exc)},
+                exc_info=True,
+            )
+
+
+def _run_scanner_iteration(scan_stale_bridges: bool) -> None:
+    """Keep synchronous DB/Redis maintenance off the asyncio event loop."""
+
+    with session_make() as db:
         try:
             RemoteControlService.retry_pending_commands(db)
             RemoteControlService.expire_timed_out_commands(db)
-            now = datetime.utcnow()
-            if _last_bridge_ttl_scan_at is None or now - _last_bridge_ttl_scan_at >= timedelta(seconds=30):
-                _last_bridge_ttl_scan_at = now
+            CommandControlService.expire_pending_commands(db)
+            if scan_stale_bridges:
                 RemoteControlService.expire_stale_bridges(db)
-        except Exception as exc:
+            db.commit()
+        except Exception:
             db.rollback()
-            logger.warning("Remote-control scanner iteration failed", extra={"error": str(exc)}, exc_info=True)
-        finally:
-            db.close()
+            raise
+    drain_command_notification_outbox()
+    if scan_stale_bridges:
+        cleanup_published_command_outbox()

--- a/server/app/domains/remote_control/schema/schemas.py
+++ b/server/app/domains/remote_control/schema/schemas.py
@@ -12,19 +12,21 @@
 # limitations under the License.
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+import json
+import math
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.model.project.project import ProjectOut
 from app.model.space.apply import ApplyResolutionIn
 from app.model.space.space import SpaceOut
 
-
 RemoteControlCommandType = Literal[
     "user_message",
     "human_reply",
+    "interaction_decision",
     "stop",
     "skip_task",
     "add_task",
@@ -37,6 +39,29 @@ RemoteControlCommandType = Literal[
     "space_refresh_project",
     "space_discard_project_overlays",
 ]
+
+
+def _bounded_interaction_value(value: Any) -> bool:
+    node_count = 0
+
+    def visit(item: Any, depth: int) -> bool:
+        nonlocal node_count
+        node_count += 1
+        if node_count > 1024 or depth > 6:
+            return False
+        if isinstance(item, dict):
+            return all(
+                isinstance(key, str) and len(key) <= 255 and visit(child, depth + 1) for key, child in item.items()
+            )
+        if isinstance(item, list):
+            return len(item) <= 256 and all(visit(child, depth + 1) for child in item)
+        if isinstance(item, float):
+            return math.isfinite(item)
+        return item is None or isinstance(item, (str, int, bool))
+
+    if not visit(value, 0):
+        return False
+    return len(json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")) <= 256 * 1024
 
 
 class RemoteControlCreateSessionIn(BaseModel):
@@ -96,6 +121,7 @@ class RemoteControlExtendOut(BaseModel):
 
 
 class RemoteControlCommandIn(BaseModel):
+    client_request_id: str = Field(min_length=1, max_length=128)
     source_channel: str = "remote_web"
     type: RemoteControlCommandType
     payload: dict[str, Any] = Field(default_factory=dict)
@@ -103,6 +129,230 @@ class RemoteControlCommandIn(BaseModel):
     target_project_id: str | None = None
     target_task_id: str | None = None
     target_brain_session_id: str | None = None
+
+    @model_validator(mode="after")
+    def validate_interaction_decision(self):
+        if self.type != "interaction_decision":
+            return self
+        allowed = {
+            "run_id",
+            "interaction_id",
+            "expected_version",
+            "action_digest",
+            "decision",
+            "supersedes_command_id",
+        }
+        unknown = set(self.payload) - allowed
+        if unknown:
+            raise ValueError("unsupported interaction decision fields: " + ", ".join(sorted(unknown)))
+        run_id = self.payload.get("run_id")
+        interaction_id = self.payload.get("interaction_id")
+        expected_version = self.payload.get("expected_version")
+        decision = self.payload.get("decision")
+        if not isinstance(run_id, str) or not 1 <= len(run_id) <= 128:
+            raise ValueError("interaction_decision requires a valid run_id")
+        if not isinstance(interaction_id, str) or not 1 <= len(interaction_id) <= 128:
+            raise ValueError("interaction_decision requires a valid interaction_id")
+        if not isinstance(expected_version, int) or isinstance(expected_version, bool) or expected_version < 0:
+            raise ValueError("interaction_decision requires a non-negative expected_version")
+        action_digest = self.payload.get("action_digest")
+        if action_digest is not None and (
+            not isinstance(action_digest, str)
+            or len(action_digest) != 64
+            or any(character not in "0123456789abcdef" for character in action_digest)
+        ):
+            raise ValueError("interaction_decision action_digest is invalid")
+        supersedes_command_id = self.payload.get("supersedes_command_id")
+        if supersedes_command_id is not None and (
+            not isinstance(supersedes_command_id, str) or not 1 <= len(supersedes_command_id) <= 64
+        ):
+            raise ValueError("interaction_decision supersedes_command_id is invalid")
+        if not isinstance(decision, dict) or not decision:
+            raise ValueError("interaction_decision requires a decision object")
+        allowed_decision_fields = {
+            "reply",
+            "decision",
+            "scope",
+            "option_id",
+            "value",
+            "values",
+        }
+        unknown_decision_fields = set(decision) - allowed_decision_fields
+        if unknown_decision_fields:
+            raise ValueError("unsupported interaction response fields: " + ", ".join(sorted(unknown_decision_fields)))
+        variants = sum(key in decision for key in ("reply", "decision", "option_id", "values"))
+        if variants != 1:
+            raise ValueError("interaction_decision must contain exactly one response shape")
+        if "reply" in decision and set(decision) != {"reply"}:
+            raise ValueError("interaction reply has incompatible fields")
+        if "decision" in decision and not set(decision).issubset({"decision", "scope"}):
+            raise ValueError("interaction approval has incompatible fields")
+        if "option_id" in decision and not set(decision).issubset({"option_id", "value"}):
+            raise ValueError("interaction choice has incompatible fields")
+        if "values" in decision and set(decision) != {"values"}:
+            raise ValueError("interaction form has incompatible fields")
+        if "reply" in decision and (
+            not isinstance(decision["reply"], str) or not decision["reply"].strip() or len(decision["reply"]) > 100_000
+        ):
+            raise ValueError("interaction reply is invalid")
+        if "decision" in decision and decision["decision"] not in {
+            "approved",
+            "rejected",
+        }:
+            raise ValueError("interaction approval decision is invalid")
+        if "scope" in decision and decision["scope"] not in {
+            "once",
+            "run",
+            "space",
+        }:
+            raise ValueError("interaction decision scope is invalid")
+        if "option_id" in decision and (
+            not isinstance(decision["option_id"], str)
+            or not decision["option_id"].strip()
+            or len(decision["option_id"]) > 255
+        ):
+            raise ValueError("interaction option_id is invalid")
+        if "values" in decision and (
+            not isinstance(decision["values"], dict)
+            or not decision["values"]
+            or len(decision["values"]) > 128
+            or not _bounded_interaction_value(decision["values"])
+        ):
+            raise ValueError("interaction form values are invalid")
+        if not _bounded_interaction_value(decision):
+            raise ValueError("interaction decision payload is too large or deeply nested")
+        return self
+
+
+class DeviceRegistrationIn(BaseModel):
+    install_public_key: str | None = Field(default=None, max_length=8192)
+    app_version: str | None = Field(default=None, max_length=64)
+    capabilities: dict[str, Any] = Field(default_factory=dict)
+
+
+class DeviceRegistrationOut(BaseModel):
+    device_id: str
+    account_owner_id: str
+    credential_version: int
+    registered_at: datetime
+
+
+class ProjectRouteClaimIn(BaseModel):
+    expected_route_version: int | None = Field(default=None, ge=1)
+
+
+class ProjectRouteOut(BaseModel):
+    project_id: str
+    target_device_id: str
+    route_version: int
+
+
+class PendingCommandOut(BaseModel):
+    command_id: str
+    session_id: str
+    user_id: int
+    project_id: str
+    run_id: str | None
+    route_version: int
+    command_type: str
+    payload: dict[str, Any]
+    space_id: str | None
+    target_brain_session_id: str | None
+    source_channel: str
+    next_task_id: str | None
+    expires_at: datetime
+    receipt_grace_until: datetime
+    requires_online_receipt_confirmation: bool
+    lease_token: str = Field(min_length=1, max_length=64)
+
+
+class PendingCommandsOut(BaseModel):
+    items: list[PendingCommandOut]
+
+
+class ConfirmCommandReceiptIn(BaseModel):
+    event_id: str = Field(min_length=1, max_length=64)
+    desktop_event_sequence: int = Field(ge=1)
+    occurred_at: datetime
+    lease_token: str = Field(min_length=1, max_length=64)
+
+
+class ConfirmCommandReceiptOut(BaseModel):
+    result: str
+    command_id: str
+    receipt_state: str
+    expected_next_desktop_event_sequence: int
+    may_execute: bool
+
+
+class CommandEventIn(BaseModel):
+    event_id: str = Field(min_length=1, max_length=64)
+    desktop_event_sequence: int = Field(ge=1)
+    event_type: str = Field(min_length=1, max_length=64)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    occurred_at: datetime
+
+
+class CommandEventsIn(BaseModel):
+    events: list[CommandEventIn] = Field(min_length=1, max_length=100)
+    delivery_lease_token: str | None = Field(default=None, min_length=1, max_length=64)
+
+    @model_validator(mode="after")
+    def require_consecutive_unique_events(self):
+        event_ids = [event.event_id for event in self.events]
+        if len(event_ids) != len(set(event_ids)):
+            raise ValueError("event_id values must be unique within a batch")
+        sequences = [event.desktop_event_sequence for event in self.events]
+        if sequences != list(range(sequences[0], sequences[0] + len(sequences))):
+            raise ValueError("events must be ordered by consecutive desktop_event_sequence")
+        return self
+
+
+class CommandEventAckOut(BaseModel):
+    event_id: str
+    desktop_event_sequence: int
+    inserted: bool
+
+
+class CommandEventsOut(BaseModel):
+    command_id: str
+    expected_next_desktop_event_sequence: int
+    receipt_state: str
+    admission_state: str
+    execution_state: str
+    late_result: bool
+    items: list[CommandEventAckOut]
+
+
+class CommandStateEventOut(BaseModel):
+    event_id: str
+    producer: str
+    desktop_event_sequence: int | None
+    server_recorded_version: int | None
+    # Temporary protocol alias for Desktop builds released before the
+    # self-hosted server renamed this lane. It carries the same local value;
+    # no hosted/cloud storage is involved.
+    cloud_recorded_version: int | None = None
+    event_type: str
+    payload: dict[str, Any]
+    occurred_at: datetime
+
+
+class CommandStateOut(BaseModel):
+    command_id: str
+    project_id: str
+    run_id: str | None
+    route_device_id: str
+    route_version: int
+    receipt_state: str
+    admission_state: str
+    execution_state: str
+    actual_execution_state: str | None
+    late_result: bool
+    integrity_alert: str | None
+    expires_at: datetime
+    receipt_grace_until: datetime
+    events: list[CommandStateEventOut]
 
 
 class RemoteControlPatchTargetIn(BaseModel):

--- a/server/app/domains/remote_control/service/command_control_service.py
+++ b/server/app/domains/remote_control/service/command_control_service.py
@@ -1,0 +1,903 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from fastapi import HTTPException
+from sqlalchemy import or_
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, select
+
+from app.domains.remote_control.schema import (
+    CommandEventAckOut,
+    CommandEventIn,
+    CommandEventsIn,
+    CommandEventsOut,
+    CommandStateEventOut,
+    CommandStateOut,
+    ConfirmCommandReceiptIn,
+    ConfirmCommandReceiptOut,
+    DeviceRegistrationIn,
+    DeviceRegistrationOut,
+    PendingCommandOut,
+    PendingCommandsOut,
+    ProjectRouteOut,
+)
+from app.model.project.project import Project
+from app.model.remote_control import (
+    DesktopDevice,
+    ProjectExecutionRoute,
+    RemoteCommandLifecycleEvent,
+    RemoteCommandNotificationOutbox,
+    RemoteCommandState,
+    RemoteControlCommand,
+    RemoteControlSession,
+)
+
+COMMAND_TTL = timedelta(minutes=5)
+RECEIPT_GRACE = timedelta(seconds=30)
+DELIVERY_LEASE = timedelta(seconds=30)
+HIGH_RISK_COMMAND_TYPES = {
+    "interaction_decision",
+    "stop",
+    "stop_task",
+    "remove_task",
+    "apply_project",
+    "discard_project_overlays",
+    "space_apply_project_run",
+    "space_discard_project_overlays",
+}
+DESKTOP_EVENT_TYPES = {
+    "receipt.durably_received",
+    "admission.accepted",
+    "admission.rejected",
+    "execution.started",
+    "execution.completed",
+    "execution.failed",
+}
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _id(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex}"
+
+
+def _conflict(code: str, message: str, **context: object) -> HTTPException:
+    return HTTPException(
+        status_code=409,
+        detail={"code": code, "message": message, **context},
+    )
+
+
+class CommandControlService:
+    """Self-hosted durable command plane; callers own transactions."""
+
+    @staticmethod
+    def register_device(
+        device_id: str,
+        user_id: int,
+        body: DeviceRegistrationIn,
+        db: Session,
+    ) -> DeviceRegistrationOut:
+        now = _now()
+        device = db.get(DesktopDevice, device_id)
+        if device is None:
+            candidate = DesktopDevice(
+                id=device_id,
+                user_id=user_id,
+                install_public_key=body.install_public_key,
+                app_version=body.app_version,
+                capabilities=body.capabilities,
+                last_seen_at=now,
+                created_at=now,
+                updated_at=now,
+            )
+            try:
+                with db.begin_nested():
+                    db.add(candidate)
+                    db.flush()
+                device = candidate
+            except IntegrityError:
+                device = db.get(DesktopDevice, device_id)
+                if device is None:
+                    raise
+        if device.user_id != user_id:
+            raise _conflict(
+                "device_owner_mismatch",
+                "Desktop device belongs to another user",
+            )
+        if device.revoked_at is not None:
+            raise HTTPException(status_code=403, detail={"code": "device_revoked"})
+        if body.install_public_key:
+            if device.install_public_key and device.install_public_key != body.install_public_key:
+                raise _conflict(
+                    "install_key_mismatch",
+                    "Device install key requires explicit credential rotation",
+                )
+            device.install_public_key = body.install_public_key
+        device.app_version = body.app_version or device.app_version
+        device.capabilities = body.capabilities
+        device.last_seen_at = now
+        device.updated_at = now
+        db.add(device)
+        db.flush()
+        return DeviceRegistrationOut(
+            device_id=device.id,
+            account_owner_id=str(user_id),
+            credential_version=device.credential_version,
+            registered_at=device.created_at,
+        )
+
+    @staticmethod
+    def require_device(device_id: str, user_id: int, db: Session) -> DesktopDevice:
+        device = db.get(DesktopDevice, device_id)
+        if device is None:
+            raise HTTPException(
+                status_code=401,
+                detail={"code": "device_not_registered"},
+            )
+        if device.user_id != user_id:
+            raise HTTPException(status_code=403, detail={"code": "device_owner_mismatch"})
+        if device.revoked_at is not None:
+            raise HTTPException(status_code=403, detail={"code": "device_revoked"})
+        return device
+
+    @staticmethod
+    def _require_project_owner(project_id: str, user_id: int, db: Session) -> Project:
+        project = db.get(Project, project_id)
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        if str(project.user_id) != str(user_id):
+            raise HTTPException(
+                status_code=403,
+                detail="Project does not belong to this user",
+            )
+        return project
+
+    @staticmethod
+    def claim_project_route(
+        project_id: str,
+        device_id: str,
+        user_id: int,
+        expected_route_version: int | None,
+        db: Session,
+    ) -> ProjectRouteOut:
+        CommandControlService.require_device(device_id, user_id, db)
+        CommandControlService._require_project_owner(project_id, user_id, db)
+        route = db.exec(
+            select(ProjectExecutionRoute).where(ProjectExecutionRoute.project_id == project_id).with_for_update()
+        ).one_or_none()
+        now = _now()
+        if route is None:
+            if expected_route_version is not None:
+                raise _conflict(
+                    "route_version_conflict",
+                    "Project has no execution route",
+                    current_route_version=None,
+                )
+            candidate = ProjectExecutionRoute(
+                project_id=project_id,
+                user_id=user_id,
+                target_device_id=device_id,
+                route_version=1,
+                created_at=now,
+                updated_at=now,
+            )
+            try:
+                with db.begin_nested():
+                    db.add(candidate)
+                    db.flush()
+                route = candidate
+            except IntegrityError:
+                route = db.get(ProjectExecutionRoute, project_id)
+                if route is None:
+                    raise
+                if route.user_id != user_id:
+                    raise _conflict(
+                        "route_owner_mismatch",
+                        "Project route belongs to another user",
+                    )
+                if route.target_device_id != device_id:
+                    raise _conflict(
+                        "route_version_conflict",
+                        "Project route was concurrently claimed",
+                        current_route_version=route.route_version,
+                        target_device_id=route.target_device_id,
+                    )
+        elif route.user_id != user_id:
+            raise _conflict(
+                "route_owner_mismatch",
+                "Project route belongs to another user",
+            )
+        elif route.target_device_id != device_id:
+            if expected_route_version != route.route_version:
+                raise _conflict(
+                    "route_version_conflict",
+                    "Route transfer requires the current route version",
+                    current_route_version=route.route_version,
+                    target_device_id=route.target_device_id,
+                )
+            route.target_device_id = device_id
+            route.route_version += 1
+            route.updated_at = now
+        db.add(route)
+        db.flush()
+        return ProjectRouteOut(
+            project_id=route.project_id,
+            target_device_id=route.target_device_id,
+            route_version=route.route_version,
+        )
+
+    @staticmethod
+    def _append_server_event(
+        state: RemoteCommandState,
+        event_type: str,
+        payload: dict,
+        db: Session,
+        *,
+        occurred_at: datetime | None = None,
+    ) -> RemoteCommandLifecycleEvent:
+        state.server_recorded_version += 1
+        event = RemoteCommandLifecycleEvent(
+            id=_id("rcse"),
+            command_id=state.command_id,
+            producer="server",
+            server_recorded_version=state.server_recorded_version,
+            event_type=event_type,
+            payload=payload,
+            occurred_at=occurred_at or _now(),
+        )
+        db.add(event)
+        db.flush()
+        db.add(
+            RemoteCommandNotificationOutbox(
+                event_id=event.id,
+                command_id=state.command_id,
+                session_id=state.session_id,
+            )
+        )
+        return event
+
+    @staticmethod
+    def create_state_for_command(
+        command: RemoteControlCommand,
+        rc_session: RemoteControlSession,
+        db: Session,
+    ) -> RemoteCommandState:
+        existing = db.get(RemoteCommandState, command.id)
+        if existing is not None:
+            return existing
+        project_id = command.target_project_id or rc_session.current_project_id or rc_session.project_id
+        if not project_id:
+            raise HTTPException(status_code=400, detail={"code": "REMOTE_TARGET_REQUIRED"})
+        route = db.get(ProjectExecutionRoute, project_id)
+        if route is None:
+            device = CommandControlService.require_device(rc_session.desktop_instance_id, command.user_id, db)
+            route_out = CommandControlService.claim_project_route(
+                project_id,
+                device.id,
+                command.user_id,
+                expected_route_version=None,
+                db=db,
+            )
+            route = db.get(ProjectExecutionRoute, route_out.project_id)
+        if route is None or route.user_id != command.user_id:
+            raise _conflict(
+                "route_owner_mismatch",
+                "Project execution route is invalid",
+            )
+        if route.target_device_id != rc_session.desktop_instance_id:
+            raise _conflict(
+                "project_routed_to_another_device",
+                "Remote session is not attached to the execution owner",
+                target_device_id=route.target_device_id,
+                route_version=route.route_version,
+            )
+        now = _now()
+        expires_at = min(_utc(rc_session.expires_at), now + COMMAND_TTL)
+        state = RemoteCommandState(
+            command_id=command.id,
+            session_id=command.session_id,
+            user_id=command.user_id,
+            project_id=project_id,
+            run_id=command.target_task_id,
+            route_device_id=route.target_device_id,
+            route_version=route.route_version,
+            expires_at=expires_at,
+            receipt_grace_until=expires_at + RECEIPT_GRACE,
+            next_delivery_attempt_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        try:
+            with db.begin_nested():
+                db.add(state)
+                db.flush()
+        except IntegrityError:
+            winner = db.get(RemoteCommandState, command.id)
+            if winner is None:
+                raise
+            if (
+                winner.user_id != command.user_id
+                or winner.session_id != command.session_id
+                or winner.project_id != project_id
+                or winner.route_device_id != route.target_device_id
+                or winner.route_version != route.route_version
+            ):
+                raise _conflict(
+                    "command_state_conflict",
+                    "Concurrent command state has different ownership",
+                )
+            return winner
+        CommandControlService._append_server_event(
+            state,
+            "command.pending",
+            {
+                "route_device_id": route.target_device_id,
+                "route_version": route.route_version,
+            },
+            db,
+            occurred_at=now,
+        )
+        db.flush()
+        return state
+
+    @staticmethod
+    def claim_pending_commands(
+        device_id: str,
+        user_id: int,
+        limit: int,
+        db: Session,
+    ) -> PendingCommandsOut:
+        CommandControlService.require_device(device_id, user_id, db)
+        now = _now()
+        rows = list(
+            db.exec(
+                select(RemoteCommandState)
+                .where(
+                    RemoteCommandState.user_id == user_id,
+                    RemoteCommandState.route_device_id == device_id,
+                    RemoteCommandState.receipt_state == "pending",
+                    RemoteCommandState.expires_at >= now,
+                    RemoteCommandState.next_delivery_attempt_at <= now,
+                    or_(
+                        RemoteCommandState.lease_until.is_(None),
+                        RemoteCommandState.lease_until < now,
+                    ),
+                )
+                .order_by(
+                    RemoteCommandState.created_at,
+                    RemoteCommandState.command_id,
+                )
+                .limit(limit)
+                .with_for_update(skip_locked=True)
+            ).all()
+        )
+        items: list[PendingCommandOut] = []
+        for state in rows:
+            command = db.get(RemoteControlCommand, state.command_id)
+            if command is None:
+                state.integrity_alert = "missing_remote_control_command"
+                state.updated_at = now
+                db.add(state)
+                continue
+            state.delivery_attempt_count += 1
+            state.delivery_lease_owner = device_id
+            state.lease_token = uuid4().hex
+            state.lease_until = min(_utc(state.expires_at), now + DELIVERY_LEASE)
+            state.next_delivery_attempt_at = state.lease_until
+            state.updated_at = now
+            CommandControlService._append_server_event(
+                state,
+                "delivery.leased",
+                {
+                    "attempt": state.delivery_attempt_count,
+                    "lease_until": state.lease_until.isoformat(),
+                },
+                db,
+                occurred_at=now,
+            )
+            db.add(state)
+            items.append(
+                PendingCommandOut(
+                    command_id=command.id,
+                    session_id=command.session_id,
+                    user_id=command.user_id,
+                    project_id=state.project_id,
+                    run_id=state.run_id,
+                    route_version=state.route_version,
+                    command_type=command.type,
+                    payload=command.payload,
+                    space_id=command.space_id,
+                    target_brain_session_id=command.target_brain_session_id,
+                    source_channel=command.source_channel,
+                    next_task_id=command.next_task_id,
+                    expires_at=state.expires_at,
+                    receipt_grace_until=state.receipt_grace_until,
+                    requires_online_receipt_confirmation=(command.type in HIGH_RISK_COMMAND_TYPES),
+                    lease_token=state.lease_token,
+                )
+            )
+        db.flush()
+        return PendingCommandsOut(items=items)
+
+    @staticmethod
+    def lease_command_for_delivery(
+        command_id: str,
+        device_id: str,
+        user_id: int,
+        db: Session,
+    ) -> RemoteCommandState:
+        CommandControlService.require_device(device_id, user_id, db)
+        state = db.exec(
+            select(RemoteCommandState).where(RemoteCommandState.command_id == command_id).with_for_update()
+        ).one_or_none()
+        if state is None:
+            raise HTTPException(status_code=404, detail="Command not found")
+        if state.user_id != user_id or state.route_device_id != device_id:
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "command_device_mismatch"},
+            )
+        now = _now()
+        if state.receipt_state != "pending" or _utc(state.expires_at) < now:
+            return state
+        if (
+            state.lease_token
+            and state.delivery_lease_owner == device_id
+            and state.lease_until is not None
+            and _utc(state.lease_until) >= now
+        ):
+            return state
+        state.delivery_attempt_count += 1
+        state.delivery_lease_owner = device_id
+        state.lease_token = uuid4().hex
+        state.lease_until = min(_utc(state.expires_at), now + DELIVERY_LEASE)
+        state.next_delivery_attempt_at = state.lease_until
+        state.updated_at = now
+        CommandControlService._append_server_event(
+            state,
+            "delivery.leased",
+            {
+                "attempt": state.delivery_attempt_count,
+                "lease_until": state.lease_until.isoformat(),
+            },
+            db,
+            occurred_at=now,
+        )
+        db.add(state)
+        db.flush()
+        return state
+
+    @staticmethod
+    def _lock_owned_state(
+        command_id: str,
+        device_id: str,
+        user_id: int,
+        db: Session,
+    ) -> RemoteCommandState:
+        state = db.exec(
+            select(RemoteCommandState).where(RemoteCommandState.command_id == command_id).with_for_update()
+        ).one_or_none()
+        if state is None:
+            raise HTTPException(status_code=404, detail="Command not found")
+        if state.user_id != user_id or state.route_device_id != device_id:
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "command_device_mismatch"},
+            )
+        return state
+
+    @staticmethod
+    def _require_current_delivery_lease(
+        state: RemoteCommandState,
+        *,
+        device_id: str,
+        lease_token: str | None,
+        now: datetime,
+    ) -> None:
+        if state.receipt_state != "pending":
+            return
+        if (
+            not lease_token
+            or state.delivery_lease_owner != device_id
+            or state.lease_token != lease_token
+            or state.lease_until is None
+            or (_utc(state.lease_until) < now and now <= _utc(state.receipt_grace_until))
+        ):
+            raise _conflict(
+                "stale_command_delivery_lease",
+                "Command receipt does not own the current delivery lease",
+            )
+
+    @staticmethod
+    def _same_desktop_event(
+        existing: RemoteCommandLifecycleEvent,
+        event: CommandEventIn,
+    ) -> bool:
+        return (
+            existing.desktop_event_sequence == event.desktop_event_sequence
+            and existing.event_type == event.event_type
+            and existing.payload == event.payload
+            and _utc(existing.occurred_at) == _utc(event.occurred_at)
+        )
+
+    @staticmethod
+    def _insert_desktop_event(
+        state: RemoteCommandState,
+        event: CommandEventIn,
+        db: Session,
+    ) -> RemoteCommandLifecycleEvent:
+        row = RemoteCommandLifecycleEvent(
+            id=event.event_id,
+            command_id=state.command_id,
+            producer="desktop",
+            desktop_event_sequence=event.desktop_event_sequence,
+            event_type=event.event_type,
+            payload=event.payload,
+            occurred_at=_utc(event.occurred_at),
+        )
+        db.add(row)
+        db.flush()
+        db.add(
+            RemoteCommandNotificationOutbox(
+                event_id=row.id,
+                command_id=state.command_id,
+                session_id=state.session_id,
+            )
+        )
+        return row
+
+    @staticmethod
+    def _mark_legacy_command_expired(command_id: str, db: Session) -> None:
+        command = db.get(RemoteControlCommand, command_id)
+        if command is not None and command.status in {"pending", "delivered"}:
+            command.status = "expired"
+            command.error_code = "COMMAND_EXPIRED"
+            command.error = "Remote command expired before durable receipt"
+            db.add(command)
+
+    @staticmethod
+    def _expire_pending_receipt(
+        state: RemoteCommandState,
+        db: Session,
+        *,
+        now: datetime,
+        reason: str,
+        integrity_alert: str | None = None,
+    ) -> bool:
+        if state.receipt_state != "pending":
+            if state.receipt_state == "expired":
+                CommandControlService._mark_legacy_command_expired(state.command_id, db)
+            return False
+        state.receipt_state = "expired"
+        state.expired_at = now
+        state.delivery_lease_owner = None
+        state.lease_token = None
+        state.lease_until = None
+        state.updated_at = now
+        if integrity_alert:
+            state.integrity_alert = state.integrity_alert or integrity_alert
+        CommandControlService._append_server_event(
+            state,
+            "receipt.expired",
+            {"reason": reason},
+            db,
+            occurred_at=now,
+        )
+        CommandControlService._mark_legacy_command_expired(state.command_id, db)
+        db.add(state)
+        return True
+
+    @staticmethod
+    def confirm_receipt(
+        command_id: str,
+        device_id: str,
+        user_id: int,
+        body: ConfirmCommandReceiptIn,
+        db: Session,
+    ) -> ConfirmCommandReceiptOut:
+        CommandControlService.require_device(device_id, user_id, db)
+        state = CommandControlService._lock_owned_state(command_id, device_id, user_id, db)
+        event = CommandEventIn(
+            event_id=body.event_id,
+            desktop_event_sequence=body.desktop_event_sequence,
+            event_type="receipt.durably_received",
+            occurred_at=body.occurred_at,
+        )
+        existing = db.get(RemoteCommandLifecycleEvent, body.event_id)
+        if existing is not None:
+            if existing.command_id != command_id or not CommandControlService._same_desktop_event(existing, event):
+                raise _conflict(
+                    "command_event_id_conflict",
+                    "event_id has different canonical content",
+                )
+            result = "expired_late" if state.receipt_state == "expired" else "already_received"
+            return ConfirmCommandReceiptOut(
+                result=result,
+                command_id=command_id,
+                receipt_state=state.receipt_state,
+                expected_next_desktop_event_sequence=(state.expected_next_desktop_event_sequence),
+                may_execute=state.receipt_state == "durably_received",
+            )
+        if body.desktop_event_sequence != state.expected_next_desktop_event_sequence:
+            raise _conflict(
+                "command_sequence_gap",
+                "Receipt is not the next Desktop command event",
+                expected_next_desktop_event_sequence=(state.expected_next_desktop_event_sequence),
+            )
+        if state.receipt_state == "durably_received":
+            raise _conflict(
+                "duplicate_receipt_event",
+                "Receipt was already confirmed with another event_id",
+            )
+        now = _now()
+        CommandControlService._require_current_delivery_lease(
+            state,
+            device_id=device_id,
+            lease_token=body.lease_token,
+            now=now,
+        )
+        CommandControlService._insert_desktop_event(state, event, db)
+        state.expected_next_desktop_event_sequence += 1
+        state.delivery_lease_owner = None
+        state.lease_token = None
+        state.lease_until = None
+        if state.receipt_state == "expired" or now > _utc(state.receipt_grace_until):
+            CommandControlService._expire_pending_receipt(
+                state,
+                db,
+                now=now,
+                reason="durable_receipt_after_grace",
+                integrity_alert="durable_receipt_after_grace",
+            )
+            state.late_result = True
+            result = "expired_late"
+            may_execute = False
+        else:
+            state.receipt_state = "durably_received"
+            state.durably_received_at = now
+            result = "confirmed"
+            may_execute = True
+        state.updated_at = now
+        db.add(state)
+        db.flush()
+        return ConfirmCommandReceiptOut(
+            result=result,
+            command_id=command_id,
+            receipt_state=state.receipt_state,
+            expected_next_desktop_event_sequence=(state.expected_next_desktop_event_sequence),
+            may_execute=may_execute,
+        )
+
+    @staticmethod
+    def _project_event(
+        state: RemoteCommandState,
+        event: CommandEventIn,
+        now: datetime,
+        db: Session,
+    ) -> None:
+        event_type = event.event_type
+        if event_type == "receipt.durably_received":
+            if state.receipt_state == "pending" and now <= _utc(state.receipt_grace_until):
+                state.receipt_state = "durably_received"
+                state.durably_received_at = now
+            elif state.receipt_state == "pending":
+                CommandControlService._expire_pending_receipt(
+                    state,
+                    db,
+                    now=now,
+                    reason="durable_receipt_after_grace",
+                    integrity_alert="durable_receipt_after_grace",
+                )
+                state.late_result = True
+            elif state.receipt_state == "expired":
+                state.late_result = True
+        elif event_type == "admission.accepted":
+            if state.admission_state == "unknown":
+                state.admission_state = "accepted"
+                state.admitted_at = now
+            elif state.admission_state != "accepted":
+                state.integrity_alert = "contradictory_admission_result"
+        elif event_type == "admission.rejected":
+            if state.admission_state == "unknown":
+                state.admission_state = "rejected"
+                state.admitted_at = now
+            elif state.admission_state != "rejected":
+                state.integrity_alert = "contradictory_admission_result"
+        elif event_type == "execution.started":
+            if state.execution_state == "not_started":
+                state.execution_state = "running"
+            elif state.execution_state not in {
+                "running",
+                "completed",
+                "failed",
+            }:
+                state.integrity_alert = "invalid_execution_transition"
+        elif event_type in {"execution.completed", "execution.failed"}:
+            target = "completed" if event_type.endswith("completed") else "failed"
+            if state.execution_state in {"not_started", "running"}:
+                state.execution_state = target
+                state.completed_at = now
+            elif state.execution_state != target:
+                state.integrity_alert = "contradictory_execution_result"
+            if (
+                event_type == "execution.failed"
+                and event.payload.get("error_code") == "COMMAND_OUTCOME_UNKNOWN_AFTER_RESTART"
+            ):
+                state.actual_execution_state = "outcome_unknown"
+
+        if event_type.startswith("execution.") and state.admission_state != "accepted":
+            state.integrity_alert = state.integrity_alert or "execution_without_accepted_admission"
+        if state.receipt_state == "expired" and event_type != "receipt.durably_received":
+            state.late_result = True
+            if event_type.startswith("execution."):
+                state.actual_execution_state = {
+                    "execution.started": "running",
+                    "execution.completed": "completed",
+                    "execution.failed": "failed",
+                }[event_type]
+
+    @staticmethod
+    def ingest_command_events(
+        command_id: str,
+        device_id: str,
+        user_id: int,
+        body: CommandEventsIn,
+        db: Session,
+    ) -> CommandEventsOut:
+        CommandControlService.require_device(device_id, user_id, db)
+        state = CommandControlService._lock_owned_state(command_id, device_id, user_id, db)
+        results: list[CommandEventAckOut] = []
+        inserted_new = False
+        for event in body.events:
+            if event.event_type not in DESKTOP_EVENT_TYPES:
+                raise HTTPException(
+                    status_code=422,
+                    detail={"code": "unsupported_command_event_type"},
+                )
+            existing = db.get(RemoteCommandLifecycleEvent, event.event_id)
+            if existing is not None:
+                if inserted_new:
+                    raise _conflict(
+                        "duplicate_after_new_command_event",
+                        "A retried prefix may not follow newly inserted events",
+                    )
+                if existing.command_id != command_id or not CommandControlService._same_desktop_event(existing, event):
+                    raise _conflict(
+                        "command_event_id_conflict",
+                        "event_id has different canonical content",
+                    )
+                results.append(
+                    CommandEventAckOut(
+                        event_id=event.event_id,
+                        desktop_event_sequence=event.desktop_event_sequence,
+                        inserted=False,
+                    )
+                )
+                continue
+            if event.desktop_event_sequence != state.expected_next_desktop_event_sequence:
+                raise _conflict(
+                    "command_sequence_gap",
+                    "Command event is not the next Desktop sequence",
+                    expected_next_desktop_event_sequence=(state.expected_next_desktop_event_sequence),
+                    first_failed_event_id=event.event_id,
+                )
+            if event.event_type == "receipt.durably_received":
+                CommandControlService._require_current_delivery_lease(
+                    state,
+                    device_id=device_id,
+                    lease_token=body.delivery_lease_token,
+                    now=_now(),
+                )
+            CommandControlService._insert_desktop_event(state, event, db)
+            state.expected_next_desktop_event_sequence += 1
+            now = _now()
+            CommandControlService._project_event(state, event, now, db)
+            state.updated_at = now
+            db.add(state)
+            inserted_new = True
+            results.append(
+                CommandEventAckOut(
+                    event_id=event.event_id,
+                    desktop_event_sequence=event.desktop_event_sequence,
+                    inserted=True,
+                )
+            )
+        db.flush()
+        return CommandEventsOut(
+            command_id=command_id,
+            expected_next_desktop_event_sequence=(state.expected_next_desktop_event_sequence),
+            receipt_state=state.receipt_state,
+            admission_state=state.admission_state,
+            execution_state=state.execution_state,
+            late_result=state.late_result,
+            items=results,
+        )
+
+    @staticmethod
+    def expire_pending_commands(db: Session, *, limit: int = 200) -> int:
+        now = _now()
+        states = list(
+            db.exec(
+                select(RemoteCommandState)
+                .where(
+                    RemoteCommandState.receipt_state == "pending",
+                    RemoteCommandState.receipt_grace_until < now,
+                    or_(
+                        RemoteCommandState.lease_until.is_(None),
+                        RemoteCommandState.lease_until < now,
+                    ),
+                )
+                .order_by(RemoteCommandState.receipt_grace_until)
+                .limit(limit)
+                .with_for_update(skip_locked=True)
+            ).all()
+        )
+        for state in states:
+            CommandControlService._expire_pending_receipt(
+                state,
+                db,
+                now=now,
+                reason="receipt_grace_elapsed",
+            )
+        db.flush()
+        return len(states)
+
+    @staticmethod
+    def get_command_state(command_id: str, user_id: int, db: Session) -> CommandStateOut:
+        state = db.get(RemoteCommandState, command_id)
+        if state is None:
+            raise HTTPException(status_code=404, detail="Command not found")
+        if state.user_id != user_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Command does not belong to this user",
+            )
+        rows = list(
+            db.exec(
+                select(RemoteCommandLifecycleEvent)
+                .where(RemoteCommandLifecycleEvent.command_id == command_id)
+                .order_by(
+                    RemoteCommandLifecycleEvent.created_at,
+                    RemoteCommandLifecycleEvent.id,
+                )
+            ).all()
+        )
+        return CommandStateOut(
+            command_id=state.command_id,
+            project_id=state.project_id,
+            run_id=state.run_id,
+            route_device_id=state.route_device_id,
+            route_version=state.route_version,
+            receipt_state=state.receipt_state,
+            admission_state=state.admission_state,
+            execution_state=state.execution_state,
+            actual_execution_state=state.actual_execution_state,
+            late_result=state.late_result,
+            integrity_alert=state.integrity_alert,
+            expires_at=state.expires_at,
+            receipt_grace_until=state.receipt_grace_until,
+            events=[
+                CommandStateEventOut(
+                    event_id=row.id,
+                    producer=row.producer,
+                    desktop_event_sequence=row.desktop_event_sequence,
+                    server_recorded_version=row.server_recorded_version,
+                    cloud_recorded_version=row.server_recorded_version,
+                    event_type=row.event_type,
+                    payload=row.payload,
+                    occurred_at=row.occurred_at,
+                )
+                for row in rows
+            ],
+        )

--- a/server/app/domains/remote_control/service/command_notifier.py
+++ b/server/app/domains/remote_control/service/command_notifier.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from loguru import logger
+from sqlalchemy import delete, or_, update
+from sqlmodel import select
+
+from app.core.database import session_make
+from app.core.redis_utils import get_redis_manager
+from app.model.remote_control import (
+    RemoteCommandLifecycleEvent,
+    RemoteCommandNotificationOutbox,
+    RemoteCommandState,
+)
+
+OUTBOX_BATCH_SIZE = 200
+OUTBOX_LEASE_SECONDS = 30
+OUTBOX_MAX_BACKOFF_SECONDS = 300
+OUTBOX_RETENTION = timedelta(days=7)
+
+
+@dataclass(frozen=True)
+class ClaimedCommandNotification:
+    event_id: str
+    lease_token: str
+    attempt_count: int
+    channel: str
+    payload: str
+
+
+def _claim_batch(limit: int) -> list[ClaimedCommandNotification]:
+    now = datetime.now(UTC)
+    lease_until = now + timedelta(seconds=OUTBOX_LEASE_SECONDS)
+    claimed: list[ClaimedCommandNotification] = []
+    with session_make() as db:
+        rows = list(
+            db.exec(
+                select(RemoteCommandNotificationOutbox)
+                .where(
+                    RemoteCommandNotificationOutbox.status == "pending",
+                    RemoteCommandNotificationOutbox.available_at <= now,
+                    or_(
+                        RemoteCommandNotificationOutbox.lease_until.is_(None),
+                        RemoteCommandNotificationOutbox.lease_until < now,
+                    ),
+                )
+                .order_by(
+                    RemoteCommandNotificationOutbox.session_id,
+                    RemoteCommandNotificationOutbox.available_at,
+                    RemoteCommandNotificationOutbox.event_id,
+                )
+                .limit(limit)
+                .with_for_update(skip_locked=True)
+            ).all()
+        )
+        for row in rows:
+            event = db.get(RemoteCommandLifecycleEvent, row.event_id)
+            state = db.get(RemoteCommandState, row.command_id)
+            if event is None or state is None:
+                row.attempt_count += 1
+                row.available_at = now + timedelta(seconds=OUTBOX_MAX_BACKOFF_SECONDS)
+                row.last_error = "command event or state missing"
+                db.add(row)
+                continue
+            token = uuid4().hex
+            row.lease_token = token
+            row.lease_until = lease_until
+            db.add(row)
+            claimed.append(
+                ClaimedCommandNotification(
+                    event_id=row.event_id,
+                    lease_token=token,
+                    attempt_count=row.attempt_count,
+                    channel=f"rc:ack:{row.session_id}",
+                    payload=json.dumps(
+                        {
+                            "type": "command_event",
+                            "session_id": row.session_id,
+                            "command_id": row.command_id,
+                            "event": {
+                                "event_id": event.id,
+                                "producer": event.producer,
+                                "desktop_event_sequence": (event.desktop_event_sequence),
+                                "server_recorded_version": (event.server_recorded_version),
+                                # Temporary wire alias for older Desktop and
+                                # Remote Web clients during self-host rollout.
+                                "cloud_recorded_version": (event.server_recorded_version),
+                                "event_type": event.event_type,
+                                "payload": event.payload,
+                                "occurred_at": event.occurred_at.isoformat(),
+                            },
+                            "projection": {
+                                "receipt_state": state.receipt_state,
+                                "admission_state": state.admission_state,
+                                "execution_state": state.execution_state,
+                                "actual_execution_state": (state.actual_execution_state),
+                                "late_result": state.late_result,
+                                "integrity_alert": state.integrity_alert,
+                            },
+                        }
+                    ),
+                )
+            )
+        db.commit()
+    return claimed
+
+
+def _finish(item: ClaimedCommandNotification, *, error: Exception | None = None) -> bool:
+    values: dict = {"lease_token": None, "lease_until": None}
+    if error is None:
+        values.update(
+            status="published",
+            published_at=datetime.now(UTC),
+            last_error=None,
+        )
+    else:
+        attempt_count = item.attempt_count + 1
+        values.update(
+            attempt_count=attempt_count,
+            available_at=datetime.now(UTC)
+            + timedelta(
+                seconds=min(
+                    2 ** min(attempt_count, 8),
+                    OUTBOX_MAX_BACKOFF_SECONDS,
+                )
+            ),
+            last_error=str(error)[:4000],
+        )
+    with session_make() as db:
+        result = db.execute(
+            update(RemoteCommandNotificationOutbox)
+            .where(
+                RemoteCommandNotificationOutbox.event_id == item.event_id,
+                RemoteCommandNotificationOutbox.status == "pending",
+                RemoteCommandNotificationOutbox.lease_token == item.lease_token,
+            )
+            .values(**values)
+        )
+        db.commit()
+        return result.rowcount == 1
+
+
+def drain_command_notification_outbox(
+    limit: int = OUTBOX_BATCH_SIZE,
+) -> int:
+    published = 0
+    for item in _claim_batch(limit):
+        try:
+            get_redis_manager().client.publish(item.channel, item.payload)
+        except Exception as exc:  # noqa: BLE001
+            _finish(item, error=exc)
+            logger.warning(
+                "Command notification publish failed",
+                extra={"event_id": item.event_id, "error": str(exc)},
+            )
+            continue
+        if _finish(item):
+            published += 1
+    return published
+
+
+def cleanup_published_command_outbox(*, retention: timedelta = OUTBOX_RETENTION) -> int:
+    cutoff = datetime.now(UTC) - retention
+    with session_make() as db:
+        result = db.execute(
+            delete(RemoteCommandNotificationOutbox).where(
+                RemoteCommandNotificationOutbox.status == "published",
+                RemoteCommandNotificationOutbox.published_at < cutoff,
+            )
+        )
+        db.commit()
+        return int(result.rowcount or 0)

--- a/server/app/domains/remote_control/service/remote_control_service.py
+++ b/server/app/domains/remote_control/service/remote_control_service.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import hashlib
 import json
 import secrets
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
 from urllib.parse import quote
@@ -25,7 +25,8 @@ from uuid import uuid4
 
 from fastapi import HTTPException
 from loguru import logger
-from sqlalchemy import desc
+from sqlalchemy import and_, desc, or_
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
 from app.core.environment import env
@@ -48,6 +49,10 @@ from app.domains.remote_control.schema import (
     RemoteControlStepOut,
     RemoteControlStepsOut,
 )
+from app.domains.remote_control.service.command_control_service import (
+    HIGH_RISK_COMMAND_TYPES,
+    CommandControlService,
+)
 from app.domains.space.service.overlay_service import SpaceOverlayService
 from app.domains.space.service.space_service import SpaceService
 from app.model.chat.chat_history import ChatHistory, ChatStatus
@@ -55,6 +60,7 @@ from app.model.chat.chat_step import ChatStep
 from app.model.project.project import Project, ProjectIn, ProjectMode, ProjectOut
 from app.model.provider.provider import Provider
 from app.model.remote_control import (
+    RemoteCommandState,
     RemoteControlCommand,
     RemoteControlEvent,
     RemoteControlLink,
@@ -81,6 +87,7 @@ DEFAULT_CAPABILITIES = {
     "commands": [
         "user_message",
         "human_reply",
+        "interaction_decision",
         "stop",
         "skip_task",
         "add_task",
@@ -115,12 +122,155 @@ def _now() -> datetime:
     return datetime.utcnow()
 
 
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
 def _id(prefix: str) -> str:
     return f"{prefix}_{uuid4().hex}"
 
 
 def _token_hash(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _command_request_fingerprint(data: RemoteControlCommandIn) -> str:
+    canonical = data.model_dump(
+        mode="json",
+        exclude={"client_request_id"},
+        exclude_none=False,
+    )
+    encoded = json.dumps(
+        canonical,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _effective_client_request_id(
+    data: RemoteControlCommandIn,
+    *,
+    supersede_chain_depth: int = 0,
+) -> str:
+    if data.type != "interaction_decision":
+        return data.client_request_id
+    encoded = json.dumps(
+        {
+            "run_id": data.payload["run_id"],
+            "interaction_id": data.payload["interaction_id"],
+            "supersede_chain_depth": supersede_chain_depth,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:48]
+    return f"interaction_decision_{digest}"
+
+
+def _interaction_decision_key(
+    data: RemoteControlCommandIn,
+    *,
+    user_id: int,
+    supersede_chain_depth: int,
+) -> str | None:
+    if data.type != "interaction_decision":
+        return None
+    encoded = json.dumps(
+        {
+            "user_id": user_id,
+            "run_id": data.payload["run_id"],
+            "interaction_id": data.payload["interaction_id"],
+            "generation": supersede_chain_depth,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _command_replay_statement(
+    *,
+    session_id: str,
+    submitted_client_request_id: str,
+    effective_client_request_id: str,
+    decision_key: str | None,
+):
+    request_ids = tuple(dict.fromkeys((submitted_client_request_id, effective_client_request_id)))
+    legacy_identity = and_(
+        RemoteControlCommand.session_id == session_id,
+        RemoteControlCommand.client_request_id.in_(request_ids),
+    )
+    if decision_key is None:
+        return select(RemoteControlCommand).where(legacy_identity)
+    legacy_decision_identity = and_(
+        legacy_identity,
+        RemoteControlCommand.type == "interaction_decision",
+        RemoteControlCommand.interaction_decision_key.is_(None),
+    )
+    return select(RemoteControlCommand).where(
+        or_(
+            RemoteControlCommand.interaction_decision_key == decision_key,
+            legacy_decision_identity,
+        )
+    )
+
+
+def _interaction_supersede_chain(
+    data: RemoteControlCommandIn,
+    *,
+    user_id: int,
+    db: Session,
+) -> tuple[int, RemoteControlCommand | None, RemoteCommandState | None]:
+    if data.type != "interaction_decision":
+        return 0, None, None
+    command_id = data.payload.get("supersedes_command_id")
+    if not command_id:
+        return 0, None, None
+
+    run_id = data.payload.get("run_id")
+    interaction_id = data.payload.get("interaction_id")
+    seen: set[str] = set()
+    depth = 0
+    immediate: RemoteControlCommand | None = None
+    immediate_state: RemoteCommandState | None = None
+    while command_id:
+        if command_id in seen:
+            raise HTTPException(
+                status_code=409,
+                detail={"code": "REMOTE_COMMAND_SUPERSEDE_CYCLE"},
+            )
+        seen.add(command_id)
+        command = db.get(RemoteControlCommand, command_id)
+        state = db.get(RemoteCommandState, command_id)
+        same_interaction = bool(
+            command
+            and command.user_id == user_id
+            and command.type == "interaction_decision"
+            and command.payload.get("run_id") == run_id
+            and command.payload.get("interaction_id") == interaction_id
+        )
+        if not same_interaction:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "REMOTE_COMMAND_NOT_SUPERSEDABLE",
+                    "message": ("The superseded command is outside this interaction chain"),
+                    "supersedes_command_id": command_id,
+                },
+            )
+        assert command is not None
+        if immediate is None:
+            immediate = command
+            immediate_state = state
+        depth += 1
+        command_id = command.payload.get("supersedes_command_id")
+    return depth, immediate, immediate_state
 
 
 def _utc_iso(value: datetime | None) -> str | None:
@@ -401,10 +551,7 @@ class RemoteControlService:
         return (
             normalized["target_project_id"] == session.project_id
             and normalized["target_brain_session_id"] == session.brain_session_id
-            and (
-                normalized["target_task_id"] is None
-                or normalized["target_task_id"] == session.active_task_id
-            )
+            and (normalized["target_task_id"] is None or normalized["target_task_id"] == session.active_task_id)
         )
 
     @staticmethod
@@ -481,8 +628,7 @@ class RemoteControlService:
         else:
             session = RemoteControlService._owned_session(session_id, user_id, db)
         link = db.exec(
-            select(RemoteControlLink)
-            .where(
+            select(RemoteControlLink).where(
                 RemoteControlLink.session_id == session_id,
                 RemoteControlLink.token_hash == _token_hash(token),
             )
@@ -512,10 +658,11 @@ class RemoteControlService:
         if not RemoteControlRedis.is_bridge_online(data.desktop_instance_id, user_id):
             raise HTTPException(status_code=409, detail={"code": "BRIDGE_OFFLINE"})
 
-        is_v2_request = any(
-            value is not None
-            for value in (data.initial_project_id, data.initial_task_id, data.initial_history_id)
-        ) or data.space_id is not None or not (data.project_id and data.active_task_id)
+        is_v2_request = (
+            any(value is not None for value in (data.initial_project_id, data.initial_task_id, data.initial_history_id))
+            or data.space_id is not None
+            or not (data.project_id and data.active_task_id)
+        )
         target_project_id = data.initial_project_id if data.initial_project_id is not None else data.project_id
         target_task_id = data.initial_task_id if data.initial_task_id is not None else data.active_task_id
         target_history_id = data.initial_history_id if is_v2_request else None
@@ -611,9 +758,7 @@ class RemoteControlService:
             session.last_target_task_id = target_task_id or session.last_target_task_id
             session.last_target_history_id = target_history_id or session.last_target_history_id
             session.last_target_brain_session_id = (
-                current_brain_session_id
-                or legacy_brain_session_id
-                or session.last_target_brain_session_id
+                current_brain_session_id or legacy_brain_session_id or session.last_target_brain_session_id
             )
 
         token = secrets.token_urlsafe(32)
@@ -784,9 +929,7 @@ class RemoteControlService:
                 "current_project_id": session.current_project_id or data.project_id,
                 "current_task_id": session.current_task_id,
                 "current_history_id": session.current_history_id,
-                "current_brain_session_id": (
-                    session.current_brain_session_id or current_brain_session_id
-                ),
+                "current_brain_session_id": (session.current_brain_session_id or current_brain_session_id),
                 "previous_project_id": previous_project_id,
                 "previous_task_id": previous_task_id,
             },
@@ -1177,9 +1320,7 @@ class RemoteControlService:
                 "project_id": project_id,
                 "run_id": data.run_id,
                 "paths": data.paths,
-                "force_resolutions": [
-                    item.model_dump(mode="json") for item in (data.force_resolutions or [])
-                ],
+                "force_resolutions": [item.model_dump(mode="json") for item in (data.force_resolutions or [])],
             },
             db,
             target_project_id=project_id,
@@ -1249,9 +1390,65 @@ class RemoteControlService:
         db: Session,
     ) -> RemoteControlCommandOut:
         session = RemoteControlService._owned_session(session_id, user_id, db)
+        request_fingerprint = _command_request_fingerprint(data)
+        (
+            supersede_chain_depth,
+            superseded,
+            superseded_state,
+        ) = _interaction_supersede_chain(data, user_id=user_id, db=db)
+        client_request_id = _effective_client_request_id(data, supersede_chain_depth=supersede_chain_depth)
+        decision_key = _interaction_decision_key(
+            data,
+            user_id=user_id,
+            supersede_chain_depth=supersede_chain_depth,
+        )
+        replay_statement = _command_replay_statement(
+            session_id=session.id,
+            submitted_client_request_id=data.client_request_id,
+            effective_client_request_id=client_request_id,
+            decision_key=decision_key,
+        )
+        existing = db.exec(replay_statement).first()
+        if existing is not None:
+            if existing.request_fingerprint != request_fingerprint:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "REMOTE_COMMAND_IDEMPOTENCY_CONFLICT",
+                        "command_id": existing.id,
+                    },
+                )
+            return RemoteControlCommandOut(
+                command_id=existing.id,
+                status=existing.status,
+                next_task_id=existing.next_task_id,
+            )
         if not RemoteControlRedis.is_bridge_online(session.desktop_instance_id, user_id):
             raise HTTPException(status_code=409, detail={"code": "BRIDGE_OFFLINE"})
         session_space = RemoteControlService._session_space(session, user_id, db)
+
+        if superseded is not None:
+            unsuccessful_terminal = bool(
+                superseded.status in {COMMAND_FAILED, COMMAND_EXPIRED, "outcome_unknown"}
+                or (
+                    superseded_state is not None
+                    and (
+                        superseded_state.receipt_state == "expired"
+                        or superseded_state.admission_state == "rejected"
+                        or superseded_state.execution_state == "failed"
+                        or superseded_state.actual_execution_state == "outcome_unknown"
+                    )
+                )
+            )
+            if not unsuccessful_terminal:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "REMOTE_COMMAND_NOT_SUPERSEDABLE",
+                        "message": ("Only a terminal unsuccessful decision may be replaced"),
+                        "supersedes_command_id": superseded.id,
+                    },
+                )
 
         normalized = {
             "space_id": data.space_id or session_space.id,
@@ -1306,6 +1503,9 @@ class RemoteControlService:
             id=_id("rc_cmd"),
             session_id=session.id,
             user_id=user_id,
+            client_request_id=client_request_id,
+            request_fingerprint=request_fingerprint,
+            interaction_decision_key=decision_key,
             source_channel=data.source_channel,
             type=command_type,
             payload=normalized["payload"],
@@ -1317,23 +1517,47 @@ class RemoteControlService:
             status=COMMAND_PENDING,
         )
 
-        if next_task_id:
-            try:
-                history = RemoteControlService._create_history_for_command(
-                    user_id,
-                    normalized["space_id"],
-                    target_project_id,
-                    target_task_id,
-                    data,
-                    next_task_id,
-                    db,
-                )
+        try:
+            with db.begin_nested():
+                if next_task_id:
+                    history = RemoteControlService._create_history_for_command(
+                        user_id,
+                        normalized["space_id"],
+                        target_project_id,
+                        target_task_id,
+                        data,
+                        next_task_id,
+                        db,
+                    )
+                    db.flush()
+                    normalized["payload"]["remote_history_id"] = history.id
+                    command.payload = normalized["payload"]
+                db.add(command)
                 db.flush()
-                normalized["payload"]["remote_history_id"] = history.id
-                command.payload = normalized["payload"]
-            except HTTPException:
+        except IntegrityError:
+            existing = db.exec(replay_statement).first()
+            if existing is None:
                 raise
-        db.add(command)
+            if existing.request_fingerprint != request_fingerprint:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "REMOTE_COMMAND_IDEMPOTENCY_CONFLICT",
+                        "command_id": existing.id,
+                    },
+                )
+            return RemoteControlCommandOut(
+                command_id=existing.id,
+                status=existing.status,
+                next_task_id=existing.next_task_id,
+            )
+        command_state = CommandControlService.create_state_for_command(command, session, db)
+        command_state = CommandControlService.lease_command_for_delivery(
+            command.id,
+            session.desktop_instance_id,
+            user_id,
+            db,
+        )
         db.commit()
         db.refresh(command)
         RemoteControlService.record_event(
@@ -1351,7 +1575,7 @@ class RemoteControlService:
             db,
         )
 
-        RemoteControlService.publish_command(session, command)
+        RemoteControlService.publish_command(session, command, command_state)
         return RemoteControlCommandOut(
             command_id=command.id,
             status=command.status,
@@ -1359,10 +1583,16 @@ class RemoteControlService:
         )
 
     @staticmethod
-    def command_payload(session: RemoteControlSession, command: RemoteControlCommand) -> dict[str, Any]:
+    def command_payload(
+        session: RemoteControlSession,
+        command: RemoteControlCommand,
+        state: RemoteCommandState | None = None,
+    ) -> dict[str, Any]:
         project_id = command.target_project_id or session.current_project_id or session.project_id
         task_id = command.target_task_id or session.current_task_id or session.active_task_id
-        brain_session_id = command.target_brain_session_id or session.current_brain_session_id or session.brain_session_id
+        brain_session_id = (
+            command.target_brain_session_id or session.current_brain_session_id or session.brain_session_id
+        )
         payload: dict[str, Any] = {
             "type": "remote_command",
             "command": {
@@ -1384,13 +1614,27 @@ class RemoteControlService:
         }
         if command.next_task_id:
             payload["command"]["next_task_id"] = command.next_task_id
+        if state is not None:
+            payload["command"].update(
+                {
+                    "route_version": state.route_version,
+                    "expires_at": state.expires_at.isoformat(),
+                    "receipt_grace_until": (state.receipt_grace_until.isoformat()),
+                    "requires_online_receipt_confirmation": (command.type in HIGH_RISK_COMMAND_TYPES),
+                    "lease_token": state.lease_token,
+                }
+            )
         return payload
 
     @staticmethod
-    def publish_command(session: RemoteControlSession, command: RemoteControlCommand) -> bool:
+    def publish_command(
+        session: RemoteControlSession,
+        command: RemoteControlCommand,
+        state: RemoteCommandState | None = None,
+    ) -> bool:
         had_subscriber = RemoteControlRedis.publish(
             RemoteControlRedis.command_channel(session.desktop_instance_id),
-            RemoteControlService.command_payload(session, command),
+            RemoteControlService.command_payload(session, command, state),
         )
         logger.info(
             "[RC-TRACE] command published",
@@ -1557,7 +1801,8 @@ class RemoteControlService:
         RemoteControlService._ensure_project_in_session_space(session, user_id, target_project_id, db)
         limit = min(max(limit, 1), 1000)
         histories = db.exec(
-            select(ChatHistory).where(
+            select(ChatHistory)
+            .where(
                 ChatHistory.user_id == user_id,
                 ChatHistory.project_id == target_project_id,
             )
@@ -1627,10 +1872,27 @@ class RemoteControlService:
                 RemoteControlCommand.created_at < cutoff,
             )
         ).all()
+        deliveries: list[
+            tuple[
+                RemoteControlSession,
+                RemoteControlCommand,
+                RemoteCommandState | None,
+            ]
+        ] = []
         for command in commands:
             session = db.get(RemoteControlSession, command.session_id)
             if not session or session.status != SESSION_ACTIVE:
                 continue
+            state = db.get(RemoteCommandState, command.id)
+            if state is not None:
+                now = datetime.now(UTC)
+                if (
+                    state.receipt_state != "pending"
+                    or _utc(state.expires_at) < now
+                    or _utc(state.next_delivery_attempt_at) > now
+                    or (state.lease_until is not None and _utc(state.lease_until) >= now)
+                ):
+                    continue
             if not RemoteControlRedis.is_bridge_online(session.desktop_instance_id, session.user_id):
                 logger.warning(
                     "[RC-TRACE] pending command waiting, bridge offline",
@@ -1649,7 +1911,20 @@ class RemoteControlService:
                     "age_seconds": (_now() - command.created_at).total_seconds(),
                 },
             )
-            RemoteControlService.publish_command(session, command)
+            if state is not None:
+                state = CommandControlService.lease_command_for_delivery(
+                    command.id,
+                    session.desktop_instance_id,
+                    session.user_id,
+                    db,
+                )
+            deliveries.append((session, command, state))
+
+        # Persist the new lease before notifying Desktop. Legacy commands have
+        # no state and retain their existing delivery behavior.
+        db.commit()
+        for session, command, state in deliveries:
+            RemoteControlService.publish_command(session, command, state)
 
     @staticmethod
     def expire_timed_out_commands(db: Session) -> None:

--- a/server/app/model/remote_control/__init__.py
+++ b/server/app/model/remote_control/__init__.py
@@ -12,6 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
+from app.model.remote_control.command_control import (
+    DesktopDevice,
+    ProjectExecutionRoute,
+    RemoteCommandLifecycleEvent,
+    RemoteCommandNotificationOutbox,
+    RemoteCommandState,
+)
 from app.model.remote_control.remote_control import (
     RemoteControlCommand,
     RemoteControlEvent,
@@ -20,6 +27,11 @@ from app.model.remote_control.remote_control import (
 )
 
 __all__ = [
+    "DesktopDevice",
+    "ProjectExecutionRoute",
+    "RemoteCommandLifecycleEvent",
+    "RemoteCommandNotificationOutbox",
+    "RemoteCommandState",
     "RemoteControlCommand",
     "RemoteControlEvent",
     "RemoteControlLink",

--- a/server/app/model/remote_control/command_control.py
+++ b/server/app/model/remote_control/command_control.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlmodel import JSON, Field
+
+from app.model.abstract.model import AbstractModel
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+JSON_DOCUMENT = JSON().with_variant(JSONB(), "postgresql")
+
+
+class DesktopDevice(AbstractModel, table=True):
+    __table_args__ = (Index("ix_desktop_device_user_active", "user_id", "revoked_at"),)
+
+    id: str = Field(sa_column=Column(String(128), primary_key=True))
+    user_id: int = Field(sa_column=Column(Integer, nullable=False))
+    install_public_key: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    credential_version: int = Field(
+        default=1,
+        sa_column=Column(Integer, nullable=False, server_default="1"),
+    )
+    app_version: str | None = Field(default=None, sa_column=Column(String(64), nullable=True))
+    capabilities: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON_DOCUMENT, nullable=False),
+    )
+    last_seen_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    revoked_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class ProjectExecutionRoute(AbstractModel, table=True):
+    __table_args__ = (
+        CheckConstraint(
+            "route_version >= 1",
+            name="ck_project_execution_route_version_positive",
+        ),
+        CheckConstraint(
+            "owner_kind IN ('desktop_device')",
+            name="ck_project_execution_route_owner_kind_valid",
+        ),
+        Index(
+            "ix_project_execution_route_device",
+            "target_device_id",
+            "updated_at",
+        ),
+    )
+
+    project_id: str = Field(
+        sa_column=Column(
+            String(128),
+            ForeignKey("project.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    user_id: int = Field(sa_column=Column(Integer, nullable=False))
+    owner_kind: str = Field(
+        default="desktop_device",
+        sa_column=Column(String(32), nullable=False),
+    )
+    target_device_id: str = Field(sa_column=Column(String(128), ForeignKey("desktop_device.id"), nullable=False))
+    route_version: int = Field(
+        default=1,
+        sa_column=Column(BigInteger, nullable=False, server_default="1"),
+    )
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class RemoteCommandState(AbstractModel, table=True):
+    __table_args__ = (
+        CheckConstraint(
+            "receipt_state IN ('pending', 'durably_received', 'expired')",
+            name="ck_remote_command_receipt_state_valid",
+        ),
+        CheckConstraint(
+            "admission_state IN ('unknown', 'accepted', 'rejected')",
+            name="ck_remote_command_admission_state_valid",
+        ),
+        CheckConstraint(
+            "execution_state IN ('not_started', 'running', 'completed', 'failed')",
+            name="ck_remote_command_execution_state_valid",
+        ),
+        CheckConstraint(
+            "expected_next_desktop_event_sequence >= 1",
+            name="ck_remote_command_next_desktop_sequence_positive",
+        ),
+        CheckConstraint(
+            "server_recorded_version >= 0",
+            name="ck_remote_command_server_version_non_negative",
+        ),
+        CheckConstraint(
+            "delivery_attempt_count >= 0",
+            name="ck_remote_command_delivery_attempt_non_negative",
+        ),
+        CheckConstraint(
+            "receipt_grace_until >= expires_at",
+            name="ck_remote_command_receipt_grace_order",
+        ),
+        Index(
+            "ix_remote_command_delivery_pending",
+            "route_device_id",
+            "next_delivery_attempt_at",
+            "lease_until",
+            "expires_at",
+            postgresql_where=text("receipt_state = 'pending'"),
+            sqlite_where=text("receipt_state = 'pending'"),
+        ),
+        Index(
+            "ix_remote_command_receipt_expiry",
+            "receipt_grace_until",
+            "lease_until",
+            postgresql_where=text("receipt_state = 'pending'"),
+            sqlite_where=text("receipt_state = 'pending'"),
+        ),
+        Index(
+            "ix_remote_command_state_project_created",
+            "project_id",
+            "created_at",
+        ),
+    )
+
+    command_id: str = Field(
+        sa_column=Column(
+            String(64),
+            ForeignKey("remote_control_command.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    session_id: str = Field(sa_column=Column(String(64), nullable=False))
+    user_id: int = Field(sa_column=Column(Integer, nullable=False))
+    project_id: str = Field(sa_column=Column(String(128), nullable=False))
+    run_id: str | None = Field(default=None, sa_column=Column(String(128), nullable=True))
+    route_device_id: str = Field(sa_column=Column(String(128), nullable=False))
+    route_version: int = Field(sa_column=Column(BigInteger, nullable=False))
+    receipt_state: str = Field(
+        default="pending",
+        sa_column=Column(String(32), nullable=False, server_default="pending"),
+    )
+    admission_state: str = Field(
+        default="unknown",
+        sa_column=Column(String(32), nullable=False, server_default="unknown"),
+    )
+    execution_state: str = Field(
+        default="not_started",
+        sa_column=Column(String(32), nullable=False, server_default="not_started"),
+    )
+    actual_execution_state: str | None = Field(default=None, sa_column=Column(String(32), nullable=True))
+    expected_next_desktop_event_sequence: int = Field(
+        default=1,
+        sa_column=Column(BigInteger, nullable=False, server_default="1"),
+    )
+    server_recorded_version: int = Field(
+        default=0,
+        sa_column=Column(BigInteger, nullable=False, server_default="0"),
+    )
+    expires_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    receipt_grace_until: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    next_delivery_attempt_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    delivery_attempt_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default="0"),
+    )
+    delivery_lease_owner: str | None = Field(default=None, sa_column=Column(String(128), nullable=True))
+    lease_token: str | None = Field(default=None, sa_column=Column(String(64), nullable=True))
+    lease_until: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+    durably_received_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+    admitted_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+    completed_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+    expired_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+    late_result: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default=text("false")),
+    )
+    integrity_alert: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class RemoteCommandLifecycleEvent(AbstractModel, table=True):
+    __table_args__ = (
+        UniqueConstraint(
+            "command_id",
+            "desktop_event_sequence",
+            name="uq_remote_command_event_desktop_sequence",
+        ),
+        UniqueConstraint(
+            "command_id",
+            "server_recorded_version",
+            name="uq_remote_command_event_server_version",
+        ),
+        CheckConstraint(
+            "producer IN ('desktop', 'server')",
+            name="ck_remote_command_event_producer_valid",
+        ),
+        CheckConstraint(
+            "(producer = 'desktop' AND desktop_event_sequence IS NOT NULL "
+            "AND server_recorded_version IS NULL) OR "
+            "(producer = 'server' AND desktop_event_sequence IS NULL "
+            "AND server_recorded_version IS NOT NULL)",
+            name="ck_remote_command_event_version_lane",
+        ),
+        Index(
+            "ix_remote_command_event_command_created",
+            "command_id",
+            "created_at",
+        ),
+    )
+
+    id: str = Field(sa_column=Column(String(64), primary_key=True))
+    command_id: str = Field(
+        sa_column=Column(
+            String(64),
+            ForeignKey("remote_command_state.command_id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
+    producer: str = Field(sa_column=Column(String(16), nullable=False))
+    desktop_event_sequence: int | None = Field(default=None, sa_column=Column(BigInteger, nullable=True))
+    server_recorded_version: int | None = Field(default=None, sa_column=Column(BigInteger, nullable=True))
+    event_type: str = Field(sa_column=Column(String(64), nullable=False))
+    payload: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON_DOCUMENT, nullable=False),
+    )
+    occurred_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class RemoteCommandNotificationOutbox(AbstractModel, table=True):
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('pending', 'published')",
+            name="ck_remote_command_notification_status_valid",
+        ),
+        CheckConstraint(
+            "attempt_count >= 0",
+            name="ck_remote_command_notification_attempt_non_negative",
+        ),
+        Index(
+            "ix_remote_command_notification_pending",
+            "available_at",
+            "lease_until",
+            "session_id",
+            postgresql_where=text("status = 'pending'"),
+            sqlite_where=text("status = 'pending'"),
+        ),
+        Index(
+            "ix_remote_command_notification_published",
+            "published_at",
+            postgresql_where=text("status = 'published'"),
+            sqlite_where=text("status = 'published'"),
+        ),
+    )
+
+    event_id: str = Field(
+        sa_column=Column(
+            String(64),
+            ForeignKey("remote_command_lifecycle_event.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    command_id: str = Field(sa_column=Column(String(64), nullable=False))
+    session_id: str = Field(sa_column=Column(String(64), nullable=False))
+    status: str = Field(
+        default="pending",
+        sa_column=Column(String(16), nullable=False, server_default="pending"),
+    )
+    attempt_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default="0"),
+    )
+    available_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    lease_token: str | None = Field(default=None, sa_column=Column(String(64), nullable=True))
+    lease_until: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+    published_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+    last_error: str | None = Field(default=None, sa_column=Column(Text, nullable=True))

--- a/server/app/model/remote_control/remote_control.py
+++ b/server/app/model/remote_control/remote_control.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Column, String
+from sqlalchemy import Column, Index, String, UniqueConstraint
 from sqlmodel import JSON, Field
 
 from app.model.abstract.model import AbstractModel, DefaultTimes
@@ -59,6 +59,19 @@ class RemoteControlLink(AbstractModel, DefaultTimes, table=True):
 
 
 class RemoteControlCommand(AbstractModel, DefaultTimes, table=True):
+    __table_args__ = (
+        UniqueConstraint(
+            "session_id",
+            "client_request_id",
+            name="uq_remote_control_command_session_request",
+        ),
+        Index(
+            "uq_remote_control_command_interaction_decision_key",
+            "interaction_decision_key",
+            unique=True,
+        ),
+    )
+
     id: str = Field(sa_column=Column(String(64), primary_key=True))
     session_id: str = Field(sa_column=Column(String(64), index=True))
     user_id: int = Field(index=True)
@@ -75,6 +88,18 @@ class RemoteControlCommand(AbstractModel, DefaultTimes, table=True):
     error_code: str | None = Field(default=None, sa_column=Column(String(128), nullable=True))
     delivered_at: datetime | None = None
     acknowledged_at: datetime | None = None
+    client_request_id: str | None = Field(
+        default=None,
+        sa_column=Column(String(128), nullable=True),
+    )
+    request_fingerprint: str | None = Field(
+        default=None,
+        sa_column=Column(String(64), nullable=True),
+    )
+    interaction_decision_key: str | None = Field(
+        default=None,
+        sa_column=Column(String(64), nullable=True),
+    )
 
 
 class RemoteControlEvent(AbstractModel, DefaultTimes, table=True):

--- a/server/app/shared/exception/handlers.py
+++ b/server/app/shared/exception/handlers.py
@@ -14,14 +14,15 @@
 
 """v1 exception handler registration."""
 
-from fastapi import Request, FastAPI
+from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from sqlalchemy.exc import NoResultFound
+from loguru import logger
+from sqlalchemy.exc import NoResultFound, OperationalError
 
 from app.core import code
-from app.core.pydantic.i18n import trans, get_language
+from app.core.pydantic.i18n import get_language, trans
 from app.shared.exception import (
     NoPermissionException,
     TokenException,
@@ -62,4 +63,24 @@ def register_exception_handlers(app: FastAPI) -> None:
         return JSONResponse(
             status_code=200,
             content={"code": code.not_found, "text": exception._message()},
+        )
+
+    @app.exception_handler(OperationalError)
+    async def database_operational_error(request: Request, exception: OperationalError):
+        sqlstate = getattr(exception.orig, "sqlstate", None) or getattr(exception.orig, "pgcode", None)
+        logger.warning(
+            "Database operation failed",
+            extra={
+                "path": request.url.path,
+                "sqlstate": sqlstate,
+                "database_error_type": type(exception.orig).__name__,
+            },
+        )
+        return JSONResponse(
+            status_code=503,
+            headers={"Retry-After": "1"},
+            content={
+                "code": "database_temporarily_unavailable",
+                "message": "Database is temporarily busy; retry the request.",
+            },
         )

--- a/server/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/server/lang/zh_CN/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-01 20:31+0800\n"
+"POT-Creation-Date: 2026-08-27 16:40+0800\n"
 "PO-Revision-Date: 2025-08-06 09:56+0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_Hans_CN\n"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "hello"
 msgstr ""
 
-#: app/domains/chat/api/snapshot_controller.py:42
+#: app/domains/chat/api/snapshot_controller.py:43
 msgid "Invalid api_task_id: only letters, numbers, - and _ allowed"
 msgstr ""
 
@@ -74,26 +74,25 @@ msgstr ""
 msgid "Failed to create default user"
 msgstr ""
 
-#: app/domains/user/api/login_controller.py:90
-msgid "Account or password error"
-msgstr ""
-
 #: app/domains/user/api/login_controller.py:92
-#: app/domains/user/api/login_controller.py:116
-msgid "Your account has been blocked."
+msgid "Account or password error"
 msgstr ""
 
 #: app/domains/user/api/login_controller.py:94
 #: app/domains/user/api/login_controller.py:118
+msgid "Your account has been blocked."
+msgstr ""
+
+#: app/domains/user/api/login_controller.py:96
+#: app/domains/user/api/login_controller.py:120
 msgid "Please activate your account via the email link."
 msgstr ""
 
-#: app/domains/user/api/login_controller.py:110
+#: app/domains/user/api/login_controller.py:112
 msgid "Refresh token required"
 msgstr ""
 
-#: app/domains/user/api/login_controller.py:114
-#: app/shared/auth/user_auth.py:144
+#: app/domains/user/api/login_controller.py:116
 msgid "User not found"
 msgstr ""
 
@@ -121,34 +120,24 @@ msgstr ""
 msgid "Invalid token type - admin required"
 msgstr ""
 
-#: app/shared/auth/admin_auth.py:80 app/shared/auth/user_auth.py:73
+#: app/shared/auth/admin_auth.py:80
 msgid "Validate credentials expired"
 msgstr ""
 
-#: app/shared/auth/admin_auth.py:83 app/shared/auth/user_auth.py:76
-#: app/shared/auth/user_auth.py:128
+#: app/shared/auth/admin_auth.py:83
 msgid "Could not validate credentials"
 msgstr ""
 
-#: app/shared/auth/admin_auth.py:114 app/shared/auth/user_auth.py:137
+#: app/shared/auth/admin_auth.py:114
 msgid "Token required"
 msgstr ""
 
-#: app/shared/auth/admin_auth.py:118 app/shared/auth/user_auth.py:125
-#: app/shared/auth/user_auth.py:141
+#: app/shared/auth/admin_auth.py:118
 msgid "Token has been revoked"
 msgstr ""
 
 #: app/shared/auth/admin_auth.py:121
 msgid "Admin not found"
-msgstr ""
-
-#: app/shared/auth/user_auth.py:70
-msgid "Invalid token type"
-msgstr ""
-
-#: app/shared/auth/user_auth.py:120
-msgid "Invalid token type - refresh required"
 msgstr ""
 
 #~ msgid "User"
@@ -245,5 +234,11 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Email already registered"
+#~ msgstr ""
+
+#~ msgid "Invalid token type"
+#~ msgstr ""
+
+#~ msgid "Invalid token type - refresh required"
 #~ msgstr ""
 

--- a/server/messages.pot
+++ b/server/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-01 20:31+0800\n"
+"POT-Creation-Date: 2026-08-27 16:40+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgstr ""
 msgid "hello"
 msgstr ""
 
-#: app/domains/chat/api/snapshot_controller.py:42
+#: app/domains/chat/api/snapshot_controller.py:43
 msgid "Invalid api_task_id: only letters, numbers, - and _ allowed"
 msgstr ""
 
@@ -73,26 +73,25 @@ msgstr ""
 msgid "Failed to create default user"
 msgstr ""
 
-#: app/domains/user/api/login_controller.py:90
-msgid "Account or password error"
-msgstr ""
-
 #: app/domains/user/api/login_controller.py:92
-#: app/domains/user/api/login_controller.py:116
-msgid "Your account has been blocked."
+msgid "Account or password error"
 msgstr ""
 
 #: app/domains/user/api/login_controller.py:94
 #: app/domains/user/api/login_controller.py:118
+msgid "Your account has been blocked."
+msgstr ""
+
+#: app/domains/user/api/login_controller.py:96
+#: app/domains/user/api/login_controller.py:120
 msgid "Please activate your account via the email link."
 msgstr ""
 
-#: app/domains/user/api/login_controller.py:110
+#: app/domains/user/api/login_controller.py:112
 msgid "Refresh token required"
 msgstr ""
 
-#: app/domains/user/api/login_controller.py:114
-#: app/shared/auth/user_auth.py:144
+#: app/domains/user/api/login_controller.py:116
 msgid "User not found"
 msgstr ""
 
@@ -120,33 +119,23 @@ msgstr ""
 msgid "Invalid token type - admin required"
 msgstr ""
 
-#: app/shared/auth/admin_auth.py:80 app/shared/auth/user_auth.py:73
+#: app/shared/auth/admin_auth.py:80
 msgid "Validate credentials expired"
 msgstr ""
 
-#: app/shared/auth/admin_auth.py:83 app/shared/auth/user_auth.py:76
-#: app/shared/auth/user_auth.py:128
+#: app/shared/auth/admin_auth.py:83
 msgid "Could not validate credentials"
 msgstr ""
 
-#: app/shared/auth/admin_auth.py:114 app/shared/auth/user_auth.py:137
+#: app/shared/auth/admin_auth.py:114
 msgid "Token required"
 msgstr ""
 
-#: app/shared/auth/admin_auth.py:118 app/shared/auth/user_auth.py:125
-#: app/shared/auth/user_auth.py:141
+#: app/shared/auth/admin_auth.py:118
 msgid "Token has been revoked"
 msgstr ""
 
 #: app/shared/auth/admin_auth.py:121
 msgid "Admin not found"
-msgstr ""
-
-#: app/shared/auth/user_auth.py:70
-msgid "Invalid token type"
-msgstr ""
-
-#: app/shared/auth/user_auth.py:120
-msgid "Invalid token type - refresh required"
 msgstr ""
 

--- a/server/start_server.sh
+++ b/server/start_server.sh
@@ -19,7 +19,7 @@ if [ ! -f "pyproject.toml" ]; then
 fi
 
 # Check if uv is installed
-echo -e "${YELLOW}[1/5] Checking if uv is installed...${NC}"
+echo -e "${YELLOW}[1/8] Checking if uv is installed...${NC}"
 if ! command -v uv &> /dev/null; then
     echo -e "${YELLOW}uv is not installed, attempting to install...${NC}"
     echo -e "${YELLOW}Downloading and installing uv...${NC}"
@@ -42,7 +42,7 @@ else
 fi
 
 # Install project dependencies
-echo -e "${YELLOW}[2/5] Installing project dependencies...${NC}"
+echo -e "${YELLOW}[2/8] Installing project dependencies...${NC}"
 if uv sync; then
     echo -e "${GREEN}Dependencies installed successfully${NC}"
 else
@@ -51,8 +51,24 @@ else
     exit 1
 fi
 
+# Validate the environment before running migrations or starting background
+# processes. The desktop .env.development file is intentionally not loaded by
+# the standalone server; server processes load server/.env (or exported vars).
+echo -e "${YELLOW}[3/8] Validating server environment...${NC}"
+if ! MISSING_ENV_VARS="$(uv run python -c 'import os; from dotenv import load_dotenv; load_dotenv(".env"); required = ("database_url", "redis_url", "celery_broker_url", "celery_result_url", "secret_key"); print(", ".join(name for name in required if not os.getenv(name)))')"; then
+    echo -e "${RED}Unable to validate the server environment${NC}"
+    exit 1
+fi
+if [ -n "$MISSING_ENV_VARS" ]; then
+    echo -e "${RED}Missing required server environment variables: $MISSING_ENV_VARS${NC}"
+    echo -e "${YELLOW}Create server/.env from server/.env.example or export these variables before starting.${NC}"
+    echo -e "${YELLOW}The repository-root .env.development file configures Vite/Electron and is not read by this server.${NC}"
+    exit 1
+fi
+echo -e "${GREEN}Server environment is ready${NC}"
+
 # Execute babel internationalization
-echo -e "${YELLOW}[3/5] Executing babel internationalization...${NC}"
+echo -e "${YELLOW}[4/8] Executing babel internationalization...${NC}"
 if ! uv run pybabel extract -F babel.cfg -o messages.pot .; then
     echo -e "${RED}babel extract failed${NC}"
     read -p "Press Enter to exit"
@@ -86,7 +102,7 @@ fi
 echo -e "${GREEN}babel processing completed${NC}"
 
 # Execute alembic database migration
-echo -e "${YELLOW}[4/5] Executing alembic database migration...${NC}"
+echo -e "${YELLOW}[5/8] Executing alembic database migration...${NC}"
 if uv run alembic upgrade head; then
     echo -e "${GREEN}alembic migration completed${NC}"
 else
@@ -97,7 +113,10 @@ else
 fi
 
 # Cleanup function to stop background processes on exit
+CELERY_WORKER_PID=""
+CELERY_BEAT_PID=""
 cleanup() {
+    local exit_status="${1:-0}"
     echo -e "\n${YELLOW}Shutting down services...${NC}"
     if [ -n "$CELERY_WORKER_PID" ] && kill -0 "$CELERY_WORKER_PID" 2>/dev/null; then
         kill "$CELERY_WORKER_PID" 2>/dev/null
@@ -107,28 +126,39 @@ cleanup() {
         kill "$CELERY_BEAT_PID" 2>/dev/null
         echo -e "${GREEN}Celery beat stopped${NC}"
     fi
-    exit 0
+    exit "$exit_status"
 }
 trap cleanup SIGINT SIGTERM
 
 # Start services
-echo -e "${YELLOW}[5/7] Starting Celery worker...${NC}"
+echo -e "${YELLOW}[6/8] Starting Celery worker...${NC}"
 uv run celery -A app.core.celery worker --loglevel=info --queues=celery,poll_trigger_schedules,check_execution_timeouts &
 CELERY_WORKER_PID=$!
 echo -e "${GREEN}Celery worker started (PID: $CELERY_WORKER_PID)${NC}"
 
-echo -e "${YELLOW}[6/7] Starting Celery beat...${NC}"
+echo -e "${YELLOW}[7/8] Starting Celery beat...${NC}"
 uv run celery -A app.core.celery beat --loglevel=info &
 CELERY_BEAT_PID=$!
 echo -e "${GREEN}Celery beat started (PID: $CELERY_BEAT_PID)${NC}"
 
-echo -e "${YELLOW}[7/7] Starting FastAPI service...${NC}"
+# Celery starts asynchronously. Catch immediate configuration/import failures
+# before claiming that the API service is ready.
+sleep 1
+if ! kill -0 "$CELERY_WORKER_PID" 2>/dev/null; then
+    echo -e "${RED}Celery worker exited during startup${NC}"
+    cleanup 1
+fi
+if ! kill -0 "$CELERY_BEAT_PID" 2>/dev/null; then
+    echo -e "${RED}Celery beat exited during startup${NC}"
+    cleanup 1
+fi
+
+echo -e "${YELLOW}[8/8] Starting FastAPI service...${NC}"
 echo -e "${CYAN}Service will start at http://localhost:3001${NC}"
 echo -e "${CYAN}Press Ctrl+C to stop all services${NC}"
 echo -e "${GREEN}========================================${NC}"
 
 if ! uv run uvicorn main:api --reload --port 3001 --host 0.0.0.0; then
     echo -e "${RED}Service startup failed${NC}"
-    cleanup
-    exit 1
+    cleanup 1
 fi

--- a/server/tests/test_command_control_service.py
+++ b/server/tests/test_command_control_service.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+os.environ.setdefault("database_url", "sqlite:///test.db")
+os.environ.setdefault("secret_key", "test-secret")
+os.environ.setdefault("redis_url", "redis://localhost:6379/0")
+os.environ.setdefault("celery_broker_url", "redis://localhost:6379/0")
+os.environ.setdefault("celery_result_url", "redis://localhost:6379/0")
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, select
+
+from app.domains.remote_control.schema import (
+    CommandEventIn,
+    CommandEventsIn,
+    ConfirmCommandReceiptIn,
+    DeviceRegistrationIn,
+    RemoteControlCommandIn,
+)
+from app.domains.remote_control.service.command_control_service import (
+    HIGH_RISK_COMMAND_TYPES,
+    CommandControlService,
+)
+from app.domains.remote_control.service.remote_control_service import (
+    RemoteControlRedis,
+    RemoteControlService,
+)
+from app.model.chat.chat_history import ChatHistory
+from app.model.project import Project
+from app.model.remote_control import (
+    DesktopDevice,
+    ProjectExecutionRoute,
+    RemoteCommandLifecycleEvent,
+    RemoteCommandNotificationOutbox,
+    RemoteCommandState,
+    RemoteControlCommand,
+    RemoteControlSession,
+)
+from app.model.space import Space
+
+
+@pytest.fixture()
+def engine():
+    db_engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(
+        db_engine,
+        tables=[
+            Space.__table__,
+            Project.__table__,
+            ChatHistory.__table__,
+            DesktopDevice.__table__,
+            ProjectExecutionRoute.__table__,
+            RemoteControlSession.__table__,
+            RemoteControlCommand.__table__,
+            RemoteCommandState.__table__,
+            RemoteCommandLifecycleEvent.__table__,
+            RemoteCommandNotificationOutbox.__table__,
+        ],
+    )
+    now = datetime.now(UTC)
+    with Session(db_engine) as db:
+        db.add(Space(id="space-1", user_id="7", name="Space"))
+        db.flush()
+        db.add(
+            Project(
+                id="project-1",
+                user_id="7",
+                space_id="space-1",
+                name="Project",
+            )
+        )
+        db.flush()
+        db.add(
+            RemoteControlSession(
+                id="session-1",
+                user_id=7,
+                desktop_instance_id="device-1",
+                space_id="space-1",
+                project_id="project-1",
+                current_project_id="project-1",
+                current_brain_session_id="rc_brain_1",
+                expires_at=now + timedelta(minutes=10),
+            )
+        )
+        db.flush()
+        CommandControlService.register_device(
+            "device-1",
+            7,
+            DeviceRegistrationIn(app_version="1.0"),
+            db,
+        )
+        CommandControlService.claim_project_route("project-1", "device-1", 7, None, db)
+        db.commit()
+    return db_engine
+
+
+def _create_command_state(engine) -> None:
+    with Session(engine) as db:
+        command = RemoteControlCommand(
+            id="command-1",
+            session_id="session-1",
+            user_id=7,
+            type="user_message",
+            payload={"content": "hello"},
+            target_project_id="project-1",
+        )
+        db.add(command)
+        db.flush()
+        CommandControlService.create_state_for_command(
+            command,
+            db.get(RemoteControlSession, "session-1"),
+            db,
+        )
+        db.commit()
+
+
+def _receipt(lease_token: str) -> ConfirmCommandReceiptIn:
+    return ConfirmCommandReceiptIn(
+        event_id="receipt-1",
+        desktop_event_sequence=1,
+        occurred_at=datetime.now(UTC),
+        lease_token=lease_token,
+    )
+
+
+def _event(event_id: str, sequence: int, event_type: str) -> CommandEventIn:
+    return CommandEventIn(
+        event_id=event_id,
+        desktop_event_sequence=sequence,
+        event_type=event_type,
+        occurred_at=datetime.now(UTC),
+    )
+
+
+def test_interaction_decision_is_strict_and_high_risk() -> None:
+    request = RemoteControlCommandIn(
+        client_request_id="decision-request-1",
+        type="interaction_decision",
+        payload={
+            "run_id": "run-1",
+            "interaction_id": "approval-1",
+            "expected_version": 0,
+            "decision": {"decision": "approved", "scope": "once"},
+        },
+        target_project_id="project-1",
+        target_brain_session_id="rc_brain_1",
+    )
+
+    assert request.type in HIGH_RISK_COMMAND_TYPES
+    with pytest.raises(ValueError, match="exactly one response shape"):
+        RemoteControlCommandIn(
+            client_request_id="invalid-decision",
+            type="interaction_decision",
+            payload={
+                "run_id": "run-1",
+                "interaction_id": "approval-1",
+                "expected_version": 0,
+                "decision": {
+                    "decision": "approved",
+                    "reply": "also do this",
+                },
+            },
+            target_project_id="project-1",
+            target_brain_session_id="rc_brain_1",
+        )
+
+
+def test_remote_command_creation_is_idempotent(engine, monkeypatch) -> None:
+    monkeypatch.setattr(
+        RemoteControlRedis,
+        "is_bridge_online",
+        staticmethod(lambda *_args, **_kwargs: True),
+    )
+    monkeypatch.setattr(
+        RemoteControlService,
+        "publish_command",
+        staticmethod(lambda *_args, **_kwargs: True),
+    )
+    monkeypatch.setattr(
+        RemoteControlService,
+        "record_event",
+        staticmethod(lambda *_args, **_kwargs: None),
+    )
+    request = RemoteControlCommandIn(
+        client_request_id="mobile-request-1",
+        type="stop",
+        target_project_id="project-1",
+        target_brain_session_id="rc_brain_1",
+    )
+
+    with Session(engine) as db:
+        first = RemoteControlService.send_command("session-1", 7, request, db)
+        replay = RemoteControlService.send_command("session-1", 7, request, db)
+        commands = db.exec(
+            select(RemoteControlCommand).where(RemoteControlCommand.client_request_id == "mobile-request-1")
+        ).all()
+
+        assert replay.command_id == first.command_id
+        assert len(commands) == 1
+        assert db.get(RemoteCommandState, first.command_id) is not None
+
+
+def test_interaction_decision_converges_across_browser_tabs(engine, monkeypatch) -> None:
+    monkeypatch.setattr(
+        RemoteControlRedis,
+        "is_bridge_online",
+        staticmethod(lambda *_args, **_kwargs: True),
+    )
+    monkeypatch.setattr(
+        RemoteControlService,
+        "publish_command",
+        staticmethod(lambda *_args, **_kwargs: True),
+    )
+    monkeypatch.setattr(
+        RemoteControlService,
+        "record_event",
+        staticmethod(lambda *_args, **_kwargs: None),
+    )
+    payload = {
+        "run_id": "run-1",
+        "interaction_id": "approval-1",
+        "expected_version": 3,
+        "action_digest": "a" * 64,
+        "decision": {"decision": "approved", "scope": "once"},
+    }
+
+    with Session(engine) as db:
+        first = RemoteControlService.send_command(
+            "session-1",
+            7,
+            RemoteControlCommandIn(
+                client_request_id="browser-tab-one",
+                type="interaction_decision",
+                payload=payload,
+                target_project_id="project-1",
+                target_brain_session_id="rc_brain_1",
+            ),
+            db,
+        )
+        replay = RemoteControlService.send_command(
+            "session-1",
+            7,
+            RemoteControlCommandIn(
+                client_request_id="browser-tab-two",
+                type="interaction_decision",
+                payload=payload,
+                target_project_id="project-1",
+                target_brain_session_id="rc_brain_1",
+            ),
+            db,
+        )
+
+        assert replay.command_id == first.command_id
+        with pytest.raises(HTTPException) as conflict:
+            RemoteControlService.send_command(
+                "session-1",
+                7,
+                RemoteControlCommandIn(
+                    client_request_id="browser-tab-three",
+                    type="interaction_decision",
+                    payload={
+                        **payload,
+                        "decision": {
+                            "decision": "rejected",
+                            "scope": "once",
+                        },
+                    },
+                    target_project_id="project-1",
+                    target_brain_session_id="rc_brain_1",
+                ),
+                db,
+            )
+
+    assert conflict.value.status_code == 409
+    assert conflict.value.detail["code"] == ("REMOTE_COMMAND_IDEMPOTENCY_CONFLICT")
+
+
+def test_pending_delivery_lease_and_receipt_are_idempotent(engine) -> None:
+    _create_command_state(engine)
+    with Session(engine) as db:
+        first = CommandControlService.claim_pending_commands("device-1", 7, 10, db)
+        db.commit()
+        assert [item.command_id for item in first.items] == ["command-1"]
+        assert first.items[0].requires_online_receipt_confirmation is False
+        assert CommandControlService.claim_pending_commands("device-1", 7, 10, db).items == []
+        db.rollback()
+
+    with Session(engine) as db:
+        receipt = _receipt(first.items[0].lease_token)
+        confirmed = CommandControlService.confirm_receipt("command-1", "device-1", 7, receipt, db)
+        db.commit()
+        assert confirmed.result == "confirmed"
+        assert confirmed.may_execute is True
+
+    with Session(engine) as db:
+        duplicate = CommandControlService.confirm_receipt("command-1", "device-1", 7, receipt, db)
+        db.commit()
+        assert duplicate.result == "already_received"
+        receipt_events = db.exec(
+            select(RemoteCommandLifecycleEvent).where(RemoteCommandLifecycleEvent.desktop_event_sequence == 1)
+        ).all()
+        assert len(receipt_events) == 1
+
+
+def test_desktop_event_sequence_is_monotonic(engine) -> None:
+    _create_command_state(engine)
+    with Session(engine) as db:
+        lease = CommandControlService.lease_command_for_delivery("command-1", "device-1", 7, db)
+        receipt = _receipt(lease.lease_token)
+        CommandControlService.confirm_receipt("command-1", "device-1", 7, receipt, db)
+        result = CommandControlService.ingest_command_events(
+            "command-1",
+            "device-1",
+            7,
+            CommandEventsIn(
+                events=[
+                    _event("admission-1", 2, "admission.accepted"),
+                    _event("execution-1", 3, "execution.completed"),
+                ]
+            ),
+            db,
+        )
+        db.commit()
+        assert result.admission_state == "accepted"
+        assert result.execution_state == "completed"
+        assert result.expected_next_desktop_event_sequence == 4
+
+    with Session(engine) as db:
+        with pytest.raises(HTTPException) as gap:
+            CommandControlService.ingest_command_events(
+                "command-1",
+                "device-1",
+                7,
+                CommandEventsIn(events=[_event("execution-gap", 5, "execution.failed")]),
+                db,
+            )
+        assert gap.value.detail["code"] == "command_sequence_gap"
+
+
+def test_internal_version_lane_keeps_legacy_wire_alias(engine) -> None:
+    _create_command_state(engine)
+    with Session(engine) as db:
+        state = CommandControlService.get_command_state("command-1", 7, db)
+
+    server_events = [event for event in state.events if event.producer == "server"]
+    assert server_events
+    assert server_events[0].server_recorded_version == 1
+    assert server_events[0].cloud_recorded_version == server_events[0].server_recorded_version
+
+
+def test_legacy_pending_command_without_state_still_retries(engine, monkeypatch) -> None:
+    with Session(engine) as db:
+        db.add(
+            RemoteControlCommand(
+                id="legacy-command",
+                session_id="session-1",
+                user_id=7,
+                type="switch_project_view",
+                payload={},
+                target_project_id="project-1",
+                status="pending",
+                created_at=datetime.now(UTC) - timedelta(minutes=2),
+            )
+        )
+        db.commit()
+
+    published: list[tuple[str, RemoteCommandState | None]] = []
+    monkeypatch.setattr(
+        RemoteControlRedis,
+        "is_bridge_online",
+        staticmethod(lambda *_args, **_kwargs: True),
+    )
+    monkeypatch.setattr(
+        RemoteControlService,
+        "publish_command",
+        staticmethod(lambda _session, command, state=None: published.append((command.id, state)) or True),
+    )
+
+    with Session(engine) as db:
+        RemoteControlService.retry_pending_commands(db)
+
+    assert published == [("legacy-command", None)]
+
+
+def test_retry_persists_delivery_lease_before_notification(engine, monkeypatch) -> None:
+    _create_command_state(engine)
+    with Session(engine) as db:
+        command = db.get(RemoteControlCommand, "command-1")
+        command.created_at = datetime.now(UTC) - timedelta(minutes=2)
+        db.add(command)
+        db.commit()
+
+    observed_lease_tokens: list[str | None] = []
+    monkeypatch.setattr(
+        RemoteControlRedis,
+        "is_bridge_online",
+        staticmethod(lambda *_args, **_kwargs: True),
+    )
+
+    def publish_after_commit(_session, command, _state=None) -> bool:
+        with Session(engine) as verification_db:
+            stored = verification_db.get(RemoteCommandState, command.id)
+            observed_lease_tokens.append(stored.lease_token)
+        return True
+
+    monkeypatch.setattr(
+        RemoteControlService,
+        "publish_command",
+        staticmethod(publish_after_commit),
+    )
+
+    with Session(engine) as db:
+        RemoteControlService.retry_pending_commands(db)
+        RemoteControlService.retry_pending_commands(db)
+
+    assert len(observed_lease_tokens) == 1
+    assert observed_lease_tokens[0]

--- a/server/tests/test_database_safety.py
+++ b/server/tests/test_database_safety.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+os.environ.setdefault("database_url", "sqlite:///test.db")
+
+from app.core import database
+
+
+def test_postgres_connections_have_bounded_waits(monkeypatch):
+    monkeypatch.delenv("DB_CONNECT_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("DB_LOCK_TIMEOUT_MS", raising=False)
+    monkeypatch.delenv("DB_STATEMENT_TIMEOUT_MS", raising=False)
+    monkeypatch.delenv("DB_IDLE_IN_TRANSACTION_TIMEOUT_MS", raising=False)
+
+    args = database._database_connect_args("postgresql://postgres:postgres@localhost/eigent")
+
+    assert args["connect_timeout"] == 10
+    assert "lock_timeout=5000" in args["options"]
+    assert "statement_timeout=120000" in args["options"]
+    assert "idle_in_transaction_session_timeout=60000" in args["options"]
+
+
+def test_non_postgres_connections_do_not_receive_libpq_options():
+    assert database._database_connect_args("sqlite:///test.db") == {}
+
+
+def test_async_session_work_does_not_block_event_loop(monkeypatch):
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def rollback(self):
+            return None
+
+    monkeypatch.setattr(database, "session_make", FakeSession)
+
+    async def scenario() -> float:
+        started = time.monotonic()
+        task = asyncio.create_task(database.run_in_session_async(lambda _db: time.sleep(0.15)))
+        await asyncio.sleep(0.02)
+        tick_elapsed = time.monotonic() - started
+        await task
+        return tick_elapsed
+
+    assert asyncio.run(scenario()) < 0.1

--- a/server/tests/test_remote_control_bridge_errors.py
+++ b/server/tests/test_remote_control_bridge_errors.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+os.environ.setdefault("database_url", "sqlite:///test.db")
+os.environ.setdefault("secret_key", "test-secret")
+os.environ.setdefault("redis_url", "redis://localhost:6379/0")
+os.environ.setdefault("celery_broker_url", "redis://localhost:6379/0")
+os.environ.setdefault("celery_result_url", "redis://localhost:6379/0")
+
+from fastapi import HTTPException
+
+from app.domains.remote_control.api.remote_control_controller import (
+    _send_bridge_http_error,
+)
+
+
+class FakeWebSocket:
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+        self.close_codes: list[int] = []
+
+    async def send_json(self, message: dict) -> None:
+        self.messages.append(message)
+
+    async def close(self, code: int) -> None:
+        self.close_codes.append(code)
+
+
+def test_bridge_auth_expiry_is_distinct() -> None:
+    websocket = FakeWebSocket()
+
+    asyncio.run(
+        _send_bridge_http_error(
+            websocket,
+            HTTPException(status_code=401, detail="Token has expired"),
+        )
+    )
+
+    assert websocket.messages == [{"type": "auth_expired", "message": "Token has expired"}]
+    assert websocket.close_codes == [4401]
+
+
+def test_bridge_policy_error_is_not_retryable() -> None:
+    websocket = FakeWebSocket()
+
+    asyncio.run(
+        _send_bridge_http_error(
+            websocket,
+            HTTPException(
+                status_code=409,
+                detail={
+                    "code": "device_owner_mismatch",
+                    "message": "Desktop device belongs to another user",
+                },
+            ),
+        )
+    )
+
+    assert websocket.messages[0]["retryable"] is False
+    assert websocket.messages[0]["code"] == "device_owner_mismatch"
+    assert websocket.close_codes == [1008]
+
+
+def test_bridge_server_failure_remains_retryable() -> None:
+    websocket = FakeWebSocket()
+
+    asyncio.run(
+        _send_bridge_http_error(
+            websocket,
+            HTTPException(status_code=503, detail="Database temporarily unavailable"),
+        )
+    )
+
+    assert websocket.messages[0]["retryable"] is True
+    assert websocket.close_codes == [1011]

--- a/server/tests/test_self_hosted_migration_scope.py
+++ b/server/tests/test_self_hosted_migration_scope.py
@@ -1,0 +1,108 @@
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+
+MIGRATED_MODULES = (
+    "app/domains/remote_control/api/command_control_controller.py",
+    "app/domains/remote_control/service/command_control_service.py",
+    "app/domains/remote_control/service/command_notifier.py",
+    "app/model/remote_control/command_control.py",
+    "alembic/versions/2026_08_27_1200-add_self_hosted_remote_command_control.py",
+)
+
+EXCLUDED_MARKERS = (
+    "step_sync",
+    "run_sync_service",
+    "workspace_bundle",
+    "s3",
+    "cloud_model",
+    "credit",
+    "stripe",
+    "artifact_upload",
+    "file_sync",
+    "memory_sync",
+    "environment_spec",
+)
+
+
+def test_migrated_control_plane_has_no_hosted_sync_dependencies(
+    server_root: Path,
+) -> None:
+    for relative_path in MIGRATED_MODULES:
+        source = (server_root / relative_path).read_text().lower()
+        for marker in EXCLUDED_MARKERS:
+            assert marker not in source, f"{relative_path} unexpectedly contains excluded marker {marker!r}"
+
+
+def _migration_revisions(
+    path: Path,
+) -> tuple[str, str | tuple[str, ...] | None]:
+    tree = ast.parse(path.read_text())
+    values: dict[str, str | None] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.AnnAssign) or not isinstance(node.target, ast.Name):
+            continue
+        if node.target.id not in {"revision", "down_revision"}:
+            continue
+        values[node.target.id] = ast.literal_eval(node.value)
+    return values["revision"], values["down_revision"]
+
+
+def test_hosted_database_revision_rejoins_self_hosted_chain(
+    server_root: Path,
+) -> None:
+    versions = server_root / "alembic/versions"
+    marker = versions / "2026_06_10_1200-hosted_schema_compatibility_marker.py"
+    command_control = versions / "2026_08_27_1200-add_self_hosted_remote_command_control.py"
+    lineage_merge = versions / "2026_08_27_1230-merge_self_hosted_remote_command_lineages.py"
+
+    assert _migration_revisions(marker) == (
+        "add_cloud_model_table",
+        "add_rc_space_scope",
+    )
+    assert _migration_revisions(command_control) == (
+        "add_self_hosted_rc_control",
+        "add_rc_space_scope",
+    )
+    assert _migration_revisions(lineage_merge) == (
+        "merge_self_hosted_rc_lineages",
+        ("add_cloud_model_table", "add_self_hosted_rc_control"),
+    )
+    assert "op." not in marker.read_text()
+    assert "op." not in lineage_merge.read_text()
+
+
+def test_self_hosted_server_does_not_expose_run_or_step_sync_routes(
+    server_root: Path,
+) -> None:
+    controller = (server_root / "app/domains/remote_control/api/command_control_controller.py").read_text()
+
+    assert 'router = APIRouter(prefix="/sync"' in controller
+    assert '"/commands/pending"' in controller
+    assert '"/runs/' not in controller
+    assert '"/steps/' not in controller
+    assert '"/files/' not in controller
+
+
+def test_command_control_routes_load_through_server_discovery(server_root: Path, monkeypatch) -> None:
+    monkeypatch.setenv("database_url", "sqlite:///test.db")
+    monkeypatch.setenv("secret_key", "test-secret")
+    monkeypatch.setenv("redis_url", "redis://localhost:6379/0")
+    monkeypatch.setenv("celery_broker_url", "redis://localhost:6379/0")
+    monkeypatch.setenv("celery_result_url", "redis://localhost:6379/0")
+
+    from app.core.environment import auto_include_routers
+
+    api = FastAPI()
+    auto_include_routers(
+        api,
+        "",
+        str(server_root / "app/domains/remote_control/api"),
+    )
+    route_paths = {route.path for route in api.routes}
+
+    assert "/sync/devices/register" in route_paths
+    assert "/sync/commands/pending" in route_paths
+    assert "/sync/commands/{command_id}/confirm-receipt" in route_paths
+    assert "/sync/commands/{command_id}/events" in route_paths


### PR DESCRIPTION
# Pull Request

## Related Issue

N/A — internal cross-repository parity work for `feat/workforce-bundle-product`.

## Description

This PR ports the durable Remote Control command admission and result APIs from the hosted Eigent server into the open-source self-hosted server.

- Adds the self-hosted Remote Control command API, service, notifier, persistence model, and scoped Alembic migrations.
- Keeps Eigent-hosted-only capabilities out of the self-hosted path, including credits, cloud models, Workspace Bundle, and Run/step/file/S3 replication.
- Restricts full cloud Run synchronization and legacy step projection to Eigent-operated server URLs.
- Adds database safety checks and safer standalone startup defaults.
- Makes `server/start_server.sh` executable.
- Intentionally excludes the local `.env.development` configuration.

## Testing Evidence (REQUIRED)

Human-verified local self-hosted execution completed successfully before this PR was opened. Automated verification also passed:

- `43 passed` — focused backend Run Sync and journal tests.
- `18 passed` — self-hosted command control, database safety, bridge error, and migration scope tests.
- Ruff 0.14.3 lint and format checks passed.

- [x] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [x] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [ ] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)