### PR TITLE
fix: preserve Responses instructions across chained turns

### DIFF
--- a/backend/app/agent/agent_model.py
+++ b/backend/app/agent/agent_model.py
@@ -57,6 +57,57 @@ _NATIVE_STREAM_USAGE_PLATFORMS = {
 }
 
 
+def _responses_instructions(system_message: str | BaseMessage) -> str:
+    """Return the trusted agent prompt for the Responses instructions field."""
+    if isinstance(system_message, str):
+        return system_message
+
+    content = getattr(system_message, "content", "")
+    return content if isinstance(content, str) else ""
+
+
+def _configure_responses_instructions(model_backend: Any) -> None:
+    """Keep system/developer text only in Responses `instructions`.
+
+    CAMEL converts the agent system message into an input item. Eigent also
+    supplies that trusted text through `instructions` so it is present on every
+    chained response. Remove the duplicate input item to avoid sending and
+    billing the same prompt twice.
+    """
+    if getattr(model_backend, "_eigent_instructions_configured", False):
+        return
+
+    prepare = getattr(
+        model_backend, "_prepare_responses_input_and_chain", None
+    )
+    if not callable(prepare):
+        return
+
+    def prepare_without_instruction_messages(messages, chain_enabled=True):
+        state = prepare(messages, chain_enabled=chain_enabled)
+        input_messages = state.get("input_messages")
+        if not isinstance(input_messages, list):
+            return state
+
+        filtered = [
+            item
+            for item in input_messages
+            if not (
+                isinstance(item, dict)
+                and item.get("role") in {"system", "developer"}
+            )
+        ]
+        if len(filtered) == len(input_messages):
+            return state
+
+        return {**state, "input_messages": filtered}
+
+    model_backend._prepare_responses_input_and_chain = (  # noqa: SLF001
+        prepare_without_instruction_messages
+    )
+    model_backend._eigent_instructions_configured = True  # noqa: SLF001
+
+
 def agent_model(
     agent_name: str,
     system_message: str | BaseMessage,
@@ -290,6 +341,15 @@ def agent_model(
                 effective_config["model_type"],
             )
 
+        if uses_responses_transport:
+            # Responses does not carry a prior response's `instructions`
+            # forward when `previous_response_id` is used. Send the trusted
+            # agent prompt on every call so the proxy Prompt Guard can validate
+            # continuation/tool turns without weakening its fail-closed rule.
+            instructions = _responses_instructions(system_message)
+            if instructions:
+                model_config["instructions"] = instructions
+
         runtime_model_platform = resolve_cloud_model_runtime_platform(
             model_platform=str(effective_config["model_platform"]),
             api_url=effective_api_url,
@@ -365,6 +425,8 @@ def agent_model(
             timeout=600,  # 10 minutes
             **init_params,
         )
+        if uses_responses_transport and model_config.get("instructions"):
+            _configure_responses_instructions(model_backend)
         return instrument_model_backend(
             model_backend,
             agent_id=agent_id,

--- a/backend/app/agent/toolkit/terminal_toolkit.py
+++ b/backend/app/agent/toolkit/terminal_toolkit.py
@@ -61,7 +61,7 @@ logger = logging.getLogger("terminal_toolkit")
 
 # App version - should match electron app version
 # TODO: Consider getting this from a shared config
-APP_VERSION = "1.0.3"
+APP_VERSION = "1.0.4"
 
 
 _SECRET_BROKER_ENVIRONMENT_KEY = re.compile(

--- a/backend/tests/app/agent/test_agent_model.py
+++ b/backend/tests/app/agent/test_agent_model.py
@@ -17,7 +17,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.agent.agent_model import agent_model
+from app.agent.agent_model import (
+    _configure_responses_instructions,
+    agent_model,
+)
 from app.model.chat import AgentModelConfig, Chat
 from app.service.task import Agents
 
@@ -55,6 +58,42 @@ class TestAgentFactoryFunctions:
 
             assert result is mock_agent
             mock_listen_agent.assert_called_once()
+
+    def test_responses_instructions_are_not_duplicated_in_input(self):
+        class ResponsesBackend:
+            def _prepare_responses_input_and_chain(
+                self, messages, chain_enabled=True
+            ):
+                return {
+                    "input_messages": list(messages),
+                    "chain_enabled": chain_enabled,
+                }
+
+        backend = ResponsesBackend()
+        _configure_responses_instructions(backend)
+        _configure_responses_instructions(backend)
+
+        state = backend._prepare_responses_input_and_chain(
+            [
+                {"role": "system", "content": "system prompt"},
+                {"role": "developer", "content": "developer prompt"},
+                {"role": "user", "content": "hello"},
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_123",
+                    "output": "done",
+                },
+            ]
+        )
+
+        assert state["input_messages"] == [
+            {"role": "user", "content": "hello"},
+            {
+                "type": "function_call_output",
+                "call_id": "call_123",
+                "output": "done",
+            },
+        ]
 
     def test_codex_subscription_model_uses_responses_api(
         self, monkeypatch, sample_chat_data
@@ -326,6 +365,7 @@ class TestAgentFactoryFunctions:
         assert "api_version" not in kwargs
         assert "azure_deployment_name" not in kwargs
         assert kwargs["model_config_dict"]["reasoning"] == {"effort": "high"}
+        assert kwargs["model_config_dict"]["instructions"] == "You are helpful"
         assert "reasoning_effort" not in kwargs["model_config_dict"]
         assert "stream_options" not in kwargs["model_config_dict"]
 
@@ -366,6 +406,7 @@ class TestAgentFactoryFunctions:
         assert kwargs["model_platform"] == "azure"
         assert kwargs["api_mode"] == "responses"
         assert kwargs["model_config_dict"]["reasoning"] == {"effort": "high"}
+        assert kwargs["model_config_dict"]["instructions"] == "You are helpful"
         assert "reasoning_effort" not in kwargs["model_config_dict"]
         assert "stream_options" not in kwargs["model_config_dict"]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eigent",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist-electron/main/index.js",
   "description": "Eigent",
   "author": "Eigent.AI",


### PR DESCRIPTION
## Summary
- send the trusted agent prompt through Responses API instructions on every request
- remove duplicate system/developer items from Responses input to avoid double billing
- bump the desktop version to 1.0.4

## Validation
- backend/.venv/bin/pytest backend/tests/app/agent/test_agent_model.py -q (20 passed)
- pre-commit hooks passed

## Rollout
Deploy the server-side Prompt Guard Responses-shape support before publishing v1.0.4.