### PR TITLE
fix(ci): set up uv without Python dependency

### DIFF
--- a/.github/workflows/build-view.yml
+++ b/.github/workflows/build-view.yml
@@ -92,8 +92,10 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install uv
-        run: python -m pip install uv
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v9
+        with:
+          version: '0.9.26'
 
       - name: Install bun
         run: npm install -g bun

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,10 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install uv
-        run: python -m pip install uv
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v9
+        with:
+          version: '0.9.26'
 
       - name: Install bun
         run: npm install -g bun

--- a/.github/workflows/pre-build-view.yml
+++ b/.github/workflows/pre-build-view.yml
@@ -97,8 +97,10 @@ jobs:
         run: |
           node -e "const fs=require('fs'); const path='electron-builder.json'; const config=JSON.parse(fs.readFileSync(path,'utf8')); if (Array.isArray(config.publish)) { config.publish=config.publish.map((entry) => entry && entry.provider === 'github' ? { ...entry, repo: 'eigent-private-lab' } : entry); } fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');"
 
-      - name: Install uv
-        run: python -m pip install uv
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v9
+        with:
+          version: '0.9.26'
 
       - name: Install bun
         run: npm install -g bun

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -92,8 +92,10 @@ jobs:
         run: |
           node -e "const fs=require('fs'); const path='electron-builder.json'; const config=JSON.parse(fs.readFileSync(path,'utf8')); if (Array.isArray(config.publish)) { config.publish=config.publish.map((entry) => entry && entry.provider === 'github' ? { ...entry, repo: 'eigent-private-lab' } : entry); } fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');"
 
-      - name: Install uv
-        run: python -m pip install uv
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v9
+        with:
+          version: '0.9.26'
 
       - name: Install bun
         run: npm install -g bun


### PR DESCRIPTION
## Summary

- replace `python -m pip install uv` with `astral-sh/setup-uv` pinned to the immutable `v9.0.0` revision
- pin uv to `0.9.26` across all build and pre-build workflows
- remove the dependency on a `python` command being present on self-hosted runners

## Context

The ARM64 runner inherited a pyenv-provided `python` command, while the x64 runner did not, causing the x64 build to exit with code 127. The setup action installs uv directly and adds it to PATH consistently across runner architectures.

The setup-uv repository publishes the exact `v9.0.0` tag but does not publish a floating `v9` tag, so the action is referenced by the immutable commit SHA for `v9.0.0`.

## Validation

- verified the action revision against the upstream `v9.0.0` Git tag
- parsed all four workflow YAML files successfully
- ran `git diff --check`