### PR TITLE
fix(ci): install uv without upgrading pip

### DIFF
--- a/.github/workflows/build-view.yml
+++ b/.github/workflows/build-view.yml
@@ -92,10 +92,8 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Python Dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install uv
+      - name: Install uv
+        run: python -m pip install uv
 
       - name: Install bun
         run: npm install -g bun

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,10 +87,8 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Python Dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install uv
+      - name: Install uv
+        run: python -m pip install uv
 
       - name: Install bun
         run: npm install -g bun

--- a/.github/workflows/pre-build-view.yml
+++ b/.github/workflows/pre-build-view.yml
@@ -97,10 +97,8 @@ jobs:
         run: |
           node -e "const fs=require('fs'); const path='electron-builder.json'; const config=JSON.parse(fs.readFileSync(path,'utf8')); if (Array.isArray(config.publish)) { config.publish=config.publish.map((entry) => entry && entry.provider === 'github' ? { ...entry, repo: 'eigent-private-lab' } : entry); } fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');"
 
-      - name: Install Python Dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install uv
+      - name: Install uv
+        run: python -m pip install uv
 
       - name: Install bun
         run: npm install -g bun

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -92,10 +92,8 @@ jobs:
         run: |
           node -e "const fs=require('fs'); const path='electron-builder.json'; const config=JSON.parse(fs.readFileSync(path,'utf8')); if (Array.isArray(config.publish)) { config.publish=config.publish.map((entry) => entry && entry.provider === 'github' ? { ...entry, repo: 'eigent-private-lab' } : entry); } fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');"
 
-      - name: Install Python Dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install uv
+      - name: Install uv
+        run: python -m pip install uv
 
       - name: Install bun
         run: npm install -g bun


### PR DESCRIPTION
## Summary

- stop upgrading pip in build workflows
- install `uv` with the selected Python interpreter
- apply the change consistently across build and pre-build workflows

## Validation

- parsed all four workflow YAML files successfully
- ran `git diff --check`