### PR TITLE
fix: keep web search connector visible

### DIFF
--- a/src/components/Settings/Connectors/ConnectorGateway.tsx
+++ b/src/components/Settings/Connectors/ConnectorGateway.tsx
@@ -147,7 +147,7 @@ type ConnectorListItem =
       id: string;
       source: 'builtin';
       name: string;
-      active: true;
+      active: boolean;
       item: IntegrationItem;
     }
   | {
@@ -557,13 +557,15 @@ export default function ConnectorGateway() {
       active: true,
       provider,
     }));
+    // Web search owns its configuration panel on this surface, so keep the
+    // disconnected row visible instead of removing the user's only setup path.
     const builtIns: ConnectorListItem[] = builtInItems
-      .filter((item) => builtInInstalled[item.key])
+      .filter((item) => item.key === 'Search' || builtInInstalled[item.key])
       .map((item) => ({
         id: `builtin:${item.key}`,
         source: 'builtin',
         name: item.name,
-        active: true,
+        active: Boolean(builtInInstalled[item.key]),
         item,
       }));
     const custom: ConnectorListItem[] = customMcps.map((item) => ({

--- a/test/unit/components/ConnectorGateway.test.tsx
+++ b/test/unit/components/ConnectorGateway.test.tsx
@@ -1,0 +1,165 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import ConnectorGateway from '@/components/Settings/Connectors/ConnectorGateway';
+import { SettingsHeaderProvider } from '@/components/Settings/SettingsHeaderContext';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  modelType: 'custom',
+  configs: [] as Array<Record<string, unknown>>,
+  installed: {} as Record<string, boolean>,
+  checkAgentTool: vi.fn(),
+  fetchCapabilities: vi.fn(),
+  fetchInstalled: vi.fn(),
+  get: vi.fn(),
+  handleUninstall: vi.fn(),
+  saveEnvAndConfig: vi.fn(),
+  translate: (key: string) =>
+    (
+      ({
+        'layout.connectors': 'Connectors',
+        'connectors.connected': 'Connected',
+        'connectors.not-connected': 'Not connected',
+        'connectors.source-built-in': 'Built-in',
+        'connectors.web-search': 'Web search',
+        'connectors.web-search-desc':
+          'Choose Querit or Google for browser and research tasks.',
+        'connectors.querit-configuration-title': 'Querit authentication',
+      }) as Record<string, string>
+    )[key] || key,
+}));
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-i18next')>()),
+  useTranslation: () => ({
+    t: mocks.translate,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}));
+
+vi.mock('@/api/brain', () => ({
+  mcpInstall: vi.fn(),
+  mcpRemove: vi.fn(),
+  mcpUpdate: vi.fn(),
+}));
+
+vi.mock('@/api/connectors', () => ({
+  disconnectProvider: vi.fn(),
+  fetchConnectedProviders: vi.fn().mockResolvedValue([]),
+  fetchConnectorProvider: vi.fn(),
+  fetchConnectorProviders: vi.fn().mockResolvedValue({ providers: [] }),
+  invalidateConnectorProvidersCache: vi.fn(),
+  prefetchConnectorProviders: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/api/http', () => ({
+  fetchPost: vi.fn(),
+  proxyFetchDelete: vi.fn(),
+  proxyFetchGet: mocks.get,
+  proxyFetchPost: vi.fn(),
+  proxyFetchPut: vi.fn(),
+}));
+
+vi.mock('@/hooks/useIntegrationManagement', () => ({
+  useIntegrationManagement: () => ({
+    installed: mocks.installed,
+    configs: mocks.configs,
+    configsLoading: false,
+    fetchInstalled: mocks.fetchInstalled,
+    saveEnvAndConfig: mocks.saveEnvAndConfig,
+    handleUninstall: mocks.handleUninstall,
+  }),
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: () => ({
+    checkAgentTool: mocks.checkAgentTool,
+    modelType: mocks.modelType,
+  }),
+}));
+
+vi.mock('@/store/serverCapabilityStore', () => ({
+  useServerCapabilityStore: (
+    selector: (state: Record<string, unknown>) => unknown
+  ) =>
+    selector({
+      status: 'ready',
+      fetchCapabilities: mocks.fetchCapabilities,
+      isConnectorGatewayEnabled: () => false,
+    }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function renderGateway() {
+  return render(
+    <MemoryRouter>
+      <SettingsHeaderProvider activeSection="connectors">
+        <ConnectorGateway />
+      </SettingsHeaderProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('ConnectorGateway Web search visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.modelType = 'custom';
+    mocks.configs = [];
+    mocks.installed = {};
+    mocks.fetchCapabilities.mockResolvedValue(undefined);
+    mocks.fetchInstalled.mockResolvedValue(undefined);
+    mocks.get.mockImplementation((url: string) => {
+      if (url === '/api/v1/config/info') return Promise.resolve({});
+      if (url === '/api/v1/mcp/users') return Promise.resolve([]);
+      if (url === '/api/v1/configs') return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
+  });
+
+  it('keeps unconfigured Web search visible and opens its settings', async () => {
+    const user = userEvent.setup();
+    renderGateway();
+
+    const webSearch = await screen.findByRole('button', {
+      name: 'Web search',
+    });
+    expect(within(webSearch).getByText('Not connected')).toBeInTheDocument();
+
+    await user.click(webSearch);
+
+    expect(
+      await screen.findByRole('heading', { name: 'Querit authentication' })
+    ).toBeInTheDocument();
+  });
+
+  it('keeps managed-model Web search connected by default', async () => {
+    mocks.modelType = 'cloud';
+    renderGateway();
+
+    const webSearch = await screen.findByRole('button', {
+      name: 'Web search',
+    });
+    expect(within(webSearch).getByText('Connected')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

# Pull Request

## Related Issue

Related to #1378

## Description

### Problem

For users whose default model is `custom`, Web search is considered disconnected until Querit is enabled or Google Search credentials are configured. The Connectors overview filtered out every disconnected built-in connector, so Web search disappeared entirely for those users. Because the Web search row is also the entry point to its settings panel, affected users had no way to configure it from this surface.

### Changes

- Keep the built-in Web search row visible even when it is not configured.
- Show its real state as `Not connected` for unconfigured custom-model users and preserve the existing `Connected` state for managed models.
- Keep the existing filtering behavior for all other disconnected built-in connectors.
- Add regression coverage for the custom-model and managed-model states, including opening the Web search settings panel from the disconnected row.

## Testing Evidence (REQUIRED)

Automated validation completed locally:

- `npm exec vitest -- run test/unit/components/ConnectorGateway.test.tsx` — 2 tests passed.
- `npm exec vitest -- run test/unit/components/SearchSettingsPanel.test.tsx test/unit/lib/searchConfig.test.ts` — 5 tests passed.
- `npm run type-check` — passed.
- Focused ESLint and Prettier checks — passed.
- `npm run check:design-tokens` — passed.
- `git diff --check` — passed.

Manual UI evidence: pending. A screenshot or screen recording showing Web search as `Not connected` for an unconfigured custom model still needs to be attached.

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [ ] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
