### PR TITLE
fix: restrict ~/.eigent env files to owner-only (0600)

### DIFF
--- a/backend/app/component/environment.py
+++ b/backend/app/component/environment.py
@@ -40,6 +40,29 @@ env_base_dir = os.path.join(os.path.expanduser("~"), ".eigent")
 default_env_path = os.path.join(env_base_dir, ".env")
 
 
+def _restrict_env_file_permissions(path: str | os.PathLike[str]) -> None:
+    """Restrict a user env file to owner read/write (0600) on POSIX.
+
+    Best-effort: permission errors must not prevent loading credentials.
+    Only files under env_base_dir are changed.
+    """
+    if os.name != "posix":
+        return
+    try:
+        resolved = Path(path).expanduser().resolve()
+        resolved.relative_to(Path(env_base_dir).resolve())
+    except (ValueError, OSError):
+        return
+    try:
+        os.chmod(resolved, 0o600)
+    except OSError as exc:
+        logger.warning(
+            "Failed to restrict permissions on env file %s: %s",
+            resolved,
+            exc,
+        )
+
+
 def _resolve_initial_env_paths() -> tuple[Path, ...]:
     backend_dir = Path(__file__).resolve().parents[2]
     repo_root = backend_dir.parent
@@ -75,6 +98,7 @@ def _load_initial_env_files(paths: Iterable[Path]) -> list[Path]:
         seen.add(resolved_key)
         if not resolved.exists():
             continue
+        _restrict_env_file_permissions(resolved)
         load_dotenv(dotenv_path=resolved, override=True)
         loaded_paths.append(resolved)
 
@@ -190,6 +214,7 @@ def set_user_env_path(env_path: str | None = None):
     )
 
     if safe_env_path and os.path.exists(safe_env_path):
+        _restrict_env_file_permissions(safe_env_path)
         _thread_local.env_path = safe_env_path
         # Load user-specific environment variables
         load_dotenv(dotenv_path=safe_env_path, override=True)
@@ -199,6 +224,9 @@ def set_user_env_path(env_path: str | None = None):
         if hasattr(_thread_local, "env_path"):
             delattr(_thread_local, "env_path")
         logger.info("Reset to default global environment")
+
+        if os.path.exists(default_env_path):
+            _restrict_env_file_permissions(default_env_path)
 
         if env_path and not safe_env_path:
             logger.warning(

--- a/backend/tests/app/component/test_environment.py
+++ b/backend/tests/app/component/test_environment.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
 import os
+import stat
 import tempfile
 from pathlib import Path
 
@@ -24,6 +25,7 @@ from app.component.environment import (
     env,
     env_base_dir,
     sanitize_env_path,
+    set_user_env_path,
 )
 
 
@@ -264,3 +266,107 @@ def test_env_process_value_overrides_live_dotenv(monkeypatch, temp_dir: Path):
     )
 
     assert env("PROCESS_PRIORITY_KEY") == "from_process"
+
+
+def _clear_thread_env_path() -> None:
+    if hasattr(environment._thread_local, "env_path"):
+        delattr(environment._thread_local, "env_path")
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
+def test_load_initial_env_files_restricts_user_home_env_permissions(
+    monkeypatch, temp_dir: Path
+):
+    """~/.eigent/.env is loaded at startup and must not stay world-readable."""
+    monkeypatch.setattr(environment, "env_base_dir", str(temp_dir))
+    env_file = temp_dir / ".env"
+    env_file.write_text("EIGENT_PERM_INIT_KEY=secret\n")
+    os.chmod(env_file, 0o644)
+
+    try:
+        _load_initial_env_files((env_file,))
+        mode = stat.S_IMODE(env_file.stat().st_mode)
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+    finally:
+        monkeypatch.delenv("EIGENT_PERM_INIT_KEY", raising=False)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
+def test_load_initial_env_files_does_not_chmod_repo_env_files(
+    monkeypatch, temp_dir: Path
+):
+    """Repo-local .env files are not user secret stores; leave their mode."""
+    env_file = temp_dir / ".env"
+    env_file.write_text("EIGENT_PERM_REPO_KEY=secret\n")
+    os.chmod(env_file, 0o644)
+
+    try:
+        _load_initial_env_files((env_file,))
+        mode = stat.S_IMODE(env_file.stat().st_mode)
+        assert mode == 0o644, f"expected 0644, got {oct(mode)}"
+    finally:
+        monkeypatch.delenv("EIGENT_PERM_REPO_KEY", raising=False)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
+def test_set_user_env_path_restricts_existing_env_file_permissions(
+    monkeypatch, temp_dir: Path
+):
+    """User .env files must be owner-only (0600), not default umask 0644."""
+    monkeypatch.setattr(environment, "env_base_dir", str(temp_dir))
+    env_file = temp_dir / "user.env"
+    env_file.write_text("EIGENT_PERM_TEST_KEY=secret\n")
+    os.chmod(env_file, 0o644)
+
+    try:
+        set_user_env_path(str(env_file))
+        mode = stat.S_IMODE(env_file.stat().st_mode)
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+    finally:
+        _clear_thread_env_path()
+        monkeypatch.delenv("EIGENT_PERM_TEST_KEY", raising=False)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
+def test_set_user_env_path_restricts_default_env_when_resetting(
+    monkeypatch, temp_dir: Path
+):
+    """Falling back to the global ~/.eigent/.env should still tighten it."""
+    default_env = temp_dir / ".env"
+    default_env.write_text("EIGENT_PERM_DEFAULT_KEY=secret\n")
+    os.chmod(default_env, 0o644)
+    monkeypatch.setattr(environment, "env_base_dir", str(temp_dir))
+    monkeypatch.setattr(environment, "default_env_path", str(default_env))
+
+    try:
+        set_user_env_path(None)
+        mode = stat.S_IMODE(default_env.stat().st_mode)
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+    finally:
+        _clear_thread_env_path()
+        monkeypatch.delenv("EIGENT_PERM_DEFAULT_KEY", raising=False)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
+def test_set_user_env_path_still_loads_if_chmod_fails(
+    monkeypatch, temp_dir: Path
+):
+    """Permission hardening is best-effort and must not block loading."""
+    monkeypatch.setattr(environment, "env_base_dir", str(temp_dir))
+    env_file = temp_dir / "user.env"
+    env_file.write_text("EIGENT_PERM_FAIL_KEY=secret\n")
+    os.chmod(env_file, 0o644)
+
+    def _boom(_path, _mode):
+        raise OSError("operation not permitted")
+
+    monkeypatch.setattr(os, "chmod", _boom)
+
+    try:
+        set_user_env_path(str(env_file))
+        assert Path(environment.get_current_env_path()).resolve() == (
+            env_file.resolve()
+        )
+    finally:
+        _clear_thread_env_path()
+        monkeypatch.delenv("EIGENT_PERM_FAIL_KEY", raising=False)

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -115,6 +115,7 @@ import {
   readGlobalEnvKey,
   removeEnvKey,
   updateEnvBlock,
+  writeEnvFile,
 } from './utils/envUtil';
 import { createDiagnosticsZip, zipDirectories, zipFolder } from './utils/log';
 import { addMcp, readMcpConfig, removeMcp, updateMcp } from './utils/mcpConfig';
@@ -2429,7 +2430,7 @@ function registerIpcHandlers() {
     }
     let lines = content.split(/\r?\n/);
     lines = updateEnvBlock(lines, { [key]: value });
-    fs.writeFileSync(ENV_PATH, lines.join('\n'), 'utf-8');
+    writeEnvFile(ENV_PATH, lines.join('\n'));
 
     // Also write to global .env file for backend process to read
     const GLOBAL_ENV_PATH = path.join(os.homedir(), '.eigent', '.env');
@@ -2444,7 +2445,7 @@ function registerIpcHandlers() {
     let globalLines = globalContent.split(/\r?\n/);
     globalLines = updateEnvBlock(globalLines, { [key]: value });
     try {
-      fs.writeFileSync(GLOBAL_ENV_PATH, globalLines.join('\n'), 'utf-8');
+      writeEnvFile(GLOBAL_ENV_PATH, globalLines.join('\n'));
       log.info(`env-write: wrote ${key} to both user and global .env files`);
     } catch (error) {
       log.error('global env-write error:', error);
@@ -2466,7 +2467,7 @@ function registerIpcHandlers() {
     }
     let lines = content.split(/\r?\n/);
     lines = removeEnvKey(lines, key);
-    fs.writeFileSync(ENV_PATH, lines.join('\n'), 'utf-8');
+    writeEnvFile(ENV_PATH, lines.join('\n'));
     log.info('env-remove success', ENV_PATH);
 
     // Also remove from global .env file
@@ -2477,7 +2478,7 @@ function registerIpcHandlers() {
         : '';
       let globalLines = globalContent.split(/\r?\n/);
       globalLines = removeEnvKey(globalLines, key);
-      fs.writeFileSync(GLOBAL_ENV_PATH, globalLines.join('\n'), 'utf-8');
+      writeEnvFile(GLOBAL_ENV_PATH, globalLines.join('\n'));
       log.info(
         `env-remove: removed ${key} from both user and global .env files`
       );

--- a/electron/main/utils/envUtil.ts
+++ b/electron/main/utils/envUtil.ts
@@ -19,6 +19,20 @@ import path from 'path';
 export const ENV_START = '# === MCP INTEGRATION ENV START ===';
 export const ENV_END = '# === MCP INTEGRATION ENV END ===';
 
+export function restrictEnvFilePermissions(envPath: string) {
+  try {
+    fs.chmodSync(envPath, 0o600);
+  } catch {
+    // best-effort on platforms without POSIX perms
+  }
+}
+
+export function writeEnvFile(envPath: string, content: string) {
+  fs.writeFileSync(envPath, content, { encoding: 'utf-8', mode: 0o600 });
+  // writeFileSync's mode only applies on create; enforce on existing files too.
+  restrictEnvFilePermissions(envPath);
+}
+
 export function getEnvPath(email: string) {
   const tempEmail = email
     .split('@')[0]
@@ -35,7 +49,9 @@ export function getEnvPath(email: string) {
   const defaultEnv = path.join(process.resourcesPath, 'backend', '.env');
   if (!fs.existsSync(envPath) && fs.existsSync(defaultEnv)) {
     fs.copyFileSync(defaultEnv, envPath);
-    fs.chmodSync(envPath, 0o600);
+  }
+  if (fs.existsSync(envPath)) {
+    restrictEnvFilePermissions(envPath);
   }
 
   return envPath;

--- a/test/unit/electron/main/envUtil.test.ts
+++ b/test/unit/electron/main/envUtil.test.ts
@@ -1,0 +1,74 @@
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getEnvPath,
+  writeEnvFile,
+} from '../../../../electron/main/utils/envUtil';
+
+describe('envUtil file permissions', () => {
+  let homeDir: string;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eigent-env-perm-'));
+    vi.spyOn(os, 'homedir').mockReturnValue(homeDir);
+    Object.defineProperty(process, 'resourcesPath', {
+      value: path.join(homeDir, 'resources'),
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it('restricts an existing user env file to 0600', () => {
+    const eigentDir = path.join(homeDir, '.eigent');
+    fs.mkdirSync(eigentDir, { recursive: true });
+    const envPath = path.join(eigentDir, '.env.user');
+    fs.writeFileSync(envPath, 'API_KEY=secret\n');
+    fs.chmodSync(envPath, 0o644);
+
+    const resolved = getEnvPath('user@example.com');
+
+    expect(resolved).toBe(envPath);
+    expect(fs.statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('writes env files with 0600 even when umask would leave them world-readable', () => {
+    const envPath = path.join(homeDir, '.env');
+    fs.writeFileSync(envPath, 'OLD=1\n');
+    fs.chmodSync(envPath, 0o644);
+
+    writeEnvFile(envPath, 'API_KEY=secret\n');
+
+    expect(fs.readFileSync(envPath, 'utf-8')).toBe('API_KEY=secret\n');
+    expect(fs.statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('creates a missing env file with 0600', () => {
+    const envPath = path.join(homeDir, '.env');
+
+    writeEnvFile(envPath, 'API_KEY=secret\n');
+
+    expect(fs.existsSync(envPath)).toBe(true);
+    expect(fs.statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+});


### PR DESCRIPTION
## Summary
Credential-bearing `.env` files under `~/.eigent` were left at the process umask (often `0644`) after Electron `writeFileSync` updates. `getEnvPath` only applied `chmod 0600` on the copy-from-default create path, so later writes stayed world-readable.

Harden create and load paths on POSIX so secrets stay owner-readable:
- Backend: restrict permissions when loading `~/.eigent` env files / resetting to the default path
- Electron: `writeEnvFile` writes with mode `0600` and re-chmods existing files; `getEnvPath` tightens existing user env files

Fixes #1670

## Test plan
- [x] Backend pytest: existing `0644` `~/.eigent` env files become `0600` on load/reset; repo-local `.env` left alone; chmod failure does not block load
- [x] Electron vitest: `getEnvPath` / `writeEnvFile` enforce `0600` on create and update