### PR TITLE
fix(ci): pin setup-uv to resolvable revision

### DIFF
--- a/.github/workflows/build-view.yml
+++ b/.github/workflows/build-view.yml
@@ -93,7 +93,7 @@ jobs:
           python-version: '3.11'
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: '0.9.26'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           python-version: '3.11'
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: '0.9.26'
 

--- a/.github/workflows/pre-build-view.yml
+++ b/.github/workflows/pre-build-view.yml
@@ -98,7 +98,7 @@ jobs:
           node -e "const fs=require('fs'); const path='electron-builder.json'; const config=JSON.parse(fs.readFileSync(path,'utf8')); if (Array.isArray(config.publish)) { config.publish=config.publish.map((entry) => entry && entry.provider === 'github' ? { ...entry, repo: 'eigent-private-lab' } : entry); } fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: '0.9.26'
 

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -93,7 +93,7 @@ jobs:
           node -e "const fs=require('fs'); const path='electron-builder.json'; const config=JSON.parse(fs.readFileSync(path,'utf8')); if (Array.isArray(config.publish)) { config.publish=config.publish.map((entry) => entry && entry.provider === 'github' ? { ...entry, repo: 'eigent-private-lab' } : entry); } fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: '0.9.26'
 


### PR DESCRIPTION
## Summary

- replace the nonexistent floating `astral-sh/setup-uv@v9` reference with the immutable commit SHA for `v9.0.0`
- keep the installed uv version pinned to `0.9.26`

## Root cause

The setup-uv repository publishes the exact `v9.0.0` tag but does not publish a floating `v9` tag. GitHub Actions therefore failed while preparing required actions, before any workflow step ran.

## Validation

- verified `c771a70e6277c0a99b617c7a806ffedaca235ff9` against the upstream `v9.0.0` Git tag
- parsed all four workflow YAML files successfully
- ran `git diff --check`