### PR TITLE
fix: quit Eigent safely when its window closes

### DIFF
--- a/electron/main/closeCoordinator.ts
+++ b/electron/main/closeCoordinator.ts
@@ -64,6 +64,7 @@ export class CloseCoordinator {
   private readonly diagnostic: (message: string) => void;
   private responseTimer: unknown = null;
   private window: CoordinatedWindow | null = null;
+  private webContents: CoordinatedWindow['webContents'] | null = null;
   private pendingIntent: CloseIntent | null = null;
   private pendingAcknowledged = false;
   private nextIntent: CloseIntent | null = null;
@@ -169,17 +170,26 @@ export class CloseCoordinator {
     this.markRendererUnavailable('destroyed');
   };
 
-  private unbindHealthListeners(window: CoordinatedWindow): void {
-    window.off('unresponsive', this.handleRendererUnresponsive);
-    window.off('responsive', this.handleRendererResponsive);
-    window.webContents.off('did-start-loading', this.handleRendererLoading);
-    window.webContents.off('render-process-gone', this.handleRendererGone);
-    window.webContents.off('destroyed', this.handleRendererDestroyed);
+  private unbindHealthListeners(
+    window: CoordinatedWindow,
+    webContents: CoordinatedWindow['webContents']
+  ): void {
+    if (!window.isDestroyed()) {
+      window.off('unresponsive', this.handleRendererUnresponsive);
+      window.off('responsive', this.handleRendererResponsive);
+    }
+
+    if (webContents.isDestroyed()) return;
+    webContents.off('did-start-loading', this.handleRendererLoading);
+    webContents.off('render-process-gone', this.handleRendererGone);
+    webContents.off('destroyed', this.handleRendererDestroyed);
   }
 
   bindWindow(window: CoordinatedWindow): void {
     this.unbindWindow();
+    const webContents = window.webContents;
     this.window = window;
+    this.webContents = webContents;
     this.clearResponseTimer();
     this.pendingIntent = null;
     this.pendingAcknowledged = false;
@@ -192,17 +202,25 @@ export class CloseCoordinator {
     window.on('close', this.handleWindowClose);
     window.on('unresponsive', this.handleRendererUnresponsive);
     window.on('responsive', this.handleRendererResponsive);
-    window.webContents.on('did-start-loading', this.handleRendererLoading);
-    window.webContents.on('render-process-gone', this.handleRendererGone);
-    window.webContents.on('destroyed', this.handleRendererDestroyed);
+    webContents.on('did-start-loading', this.handleRendererLoading);
+    webContents.on('render-process-gone', this.handleRendererGone);
+    webContents.on('destroyed', this.handleRendererDestroyed);
   }
 
   unbindWindow(): void {
-    if (this.window) {
-      this.window.off('close', this.handleWindowClose);
-      this.unbindHealthListeners(this.window);
-    }
+    const window = this.window;
+    const webContents = this.webContents;
+    // Clear the reference before touching Electron objects so a destruction
+    // event or a repeated cleanup cannot try to unbind the same window again.
     this.window = null;
+    this.webContents = null;
+
+    if (window && webContents) {
+      if (!window.isDestroyed()) {
+        window.off('close', this.handleWindowClose);
+      }
+      this.unbindHealthListeners(window, webContents);
+    }
     this.clearResponseTimer();
     this.pendingIntent = null;
     this.pendingAcknowledged = false;

--- a/electron/main/commands/applicationMenu.ts
+++ b/electron/main/commands/applicationMenu.ts
@@ -36,8 +36,6 @@ export interface ApplicationMenuOptions {
   onOpenExternalError?: (error: unknown) => void;
   openExternal: (url: string) => Promise<void>;
   platform: DesktopMenuPlatform;
-  /** Guarded close request; must not force-close the BrowserWindow. */
-  requestClose: () => void;
   /** Guarded application quit request; intentionally not Electron's quit role. */
   requestQuit: () => void;
 }
@@ -434,13 +432,7 @@ function buildMacAppMenu(
 function buildFileMenu(
   options: ApplicationMenuOptions
 ): Electron.MenuItemConstructorOptions {
-  const {
-    dispatchRendererCommand,
-    messages,
-    platform,
-    requestClose,
-    requestQuit,
-  } = options;
+  const { dispatchRendererCommand, messages, platform, requestQuit } = options;
   const submenu: Electron.MenuItemConstructorOptions[] = [
     terminalSafe(platform, 'N', {
       id: 'file.new-project',
@@ -465,9 +457,9 @@ function buildFileMenu(
       id: 'file.close-window',
       label: messages.closeWindow,
       accelerator: platformAccelerator(platform, 'Command+W', 'Control+W'),
-      // Closing the only window exits Eigent on Windows/Linux and tears down
-      // the local Brain, so it must use quit intent/copy on those platforms.
-      click: platform === 'darwin' ? requestClose : requestQuit,
+      // Eigent owns a single application window. Closing it must tear down
+      // the local Brain and exit the app on every platform.
+      click: requestQuit,
     })
   );
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -181,7 +181,9 @@ const rendererAppCommands = new RendererAppCommandCoordinator({
   diagnostic: (message) => log.warn(message),
 });
 const closeCoordinator = new CloseCoordinator({
-  defaultIntent: process.platform === 'darwin' ? 'close-window' : 'quit-app',
+  // Eigent owns a single application window. Closing it exits the app on
+  // every platform so shutdown cleanup also stops the local backend.
+  defaultIntent: 'quit-app',
   quit: () => app.quit(),
   shouldGuard: () => rendererAppCommands.isReady(),
   diagnostic: (message) => log.info(message),
@@ -249,7 +251,6 @@ function installNativeApplicationMenu(): void {
     },
     openExternal: (url) => shell.openExternal(url),
     platform,
-    requestClose: () => closeCoordinator.request('close-window'),
     requestQuit: () => closeCoordinator.request('quit-app'),
   });
 }
@@ -1919,18 +1920,9 @@ function registerIpcHandlers() {
   });
 
   // ==================== window control handler ====================
-  ipcMain.on('window-close', (event, data: unknown) => {
+  ipcMain.on('window-close', (event) => {
     if (!isMainRendererSender(event.sender.id, win?.webContents.id)) return;
-    const isForceQuit =
-      Boolean(data) &&
-      typeof data === 'object' &&
-      (data as { isForceQuit?: unknown }).isForceQuit === true;
-    if (isForceQuit) {
-      return closeCoordinator.request('quit-app');
-    }
-    return closeCoordinator.request(
-      process.platform === 'darwin' ? 'close-window' : 'quit-app'
-    );
+    return closeCoordinator.request('quit-app');
   });
   ipcMain.on(WINDOW_CLOSE_RESPONSE_CHANNEL, (event, response: unknown) => {
     if (!isMainRendererSender(event.sender.id, win?.webContents.id)) return;
@@ -4011,9 +4003,7 @@ app.on('window-all-closed', () => {
   appShellReadinessGate.markDocumentLoading();
   protocolUrlQueue = [];
 
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
+  app.quit();
 });
 
 // ==================== app activate event ====================

--- a/test/unit/electron/applicationMenu.test.ts
+++ b/test/unit/electron/applicationMenu.test.ts
@@ -64,7 +64,6 @@ function click(item: MenuItem): void {
 function createOptions(platform: DesktopMenuPlatform, isDevelopment = false) {
   const dispatchRendererCommand = vi.fn();
   const openExternal = vi.fn().mockResolvedValue(undefined);
-  const requestClose = vi.fn();
   const requestQuit = vi.fn();
   const onOpenExternalError = vi.fn();
   const options: ApplicationMenuOptions = {
@@ -75,7 +74,6 @@ function createOptions(platform: DesktopMenuPlatform, isDevelopment = false) {
     onOpenExternalError,
     openExternal,
     platform,
-    requestClose,
     requestQuit,
   };
   return {
@@ -83,7 +81,6 @@ function createOptions(platform: DesktopMenuPlatform, isDevelopment = false) {
     onOpenExternalError,
     openExternal,
     options,
-    requestClose,
     requestQuit,
   };
 }
@@ -154,8 +151,7 @@ describe('application menu', () => {
     expect(findItem(template, 'help.keyboard-shortcuts').accelerator).toBe(
       'Command+/'
     );
-    expect(harness.requestClose).toHaveBeenCalledOnce();
-    expect(harness.requestQuit).toHaveBeenCalledOnce();
+    expect(harness.requestQuit).toHaveBeenCalledTimes(2);
     expect(harness.openExternal).toHaveBeenCalledWith(
       EIGENT_GITHUB_REPOSITORY_URL
     );
@@ -216,7 +212,6 @@ describe('application menu', () => {
 
       click(findItem(template, 'file.close-window'));
 
-      expect(harness.requestClose).not.toHaveBeenCalled();
       expect(harness.requestQuit).toHaveBeenCalledOnce();
 
       click(findItem(template, 'file.exit'));

--- a/test/unit/electron/main/closeCoordinator.test.ts
+++ b/test/unit/electron/main/closeCoordinator.test.ts
@@ -16,7 +16,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { CloseCoordinator } from '../../../../electron/main/closeCoordinator';
 import { isWindowCloseResponse } from '../../../../src/shared/windowClose';
 
-function createWindow(webContentsDestroyed = false) {
+function createWindow(initialWebContentsDestroyed = false) {
+  let windowDestroyed = false;
+  let webContentsDestroyed = initialWebContentsDestroyed;
+  let webContentsUnavailable = false;
   const windowListeners = new Map<string, Set<(...args: any[]) => void>>();
   const webContentsListeners = new Map<string, Set<(...args: any[]) => void>>();
   const addListener = (
@@ -45,9 +48,24 @@ function createWindow(webContentsDestroyed = false) {
     closeEvents.push(event);
     emit(windowListeners, 'close', event);
   });
+  const webContents = {
+    isDestroyed: () => webContentsDestroyed,
+    send,
+    on: vi.fn((event: string, listener: (...args: any[]) => void) => {
+      addListener(webContentsListeners, event, listener);
+      return webContents;
+    }),
+    off: vi.fn((event: string, listener: (...args: any[]) => void) => {
+      if (webContentsDestroyed) {
+        throw new TypeError('Object has been destroyed');
+      }
+      removeListener(webContentsListeners, event, listener);
+      return webContents;
+    }),
+  };
   const window = {
     close,
-    isDestroyed: () => false,
+    isDestroyed: () => windowDestroyed,
     on: vi.fn((event: string, listener: (...args: any[]) => void) => {
       addListener(windowListeners, event, listener);
       return window;
@@ -56,27 +74,31 @@ function createWindow(webContentsDestroyed = false) {
       removeListener(windowListeners, event, listener);
       return window;
     }),
-    webContents: {
-      isDestroyed: () => webContentsDestroyed,
-      send,
-      on: vi.fn((event: string, listener: (...args: any[]) => void) => {
-        addListener(webContentsListeners, event, listener);
-        return window.webContents;
-      }),
-      off: vi.fn((event: string, listener: (...args: any[]) => void) => {
-        removeListener(webContentsListeners, event, listener);
-        return window.webContents;
-      }),
+    get webContents() {
+      if (webContentsUnavailable) {
+        throw new TypeError('Object has been destroyed');
+      }
+      return webContents;
     },
   };
   return {
     window,
+    webContents,
     close,
     closeEvents,
     emitWindow: (event: string, ...args: any[]) =>
       emit(windowListeners, event, ...args),
     emitWebContents: (event: string, ...args: any[]) =>
       emit(webContentsListeners, event, ...args),
+    markWindowDestroyed: () => {
+      windowDestroyed = true;
+      webContentsDestroyed = true;
+      webContentsUnavailable = true;
+    },
+    markWebContentsDestroyed: () => {
+      webContentsDestroyed = true;
+      webContentsUnavailable = true;
+    },
     send,
   };
 }
@@ -226,6 +248,37 @@ describe('CloseCoordinator', () => {
       'unresponsive',
       expect.any(Function)
     );
+  });
+
+  it('does not remove listeners from destroyed web contents when unbinding', () => {
+    const fixture = createWindow();
+    const coordinator = new CloseCoordinator({
+      defaultIntent: 'close-window',
+      quit: vi.fn(),
+    });
+    coordinator.bindWindow(fixture.window as never);
+    fixture.markWebContentsDestroyed();
+
+    expect(() => coordinator.unbindWindow()).not.toThrow();
+    expect(fixture.window.off).toHaveBeenCalledWith(
+      'close',
+      expect.any(Function)
+    );
+    expect(fixture.webContents.off).not.toHaveBeenCalled();
+  });
+
+  it('does not remove listeners from a destroyed window when unbinding', () => {
+    const fixture = createWindow();
+    const coordinator = new CloseCoordinator({
+      defaultIntent: 'close-window',
+      quit: vi.fn(),
+    });
+    coordinator.bindWindow(fixture.window as never);
+    fixture.markWindowDestroyed();
+
+    expect(() => coordinator.unbindWindow()).not.toThrow();
+    expect(fixture.window.off).not.toHaveBeenCalled();
+    expect(fixture.webContents.off).not.toHaveBeenCalled();
   });
 
   it('lets trusted updater or restart quits bypass the renderer guard', () => {

--- a/test/unit/electron/main/closeCoordinator.test.ts
+++ b/test/unit/electron/main/closeCoordinator.test.ts
@@ -104,11 +104,11 @@ function createWindow(initialWebContentsDestroyed = false) {
 }
 
 describe('CloseCoordinator', () => {
-  it('routes a native macOS window close through a close-window request', () => {
+  it('routes a native window close through the single-window app quit', () => {
     const quit = vi.fn();
     const fixture = createWindow();
     const coordinator = new CloseCoordinator({
-      defaultIntent: 'close-window',
+      defaultIntent: 'quit-app',
       quit,
     });
     coordinator.bindWindow(fixture.window as never);
@@ -116,18 +116,18 @@ describe('CloseCoordinator', () => {
     fixture.close();
 
     expect(fixture.send).toHaveBeenCalledWith('before-close', {
-      intent: 'close-window',
+      intent: 'quit-app',
     });
-    expect(coordinator.getPendingIntent()).toBe('close-window');
+    expect(coordinator.getPendingIntent()).toBe('quit-app');
 
     expect(
       coordinator.respond({
-        intent: 'close-window',
+        intent: 'quit-app',
         action: 'confirm',
       })
     ).toBe(true);
-    expect(fixture.close).toHaveBeenCalledTimes(2);
-    expect(quit).not.toHaveBeenCalled();
+    expect(fixture.close).toHaveBeenCalledOnce();
+    expect(quit).toHaveBeenCalledOnce();
   });
 
   it('routes an explicit quit through the same guard and quits after confirm', () => {

--- a/test/unit/electron/main/index.test.ts
+++ b/test/unit/electron/main/index.test.ts
@@ -887,21 +887,12 @@ describe('Electron Main Index Functions', () => {
       expect(mockApp.whenReady).toBeDefined();
     });
 
-    it('should handle window-all-closed event', () => {
-      const originalPlatform = process.platform;
+    it('should quit when all windows are closed', () => {
+      const windowAllClosedHandler = () => mockApp.quit();
 
-      // Test non-darwin platform
-      Object.defineProperty(process, 'platform', { value: 'win32' });
-      const shouldQuit = process.platform !== 'darwin';
-      expect(shouldQuit).toBe(true);
+      windowAllClosedHandler();
 
-      // Test darwin platform
-      Object.defineProperty(process, 'platform', { value: 'darwin' });
-      const shouldNotQuit = process.platform !== 'darwin';
-      expect(shouldNotQuit).toBe(false);
-
-      // Restore original platform
-      Object.defineProperty(process, 'platform', { value: originalPlatform });
+      expect(mockApp.quit).toHaveBeenCalled();
     });
 
     it('should handle app activate event', () => {
@@ -1397,45 +1388,29 @@ describe('Electron Main Index Functions', () => {
   });
 
   describe('Application Lifecycle', () => {
-    it('should quit on window-all-closed for non-darwin platforms', () => {
-      const originalPlatform = process.platform;
-      Object.defineProperty(process, 'platform', { value: 'win32' });
+    it.each(['darwin', 'win32', 'linux'] as const)(
+      'should quit on window-all-closed for %s',
+      (platform) => {
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', { value: platform });
 
-      mockApp.on.mockImplementation((event, listener) => {
-        if (event === 'window-all-closed') {
-          listener();
-        }
-      });
+        mockApp.on.mockImplementation((event, listener) => {
+          if (event === 'window-all-closed') {
+            listener();
+          }
+        });
 
-      // This is a simplified representation of the app.on('window-all-closed') logic
-      const windowAllClosedHandler = () => {
-        if (process.platform !== 'darwin') {
-          mockApp.quit();
-        }
-      };
+        // This mirrors the single-window app policy in the real handler.
+        const windowAllClosedHandler = () => mockApp.quit();
 
-      windowAllClosedHandler();
-      expect(mockApp.quit).toHaveBeenCalled();
+        windowAllClosedHandler();
+        expect(mockApp.quit).toHaveBeenCalled();
 
-      Object.defineProperty(process, 'platform', { value: originalPlatform });
-    });
-
-    it('should not quit on window-all-closed for darwin platforms', () => {
-      const originalPlatform = process.platform;
-      Object.defineProperty(process, 'platform', { value: 'darwin' });
-      vi.clearAllMocks(); // Clear mocks from previous test
-
-      const windowAllClosedHandler = () => {
-        if (process.platform !== 'darwin') {
-          mockApp.quit();
-        }
-      };
-
-      windowAllClosedHandler();
-      expect(mockApp.quit).not.toHaveBeenCalled();
-
-      Object.defineProperty(process, 'platform', { value: originalPlatform });
-    });
+        Object.defineProperty(process, 'platform', {
+          value: originalPlatform,
+        });
+      }
+    );
 
     it('should call cleanup on before-quit', () => {
       const mockCleanup = vi.fn();

--- a/test/unit/shared/shortcutCatalogParity.test.ts
+++ b/test/unit/shared/shortcutCatalogParity.test.ts
@@ -80,7 +80,6 @@ function buildTemplate(platform: DesktopShortcutPlatform) {
     messages: getNativeMenuMessages('en-US'),
     openExternal: vi.fn().mockResolvedValue(undefined),
     platform,
-    requestClose: vi.fn(),
     requestQuit: vi.fn(),
   });
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

# Pull Request

## Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

<!-- Example: Closes #123 or Fixes #456 -->

Closes #

## Description

Fix Eigent's shutdown lifecycle so closing its only window exits the application cleanly on every platform.

- Route the native window close, application window-close IPC, and **Close Window** menu command through the guarded `quit-app` flow.
- Quit when `window-all-closed` fires on macOS as well as Windows and Linux, ensuring `before-quit` cleans up the local backend and allows `npm run dev` to terminate.
- Retain the bound `webContents` reference instead of reading it from an already-destroyed `BrowserWindow` during shutdown.
- Skip listener removal for destroyed `BrowserWindow` and `webContents` objects and clear coordinator references before teardown.
- Add regression coverage for the single-window quit policy and destroyed-object lifecycle cases.

## Testing Evidence (REQUIRED)

<!-- REQUIRED: Every PR must include human-verified testing proof (e.g., test logs, screenshots, or screen recordings). -->

<!-- REQUIRED for frontend/UI changes: You MUST attach at least one screenshot or screen recording in this PR. -->

<!-- Frontend/UI PRs without visual evidence will not be reviewed. -->

- `./node_modules/.bin/vitest run test/unit/electron/main/closeCoordinator.test.ts test/unit/electron/applicationMenu.test.ts test/unit/shared/shortcutCatalogParity.test.ts test/unit/electron/main/index.test.ts` — 134 tests passed.
- `npm run type-check` — passed.
- Focused ESLint on all six changed TypeScript files — passed.
- `git diff --check` — passed.

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [x] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [ ] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)