### PR TITLE
fix: address Skills and Connectors redesign review findings

### DIFF
--- a/backend/app/controller/skill_controller.py
+++ b/backend/app/controller/skill_controller.py
@@ -16,6 +16,7 @@ import logging
 from typing import Annotated
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
+from fastapi.responses import FileResponse
 
 from app.service.skill_config_service import (
     skill_config_delete,
@@ -26,6 +27,7 @@ from app.service.skill_config_service import (
 )
 from app.service.skill_service import (
     skill_delete,
+    skill_file_path,
     skill_get_path_by_name,
     skill_import_zip,
     skill_list_files,
@@ -215,7 +217,7 @@ def skill_remove(skill_dir_name: str) -> dict:
 
 @router.get("/skills/{skill_dir_name}/files")
 def skill_files(skill_dir_name: str) -> dict:
-    """List files in skill directory."""
+    """List regular files in a skill package recursively."""
     try:
         files = skill_list_files(skill_dir_name)
         return {"success": True, "files": files}
@@ -223,3 +225,21 @@ def skill_files(skill_dir_name: str) -> dict:
         raise HTTPException(status_code=400, detail=str(e))
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Skill not found")
+
+
+@router.get("/skills/{skill_dir_name}/file")
+def skill_file(
+    skill_dir_name: str,
+    path: str = Query(..., description="Relative path inside the skill"),
+) -> FileResponse:
+    """Stream one regular file contained by a skill package."""
+    try:
+        return FileResponse(skill_file_path(skill_dir_name, path))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Skill file not found")

--- a/backend/app/service/skill_service.py
+++ b/backend/app/service/skill_service.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
 import logging
+import mimetypes
 import os
 import re
 import shutil
@@ -24,6 +25,13 @@ SKILLS_ROOT = Path.home() / ".eigent" / "skills"
 SKILL_FILE = "SKILL.md"
 EXAMPLE_SKILLS_ENV = "EIGENT_EXAMPLE_SKILLS_DIR"
 EXAMPLE_SKILL_MARKER = ".eigent-example-skill"
+MAX_SKILL_PACKAGE_FILES = 1000
+SKILL_PACKAGE_MIME_FALLBACKS = {
+    ".md": "text/markdown",
+    ".py": "text/x-python",
+    ".yaml": "text/yaml",
+    ".yml": "text/yaml",
+}
 logger = logging.getLogger("skill_service")
 
 
@@ -343,15 +351,86 @@ def skill_delete(skill_dir_name: str) -> None:
         shutil.rmtree(dir_path)
 
 
-def skill_list_files(skill_dir_name: str) -> list[str]:
-    """List files in skill directory."""
+def _skill_package_root(skill_dir_name: str) -> Path:
     name = (skill_dir_name or "").strip()
-    if not name:
-        raise ValueError("Skill folder name is required")
+    normalized_name = name.replace("\\", "/")
+    if (
+        not normalized_name
+        or normalized_name in {".", ".."}
+        or "/" in normalized_name
+    ):
+        raise ValueError("A single skill folder name is required")
     dir_path = _assert_under_skills_root(SKILLS_ROOT / name)
-    if not dir_path.exists():
-        return []
-    return [e.name for e in dir_path.iterdir()]
+    if not dir_path.exists() or not dir_path.is_dir():
+        raise FileNotFoundError(f"Skill not found: {name}")
+    return dir_path
+
+
+def skill_file_path(skill_dir_name: str, relative_path: str) -> Path:
+    """Resolve one regular package file without leaving its skill directory."""
+    root = _skill_package_root(skill_dir_name)
+    normalized = (relative_path or "").replace("\\", "/")
+    parts = normalized.split("/")
+    if (
+        not normalized
+        or "\x00" in normalized
+        or normalized.startswith("/")
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
+        raise ValueError("A safe relative skill file path is required")
+
+    candidate = root.joinpath(*parts)
+    current = root
+    for part in parts:
+        current /= part
+        if current.is_symlink():
+            raise PermissionError("Symlinked skill files are not readable")
+
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except FileNotFoundError:
+        raise
+    except (OSError, ValueError):
+        raise PermissionError("Path is outside skill directory")
+    if not resolved.is_file():
+        raise FileNotFoundError(f"Skill file not found: {relative_path}")
+    return resolved
+
+
+def skill_list_files(skill_dir_name: str) -> list[dict]:
+    """Recursively list regular files in a skill package."""
+    root = _skill_package_root(skill_dir_name)
+    files: list[dict] = []
+    for current_dir, dir_names, file_names in os.walk(root, followlinks=False):
+        current = Path(current_dir)
+        dir_names[:] = sorted(
+            name for name in dir_names if not (current / name).is_symlink()
+        )
+        for file_name in sorted(file_names):
+            path = current / file_name
+            if file_name == EXAMPLE_SKILL_MARKER or path.is_symlink():
+                continue
+            relative_path = path.relative_to(root).as_posix()
+            try:
+                resolved = skill_file_path(skill_dir_name, relative_path)
+                stat = resolved.stat()
+            except (FileNotFoundError, OSError, PermissionError, ValueError):
+                continue
+            mime_type, _ = mimetypes.guess_type(relative_path)
+            mime_type = mime_type or SKILL_PACKAGE_MIME_FALLBACKS.get(
+                path.suffix.lower()
+            )
+            files.append(
+                {
+                    "path": relative_path,
+                    "size": stat.st_size,
+                    "mimeType": mime_type,
+                }
+            )
+            if len(files) >= MAX_SKILL_PACKAGE_FILES:
+                return files
+    return files
 
 
 def _get_skill_name_from_file(skill_file_path: Path) -> str:

--- a/backend/tests/app/controller/test_skill_controller.py
+++ b/backend/tests/app/controller/test_skill_controller.py
@@ -1,0 +1,80 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.controller import skill_controller
+from app.service import skill_service
+
+
+@pytest.fixture
+def skill_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    skills_root = tmp_path / "skills"
+    package = skills_root / "research"
+    (package / "scripts").mkdir(parents=True)
+    (package / "SKILL.md").write_text("# Research", encoding="utf-8")
+    (package / "scripts" / "collect.py").write_text(
+        "print('ok')", encoding="utf-8"
+    )
+    monkeypatch.setattr(skill_service, "SKILLS_ROOT", skills_root)
+
+    app = FastAPI()
+    app.include_router(skill_controller.router)
+    with TestClient(app) as client:
+        yield client
+
+
+def test_lists_and_streams_skill_package_files(skill_api: TestClient) -> None:
+    listed = skill_api.get("/skills/research/files")
+
+    assert listed.status_code == 200
+    assert [entry["path"] for entry in listed.json()["files"]] == [
+        "SKILL.md",
+        "scripts/collect.py",
+    ]
+
+    streamed = skill_api.get(
+        "/skills/research/file", params={"path": "scripts/collect.py"}
+    )
+
+    assert streamed.status_code == 200
+    assert streamed.text == "print('ok')"
+    assert streamed.headers["content-type"].startswith("text/x-python")
+
+
+def test_skill_file_endpoint_rejects_traversal(skill_api: TestClient) -> None:
+    response = skill_api.get(
+        "/skills/research/file", params={"path": "../private.txt"}
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "A safe relative skill file path is required"
+    )
+
+
+def test_skill_package_endpoints_return_not_found(
+    skill_api: TestClient,
+) -> None:
+    package_response = skill_api.get("/skills/missing/files")
+    file_response = skill_api.get(
+        "/skills/research/file", params={"path": "missing.txt"}
+    )
+
+    assert package_response.status_code == 404
+    assert file_response.status_code == 404

--- a/backend/tests/app/service/test_skill_package_files.py
+++ b/backend/tests/app/service/test_skill_package_files.py
@@ -1,0 +1,106 @@
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
+
+from pathlib import Path
+
+import pytest
+
+from app.service import skill_service
+
+
+@pytest.fixture
+def skills_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "skills"
+    root.mkdir()
+    monkeypatch.setattr(skill_service, "SKILLS_ROOT", root)
+    return root
+
+
+def test_lists_nested_regular_files_with_metadata(skills_root: Path) -> None:
+    skill = skills_root / "research"
+    (skill / "scripts").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Research", encoding="utf-8")
+    (skill / "scripts" / "collect.py").write_text(
+        "print('ok')", encoding="utf-8"
+    )
+    (skill / skill_service.EXAMPLE_SKILL_MARKER).write_text(
+        "source=research\n", encoding="utf-8"
+    )
+
+    files = skill_service.skill_list_files("research")
+
+    assert [entry["path"] for entry in files] == [
+        "SKILL.md",
+        "scripts/collect.py",
+    ]
+    assert files[0]["size"] == len("# Research")
+    assert files[0]["mimeType"] == "text/markdown"
+    assert files[1]["mimeType"] == "text/x-python"
+
+
+def test_resolves_a_nested_file_inside_one_skill(skills_root: Path) -> None:
+    expected = skills_root / "research" / "references" / "guide.md"
+    expected.parent.mkdir(parents=True)
+    expected.write_text("Guide", encoding="utf-8")
+
+    assert (
+        skill_service.skill_file_path("research", "references/guide.md")
+        == expected.resolve()
+    )
+
+
+@pytest.mark.parametrize(
+    ("skill_name", "relative_path"),
+    [
+        (".", "research/SKILL.md"),
+        ("../research", "SKILL.md"),
+        ("research", "../private.txt"),
+        ("research", "/private.txt"),
+        ("research", "scripts//collect.py"),
+    ],
+)
+def test_rejects_paths_outside_a_single_skill(
+    skills_root: Path, skill_name: str, relative_path: str
+) -> None:
+    (skills_root / "research").mkdir(exist_ok=True)
+
+    with pytest.raises((ValueError, PermissionError)):
+        skill_service.skill_file_path(skill_name, relative_path)
+
+
+def test_rejects_symlinked_package_files(
+    skills_root: Path, tmp_path: Path
+) -> None:
+    skill = skills_root / "research"
+    skill.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("secret", encoding="utf-8")
+    link = skill / "secret.txt"
+    try:
+        link.symlink_to(secret)
+    except OSError:
+        pytest.skip("Symlinks are unavailable on this platform")
+
+    assert skill_service.skill_list_files("research") == []
+    with pytest.raises(PermissionError):
+        skill_service.skill_file_path("research", "secret.txt")
+
+
+def test_missing_skill_or_file_is_not_found(skills_root: Path) -> None:
+    (skills_root / "research").mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        skill_service.skill_list_files("missing")
+    with pytest.raises(FileNotFoundError):
+        skill_service.skill_file_path("research", "missing.txt")

--- a/src/api/brain.ts
+++ b/src/api/brain.ts
@@ -21,6 +21,7 @@ import i18next from 'i18next';
 import {
   fetchDelete,
   fetchGet,
+  fetchGetBlob,
   fetchPost,
   fetchPostForm,
   fetchPut,
@@ -127,11 +128,52 @@ export async function skillDelete(
 
 export async function skillListFiles(
   skillDirName: string
-): Promise<{ success: boolean; files: string[] }> {
+): Promise<{ success: boolean; files: SkillPackageFile[] }> {
   const res = await fetchGet(
     `/skills/${encodeURIComponent(skillDirName)}/files`
   );
-  return res?.files !== undefined ? res : { success: true, files: [] };
+  if (!Array.isArray(res?.files)) return { success: true, files: [] };
+  return {
+    success: res.success !== false,
+    files: res.files.flatMap((file: unknown) => {
+      if (typeof file === 'string') {
+        return [{ path: file, size: null }];
+      }
+      if (
+        file &&
+        typeof file === 'object' &&
+        typeof (file as SkillPackageFile).path === 'string'
+      ) {
+        const entry = file as SkillPackageFile;
+        return [
+          {
+            path: entry.path,
+            size: typeof entry.size === 'number' ? entry.size : null,
+            mimeType:
+              typeof entry.mimeType === 'string' ? entry.mimeType : null,
+          },
+        ];
+      }
+      return [];
+    }),
+  };
+}
+
+export type SkillPackageFile = {
+  path: string;
+  size: number | null;
+  mimeType?: string | null;
+};
+
+export async function skillReadFile(
+  skillDirName: string,
+  relativePath: string
+): Promise<Blob> {
+  return fetchGetBlob(
+    `/skills/${encodeURIComponent(skillDirName)}/file`,
+    { path: relativePath },
+    { signal: skillRequestSignal() }
+  );
 }
 
 export async function skillGetPathByName(

--- a/src/components/Settings/Connectors/ConnectorGateway.tsx
+++ b/src/components/Settings/Connectors/ConnectorGateway.tsx
@@ -107,7 +107,7 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import SettingsContentShell from '../SettingsContentShell';
 import SettingsSectionPage from '../SettingsSectionPage';
-import { useConnectorsNavigation } from './ConnectorsNavigationContext';
+import { usePublishConnectorsNavigation } from './ConnectorsNavigationContext';
 import ConnectorBrowserPage, {
   actionLabel,
   isConnectedProvider,
@@ -404,7 +404,7 @@ export default function ConnectorGateway() {
   const navigate = useNavigate();
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { publishItems } = useConnectorsNavigation();
+  const publishItems = usePublishConnectorsNavigation();
   const { checkAgentTool, modelType } = useAuthStore();
   const capabilityStatus = useServerCapabilityStore((state) => state.status);
   const connectorGatewayEnabled = useServerCapabilityStore((state) =>

--- a/src/components/Settings/Connectors/ConnectorsNavigationContext.tsx
+++ b/src/components/Settings/Connectors/ConnectorsNavigationContext.tsx
@@ -95,3 +95,17 @@ export function useConnectorsNavigation() {
   }
   return context;
 }
+
+const ignoreConnectorNavigationItems = () => undefined;
+
+/**
+ * ConnectorGateway also has standalone consumers that do not render the
+ * Settings sidebar. Publishing is optional for those consumers; the strict
+ * reader above remains the contract for sidebar surfaces.
+ */
+export function usePublishConnectorsNavigation() {
+  return (
+    useContext(ConnectorsNavigationContext)?.publishItems ??
+    ignoreConnectorNavigationItems
+  );
+}

--- a/src/components/Settings/SettingsSidebar.tsx
+++ b/src/components/Settings/SettingsSidebar.tsx
@@ -54,7 +54,11 @@ export default function SettingsSidebar({
   const { t } = useTranslation();
   const host = useHost();
   const email = useAuthStore((state) => state.email);
-  const { entries: skills, loading: skillsLoading } = useSkillsLibrary();
+  const {
+    entries: skills,
+    loading: skillsLoading,
+    profilesLoading: skillProfilesLoading,
+  } = useSkillsLibrary();
   const { items: connectorItems, loading: connectorsLoading } =
     useConnectorsNavigation();
   const browserCount = useSettingsResourceCountsStore(
@@ -136,7 +140,7 @@ export default function SettingsSidebar({
     ? initialConnectorCount
     : connectorItems.length;
   const sectionCounts: Partial<Record<SettingsSectionId, number | null>> = {
-    skills: skillsLoading ? null : skills.length,
+    skills: skillsLoading || skillProfilesLoading ? null : skills.length,
     connectors: connectorCount,
     'browser-connections': browserCount,
     cookies: cookieCount,

--- a/src/components/Settings/Skills/SkillsProvider.tsx
+++ b/src/components/Settings/Skills/SkillsProvider.tsx
@@ -49,7 +49,7 @@ type SkillLibraryLoadError = {
   name?: string;
 };
 
-const SPACE_PROFILE_LOAD_TIMEOUT_MS = 15_000;
+const SPACE_PROFILE_BATCH_TIMEOUT_MS = 15_000;
 
 /**
  * A save that failed only because nobody is signed in gets the actionable
@@ -87,7 +87,13 @@ function useLibrary() {
   const [profiles, setProfiles] = useState<SpaceSkillProfile[]>([]);
   const [loading, setLoading] = useState(false);
   const loadingRef = useRef(false);
-  const [errors, setErrors] = useState<SkillLibraryLoadError[]>([]);
+  const [profilesLoading, setProfilesLoading] = useState(false);
+  const [globalError, setGlobalError] = useState<SkillLibraryLoadError | null>(
+    null
+  );
+  const [profileErrors, setProfileErrors] = useState<SkillLibraryLoadError[]>(
+    []
+  );
   const [refreshKey, setRefreshKey] = useState(0);
   const [previewGeneration, setPreviewGeneration] = useState(0);
   const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
@@ -122,31 +128,60 @@ function useLibrary() {
     const controllers = new Set<AbortController>();
     loadingRef.current = true;
     setLoading(true);
-    setErrors([]);
+    setGlobalError(null);
+    setProfileErrors([]);
     setProfiles([]);
-    const load = async () => {
-      const failures: SkillLibraryLoadError[] = [];
-      const loaded: SpaceSkillProfile[] = [];
-      const globalLoad = getBaseURL()
-        .then(() => syncFromDisk())
-        .catch(() => {
-          failures.push({ key: 'agents.library-global-load-failed' });
-        });
+
+    const loadGlobalSkills = async () => {
+      try {
+        await getBaseURL();
+        await syncFromDisk();
+      } catch {
+        if (generation.current === current) {
+          setGlobalError({ key: 'agents.library-global-load-failed' });
+        }
+      } finally {
+        if (generation.current === current) {
+          loadingRef.current = false;
+          setLoading(false);
+        }
+      }
+    };
+
+    const loadSpaceProfiles = async () => {
       const queue = JSON.parse(spacesKey) as Array<{
         id: string;
         name: string;
       }>;
-      if (email) {
+      if (!queue.length) {
+        setProfilesLoading(false);
+        return;
+      }
+      if (!email) {
+        setProfileErrors([{ key: 'agents.library-sign-in' }]);
+        setProfilesLoading(false);
+        return;
+      }
+
+      setProfilesLoading(true);
+      const failures: SkillLibraryLoadError[] = [];
+      let batchExpired = false;
+      const batchTimeoutId = window.setTimeout(() => {
+        batchExpired = true;
+        controllers.forEach((controller) => controller.abort());
+      }, SPACE_PROFILE_BATCH_TIMEOUT_MS);
+
+      try {
         await Promise.all(
           Array.from({ length: Math.min(queue.length, 3) }, async () => {
-            while (queue.length && generation.current === current) {
+            while (
+              queue.length &&
+              !batchExpired &&
+              generation.current === current
+            ) {
               const space = queue.shift()!;
               const controller = new AbortController();
               controllers.add(controller);
-              const timeoutId = window.setTimeout(
-                () => controller.abort(),
-                SPACE_PROFILE_LOAD_TIMEOUT_MS
-              );
               try {
                 const draft = await fetchWorkspaceConfiguration(
                   space.id,
@@ -157,30 +192,39 @@ function useLibrary() {
                 if (!Array.isArray(draft?.document?.spec?.skills)) {
                   throw new Error('Invalid Space skill profile response');
                 }
-                loaded.push({ space, draft });
+                if (generation.current === current) {
+                  setProfiles((currentProfiles) =>
+                    [...currentProfiles, { space, draft }].sort((left, right) =>
+                      left.space.id.localeCompare(right.space.id)
+                    )
+                  );
+                }
               } catch {
                 failures.push({
                   key: 'agents.library-space-load-failed',
                   name: space.name,
                 });
               } finally {
-                window.clearTimeout(timeoutId);
                 controllers.delete(controller);
               }
             }
           })
         );
-      } else if (queue.length) {
-        failures.push({ key: 'agents.library-sign-in' });
+        failures.push(
+          ...queue.map((space) => ({
+            key: 'agents.library-space-load-failed' as const,
+            name: space.name,
+          }))
+        );
+        if (generation.current === current) setProfileErrors(failures);
+      } finally {
+        window.clearTimeout(batchTimeoutId);
+        if (generation.current === current) setProfilesLoading(false);
       }
-      await globalLoad;
-      if (generation.current !== current) return;
-      setProfiles(loaded);
-      setErrors(failures);
-      loadingRef.current = false;
-      setLoading(false);
     };
-    void load();
+
+    void loadGlobalSkills();
+    void loadSpaceProfiles();
     return () => {
       generation.current += 1;
       controllers.forEach((controller) => controller.abort());
@@ -251,6 +295,10 @@ function useLibrary() {
     () => buildSkillLibrary(skills, profiles),
     [skills, profiles]
   );
+  const errors = useMemo(
+    () => [...(globalError ? [globalError] : []), ...profileErrors],
+    [globalError, profileErrors]
+  );
   const messages = useMemo(
     () => errors.map(({ key, name }) => t(key, { name })),
     [errors, t]
@@ -263,6 +311,7 @@ function useLibrary() {
       entries,
       spaces,
       loading,
+      profilesLoading,
       errors: messages,
       refresh,
       refreshKey,
@@ -282,6 +331,7 @@ function useLibrary() {
       entries,
       spaces,
       loading,
+      profilesLoading,
       messages,
       refresh,
       refreshKey,

--- a/src/components/Settings/Skills/components/SkillDetail.tsx
+++ b/src/components/Settings/Skills/components/SkillDetail.tsx
@@ -45,6 +45,7 @@ export default function SkillDetail({
   const {
     entries,
     loading,
+    profilesLoading,
     updateGlobal,
     pendingIds,
     refresh,
@@ -156,9 +157,13 @@ export default function SkillDetail({
           role="status"
         >
           <DsText>
-            {t(loading ? 'agents.library-loading' : 'agents.library-not-found')}
+            {t(
+              loading || profilesLoading
+                ? 'agents.library-loading'
+                : 'agents.library-not-found'
+            )}
           </DsText>
-          {!loading && (
+          {!loading && !profilesLoading && (
             <Button
               variant="secondary"
               disabled={pendingIds.size > 0}

--- a/src/components/Settings/Skills/components/SkillFiles.tsx
+++ b/src/components/Settings/Skills/components/SkillFiles.tsx
@@ -12,24 +12,89 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-import { skillRead } from '@/api/brain';
-import { FileViewerPanel, type FileInfo } from '@/components/Folder';
+import {
+  skillListFiles,
+  skillReadFile,
+  type SkillPackageFile,
+} from '@/api/brain';
+import {
+  buildFileTree,
+  FileTree,
+  FileViewerPanel,
+  type FileInfo,
+} from '@/components/Folder';
+import { RIGHT_RAIL_CONTENT_WIDTH_CLASS } from '@/components/Layout/rightRail';
 import { Button } from '@/components/ui/button';
 import { DsText } from '@/components/ui/ds-text';
 import { shellDetailBackState } from '@/lib/shellRoutes';
 import { splitFrontmatter } from '@/lib/skillToolkit';
-import { FILE_PREVIEW_LIMITS } from '@/shared/filePreviewContract';
+import { decideFilePreview } from '@/shared/filePreviewContract';
 import { useAuthStore } from '@/store/authStore';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import type { SkillLibraryEntry } from '../skillLibrary';
 import { spaceSkillSettingsUrl } from './SkillActions';
 
 type GlobalSkillEntry = Exclude<SkillLibraryEntry, { kind: 'space' }>;
-type SkillDocument = { content: string; url: string; size: number };
+type LoadedSkillFile = { file: FileInfo; objectUrl: string };
 
-function GlobalSkillDocument({
+const TEXT_FILE_TYPES = new Set([
+  'css',
+  'csv',
+  'env',
+  'go',
+  'h',
+  'html',
+  'java',
+  'js',
+  'json',
+  'jsx',
+  'log',
+  'md',
+  'py',
+  'rs',
+  'sh',
+  'sql',
+  'ts',
+  'tsx',
+  'txt',
+  'xml',
+  'yaml',
+  'yml',
+]);
+
+function fileName(relativePath: string) {
+  return relativePath.split('/').filter(Boolean).at(-1) || relativePath;
+}
+
+function fileType(relativePath: string) {
+  const name = fileName(relativePath);
+  const dot = name.lastIndexOf('.');
+  return dot > 0 ? name.slice(dot + 1).toLocaleLowerCase() : '';
+}
+
+function skillFileUrl(skillDirName: string, relativePath: string) {
+  const query = new URLSearchParams({ path: relativePath });
+  return `/skills/${encodeURIComponent(skillDirName)}/file?${query}`;
+}
+
+function toFileInfo(
+  skillDirName: string,
+  packageFile: SkillPackageFile
+): FileInfo {
+  return {
+    name: fileName(packageFile.path),
+    path: skillFileUrl(skillDirName, packageFile.path),
+    relativePath: packageFile.path,
+    type: fileType(packageFile.path),
+    size: packageFile.size ?? undefined,
+    mimeType: packageFile.mimeType ?? undefined,
+    isRemote: true,
+  };
+}
+
+function GlobalSkillPackage({
   entry,
   revision,
 }: {
@@ -37,62 +102,233 @@ function GlobalSkillDocument({
   revision: string | number;
 }) {
   const { t } = useTranslation();
-  const [documentFile, setDocumentFile] = useState<SkillDocument | null>(null);
-  const [error, setError] = useState(false);
-  const [retry, setRetry] = useState(0);
+  const [files, setFiles] = useState<FileInfo[]>([]);
+  const [inventoryLoading, setInventoryLoading] = useState(true);
+  const [inventoryError, setInventoryError] = useState(false);
+  const [inventoryRetry, setInventoryRetry] = useState(0);
+  const [selectedPath, setSelectedPath] = useState('');
+  const [loaded, setLoaded] = useState<LoadedSkillFile | null>(null);
+  const [fileLoading, setFileLoading] = useState(false);
+  const [fileError, setFileError] = useState(false);
+  const [fileRetry, setFileRetry] = useState(0);
   const [source, setSource] = useState(false);
+  const [treeOpen, setTreeOpen] = useState(true);
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
+    new Set()
+  );
+  const treeId = useId();
   const skillDirName = entry.skill.skillDirName;
 
   useEffect(() => {
     let active = true;
-    let objectUrl: string | undefined;
-    setDocumentFile(null);
-    setError(false);
+    setInventoryLoading(true);
+    setInventoryError(false);
+    setFiles([]);
 
-    const load = async () => {
+    const loadInventory = async () => {
       if (!skillDirName) throw new Error('Skill package has no folder');
-      const result = await skillRead(skillDirName);
+      const result = await skillListFiles(skillDirName);
       if (!active) return;
-      if (result?.success !== true || typeof result.content !== 'string') {
-        throw new Error('Invalid skill document response');
+      if (result?.success !== true) {
+        throw new Error('Invalid skill package response');
       }
-      const blob = new Blob([result.content], {
-        type: 'text/markdown;charset=utf-8',
+      const nextFiles = result.files
+        .map((packageFile) => toFileInfo(skillDirName, packageFile))
+        .sort((left, right) =>
+          (left.relativePath || left.name).localeCompare(
+            right.relativePath || right.name
+          )
+        );
+      if (!nextFiles.length) throw new Error('Skill package is empty');
+      setFiles(nextFiles);
+      setSelectedPath((currentPath) => {
+        if (
+          currentPath &&
+          nextFiles.some((file) => file.relativePath === currentPath)
+        ) {
+          return currentPath;
+        }
+        return (
+          nextFiles.find((file) => file.relativePath === 'SKILL.md')
+            ?.relativePath ||
+          nextFiles[0]?.relativePath ||
+          ''
+        );
       });
+      const folders = new Set<string>();
+      for (const file of nextFiles) {
+        const segments = (file.relativePath || '').split('/').filter(Boolean);
+        for (let index = 1; index < segments.length; index += 1) {
+          folders.add(segments.slice(0, index).join('/'));
+        }
+      }
+      setExpandedFolders(folders);
+    };
+    void loadInventory()
+      .catch(() => {
+        if (active) setInventoryError(true);
+      })
+      .finally(() => {
+        if (active) setInventoryLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [skillDirName, inventoryRetry, revision]);
+
+  const selectedMetadata = useMemo(
+    () => files.find((file) => file.relativePath === selectedPath) || null,
+    [files, selectedPath]
+  );
+
+  useEffect(() => {
+    let active = true;
+    let objectUrl: string | undefined;
+    setLoaded(null);
+    setFileError(false);
+    setSource(false);
+
+    const loadFile = async () => {
+      if (!skillDirName || !selectedMetadata?.relativePath) return;
+      const decision = decideFilePreview(selectedMetadata.type, {
+        size: selectedMetadata.size ?? null,
+        mimeType: selectedMetadata.mimeType,
+        supportsRanges: true,
+      });
+      if (
+        decision.mode === 'blocked' ||
+        (decision.mode === 'bounded-text' &&
+          selectedMetadata.size !== undefined &&
+          decision.limit !== null &&
+          selectedMetadata.size > decision.limit)
+      ) {
+        setLoaded({
+          file: {
+            ...selectedMetadata,
+            preview: {
+              kind: 'blocked',
+              reason: decision.reason || 'too-large',
+              size: selectedMetadata.size ?? null,
+              limit: decision.limit,
+            },
+          },
+          objectUrl: '',
+        });
+        return;
+      }
+
+      setFileLoading(true);
+      const blob = await skillReadFile(
+        skillDirName,
+        selectedMetadata.relativePath
+      );
+      if (!active) return;
       objectUrl = URL.createObjectURL(blob);
-      setDocumentFile({
-        content: result.content,
-        url: objectUrl,
-        size: blob.size,
+      const shouldDecodeText =
+        TEXT_FILE_TYPES.has(selectedMetadata.type) ||
+        selectedMetadata.mimeType?.startsWith('text/') ||
+        !selectedMetadata.type;
+      const content = shouldDecodeText ? await blob.text() : objectUrl;
+      if (!active) return;
+      setLoaded({
+        file: {
+          ...selectedMetadata,
+          path: shouldDecodeText ? selectedMetadata.path : objectUrl,
+          content,
+          size: blob.size,
+        },
+        objectUrl,
       });
     };
-    void load().catch(() => {
-      if (active) setError(true);
-    });
+
+    void loadFile()
+      .catch(() => {
+        if (active) setFileError(true);
+      })
+      .finally(() => {
+        if (active) setFileLoading(false);
+      });
     return () => {
       active = false;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [skillDirName, retry, revision]);
+  }, [fileRetry, selectedMetadata, skillDirName]);
 
-  if (!documentFile) {
+  const hasLoadedSelected = loaded?.file.relativePath === selectedPath;
+  const selectedFile = hasLoadedSelected ? loaded.file : selectedMetadata;
+  const viewerLoading =
+    fileLoading ||
+    Boolean(selectedMetadata && !hasLoadedSelected && !fileError);
+  const displayedFile = useMemo(() => {
+    if (
+      !selectedFile ||
+      source ||
+      selectedFile.relativePath !== 'SKILL.md' ||
+      typeof selectedFile.content !== 'string'
+    ) {
+      return selectedFile;
+    }
+    return {
+      ...selectedFile,
+      content: splitFrontmatter(selectedFile.content).body,
+    };
+  }, [selectedFile, source]);
+  const tree = useMemo(() => buildFileTree(files), [files]);
+
+  const toggleFolder = useCallback((path: string) => {
+    setExpandedFolders((current) => {
+      const next = new Set(current);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  const downloadSelected = useCallback(async () => {
+    if (!skillDirName || !selectedMetadata?.relativePath) return;
+    let objectUrl = loaded?.objectUrl;
+    let release = false;
+    try {
+      if (!objectUrl) {
+        objectUrl = URL.createObjectURL(
+          await skillReadFile(skillDirName, selectedMetadata.relativePath)
+        );
+        release = true;
+      }
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = selectedMetadata.name;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch {
+      setFileError(true);
+    } finally {
+      if (release && objectUrl) {
+        const temporaryUrl = objectUrl;
+        window.setTimeout(() => URL.revokeObjectURL(temporaryUrl), 0);
+      }
+    }
+  }, [loaded?.objectUrl, selectedMetadata, skillDirName]);
+
+  if (inventoryLoading || inventoryError) {
     return (
       <div
         className="flex flex-1 flex-col items-center justify-center gap-ds-12 p-ds-24 text-center"
-        role={error ? 'alert' : 'status'}
+        role={inventoryError ? 'alert' : 'status'}
       >
         <DsText>
           {t(
-            error
+            inventoryError
               ? 'agents.library-files-failed'
               : 'agents.library-loading-files'
           )}
         </DsText>
-        {error && (
+        {inventoryError && (
           <Button
             variant="secondary"
             size="sm"
-            onClick={() => setRetry((value) => value + 1)}
+            onClick={() => setInventoryRetry((value) => value + 1)}
           >
             {t('agents.library-retry')}
           </Button>
@@ -101,50 +337,81 @@ function GlobalSkillDocument({
     );
   }
 
-  const downloadDocument = () => {
-    const link = document.createElement('a');
-    link.href = documentFile.url;
-    link.download = 'SKILL.md';
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-  };
-  // The established Skills API returns the whole document. Bound rendering
-  // without implying that it supports recursive package browsing or ranges.
-  if (documentFile.size > FILE_PREVIEW_LIMITS.textBytes) {
-    return (
-      <div
-        className="flex flex-1 flex-col items-center justify-center gap-ds-12 p-ds-24 text-center"
-        role="status"
-      >
-        <DsText>{t('folder.preview-too-large')}</DsText>
-      </div>
-    );
-  }
-
-  const file: FileInfo = {
-    name: 'SKILL.md',
-    path: documentFile.url,
-    relativePath: 'SKILL.md',
-    type: 'md',
-    content: source
-      ? documentFile.content
-      : splitFrontmatter(documentFile.content).body,
-    size: documentFile.size,
-    isRemote: true,
-  };
   return (
-    <FileViewerPanel
-      selectedFile={file}
-      loading={false}
-      isShowSourceCode={source}
-      breadcrumbSegments={[entry.name, file.name]}
-      projectFiles={[file]}
-      embedded
-      onRevealFile={downloadDocument}
-      onDownloadFile={downloadDocument}
-      onToggleSourceCode={() => setSource((value) => !value)}
-    />
+    <div className="flex h-full min-h-0 min-w-0 flex-1 overflow-hidden">
+      <FileViewerPanel
+        selectedFile={fileError ? null : displayedFile}
+        loading={viewerLoading}
+        isShowSourceCode={source}
+        breadcrumbSegments={[
+          entry.name,
+          ...(displayedFile?.relativePath || displayedFile?.name || '')
+            .split('/')
+            .filter(Boolean),
+        ]}
+        projectFiles={files.map((file) =>
+          displayedFile && file.relativePath === displayedFile.relativePath
+            ? displayedFile
+            : file
+        )}
+        embedded
+        isFileTreeOpen={treeOpen}
+        onToggleFileTree={() => setTreeOpen((open) => !open)}
+        fileTreeControlsId={treeId}
+        emptyState={
+          fileError ? (
+            <div
+              className="flex flex-1 flex-col items-center justify-center gap-ds-12 p-ds-24 text-center"
+              role="alert"
+            >
+              <DsText>{t('agents.library-files-failed')}</DsText>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setFileRetry((value) => value + 1)}
+              >
+                {t('agents.library-retry')}
+              </Button>
+            </div>
+          ) : undefined
+        }
+        onRevealFile={() => void downloadSelected()}
+        onDownloadFile={() => void downloadSelected()}
+        onToggleSourceCode={() => setSource((value) => !value)}
+      />
+      {treeOpen && (
+        <aside
+          className={`flex h-full min-h-0 shrink-0 flex-col overflow-hidden border-y-0 border-r-0 border-l border-solid border-ds-hairline-subtle-default bg-ds-neutral-subtle-default ${RIGHT_RAIL_CONTENT_WIDTH_CLASS}`}
+          style={{ maxWidth: '50%' }}
+          aria-label={t('chat.files', { defaultValue: 'Files' })}
+        >
+          <div className="flex h-ds-layout-row-header min-h-ds-layout-row-header shrink-0 items-center px-ds-12">
+            <DsText as="span" weight="semibold">
+              {t('chat.files', { defaultValue: 'Files' })}
+            </DsText>
+          </div>
+          <div
+            id={treeId}
+            className="scrollbar-always-visible min-h-0 flex-1 overflow-y-auto px-ds-8 pb-ds-8"
+          >
+            <FileTree
+              node={tree}
+              selectedFile={displayedFile}
+              expandedFolders={expandedFolders}
+              onToggleFolder={toggleFolder}
+              onSelectFile={(file) => {
+                if (file.isFolder) {
+                  toggleFolder(file.path);
+                  return;
+                }
+                setSelectedPath(file.relativePath || file.path);
+              }}
+              isShowSourceCode={source}
+            />
+          </div>
+        </aside>
+      )}
+    </div>
   );
 }
 
@@ -190,7 +457,7 @@ export default function SkillFiles({
           </Button>
         </div>
       ) : (
-        <GlobalSkillDocument
+        <GlobalSkillPackage
           key={JSON.stringify([
             entry.id,
             entry.skill.skillDirName,

--- a/src/components/Settings/Skills/index.tsx
+++ b/src/components/Settings/Skills/index.tsx
@@ -103,6 +103,7 @@ export default function Skills() {
     entries,
     spaces,
     loading,
+    profilesLoading,
     errors,
     refresh,
     openUpload,
@@ -141,10 +142,10 @@ export default function Skills() {
     actionable.length > 0 && selectedRows.length === actionable.length;
   useEffect(() => setSelected(new Set()), [query, filter, status, spaceId]);
   useEffect(() => {
-    if (!loading && errors.length === 0) {
+    if (!loading && !profilesLoading && errors.length === 0) {
       setDismissedNoticeCount(0);
     }
-  }, [loading, errors.length]);
+  }, [loading, profilesLoading, errors.length]);
   const compactNoticeCount =
     errors.length > 0 ? errors.length : dismissedNoticeCount;
   const showNoticeBanner = errors.length > 0 && !noticeMinimized;
@@ -345,7 +346,7 @@ export default function Skills() {
           )}
           <SkillsDashboard
             entries={entries}
-            loading={loading}
+            loading={loading || profilesLoading}
             hasErrors={errors.length > 0}
           />
           {selectedRows.length > 0 && (
@@ -581,7 +582,7 @@ export default function Skills() {
               </Table>
             </div>
           )}
-          {!loading && !visible.length && (
+          {!loading && !profilesLoading && !visible.length && (
             <div className="flex flex-col items-center gap-ds-12 py-ds-40 text-center">
               <DsIcon icon={Folder} recipe="detailed" />
               <DsText className="m-0">

--- a/src/service/workspaceConfigurationApi.ts
+++ b/src/service/workspaceConfigurationApi.ts
@@ -197,16 +197,16 @@ export const fetchWorkspaceConfiguration = async (
   identity: WorkspaceConfigurationIdentity,
   name?: string,
   options: { signal?: AbortSignal } = {}
-): Promise<WorkspaceConfigurationDraft> =>
-  fetchGet(
-    `/spaces/${encodeURIComponent(spaceId)}/workspace-configuration`,
-    {
-      ...identityParams(identity),
-      ...(name ? { name } : {}),
-    },
-    undefined,
-    options
-  );
+): Promise<WorkspaceConfigurationDraft> => {
+  const url = `/spaces/${encodeURIComponent(spaceId)}/workspace-configuration`;
+  const params = {
+    ...identityParams(identity),
+    ...(name ? { name } : {}),
+  };
+  return options.signal
+    ? fetchGet(url, params, undefined, options)
+    : fetchGet(url, params);
+};
 
 export const saveWorkspaceConfiguration = async (
   spaceId: string,

--- a/test/unit/components/ConnectorGateway.test.tsx
+++ b/test/unit/components/ConnectorGateway.test.tsx
@@ -144,7 +144,9 @@ describe('ConnectorGateway Web search visibility', () => {
     const webSearch = await screen.findByRole('button', {
       name: 'Web search',
     });
-    expect(within(webSearch).getByText('Not connected')).toBeInTheDocument();
+    const row = webSearch.closest('tr');
+    expect(row).not.toBeNull();
+    expect(within(row!).getByText('Not connected')).toBeInTheDocument();
 
     await user.click(webSearch);
 
@@ -160,6 +162,8 @@ describe('ConnectorGateway Web search visibility', () => {
     const webSearch = await screen.findByRole('button', {
       name: 'Web search',
     });
-    expect(within(webSearch).getByText('Connected')).toBeInTheDocument();
+    const row = webSearch.closest('tr');
+    expect(row).not.toBeNull();
+    expect(within(row!).getByText('Connected')).toBeInTheDocument();
   });
 });

--- a/test/unit/components/Settings/Skills/SkillFiles.test.tsx
+++ b/test/unit/components/Settings/Skills/SkillFiles.test.tsx
@@ -12,12 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
-import { fetchGet } from '@/api/http';
+import { fetchGet, fetchGetBlob } from '@/api/http';
 import SkillFiles from '@/components/Settings/Skills/components/SkillFiles';
 import type { SkillLibraryEntry } from '@/components/Settings/Skills/skillLibrary';
 import { FILE_PREVIEW_LIMITS } from '@/shared/filePreviewContract';
 import { useAuthStore } from '@/store/authStore';
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -25,6 +25,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@/api/http', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/api/http')>()),
   fetchGet: vi.fn(),
+  fetchGetBlob: vi.fn(),
 }));
 
 vi.mock('@/components/ChatBox/MessageItem/MarkDown', () => ({
@@ -37,8 +38,16 @@ vi.mock('@/components/CodeViewer/SourceCodeViewer', () => ({
   ),
 }));
 
-const createObjectURL = vi.fn(() => 'blob:skill-document');
+const createObjectURL = vi.fn(() => 'blob:skill-file');
 const revokeObjectURL = vi.fn();
+
+function fileBlob(content: string) {
+  const blob = new Blob([content]);
+  Object.defineProperty(blob, 'text', {
+    value: vi.fn().mockResolvedValue(content),
+  });
+  return blob;
+}
 
 function globalEntry(
   directory = 'research',
@@ -64,12 +73,17 @@ function globalEntry(
   };
 }
 
-function deferredResponse() {
-  let resolve!: (response: { success: boolean; content: string }) => void;
-  const promise = new Promise<{ success: boolean; content: string }>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
+function inventory(
+  files: Array<{
+    path: string;
+    size: number;
+    mimeType?: string;
+  }> = [
+    { path: 'SKILL.md', size: 32, mimeType: 'text/markdown' },
+    { path: 'scripts/helper.py', size: 24, mimeType: 'text/x-python' },
+  ]
+) {
+  return { success: true, files };
 }
 
 function Location() {
@@ -79,7 +93,7 @@ function Location() {
   );
 }
 
-function renderDocument(entry: SkillLibraryEntry) {
+function renderPackage(entry: SkillLibraryEntry) {
   return render(
     <MemoryRouter>
       <SkillFiles entry={entry} />
@@ -88,10 +102,11 @@ function renderDocument(entry: SkillLibraryEntry) {
   );
 }
 
-describe('Skills document preview with the existing API', () => {
+describe('Skill package file browser', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(fetchGet).mockReset();
+    vi.mocked(fetchGetBlob).mockReset();
     useAuthStore.setState({ email: 'viewer@example.com', user_id: 1 });
     vi.stubGlobal(
       'URL',
@@ -109,74 +124,121 @@ describe('Skills document preview with the existing API', () => {
   });
 
   it.each(['global', 'builtin'] as const)(
-    'loads a %s SKILL.md from the existing endpoint and toggles source locally',
+    'loads the complete %s package and previews nested files',
     async (kind) => {
       const user = userEvent.setup();
-      const pending = deferredResponse();
-      vi.mocked(fetchGet).mockReturnValueOnce(pending.promise);
-      renderDocument(globalEntry('research notes', kind));
+      vi.mocked(fetchGet).mockResolvedValueOnce(inventory());
+      vi.mocked(fetchGetBlob).mockImplementation(
+        async (_url, params: Record<string, string>) =>
+          fileBlob(
+            params.path === 'SKILL.md'
+              ? '# Current instructions'
+              : 'print("helper")'
+          )
+      );
+
+      renderPackage(globalEntry('research notes', kind));
 
       expect(screen.getByRole('status')).toHaveTextContent(
         'Loading skill document…'
       );
-      await act(async () => {
-        pending.resolve({ success: true, content: '# Current instructions' });
-      });
+      expect(await screen.findByRole('article')).toHaveTextContent(
+        '# Current instructions'
+      );
+      expect(fetchGet).toHaveBeenCalledWith('/skills/research%20notes/files');
+      expect(fetchGetBlob).toHaveBeenCalledWith(
+        '/skills/research%20notes/file',
+        { path: 'SKILL.md' },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+      expect(screen.getByRole('tree', { name: 'Files' })).toBeVisible();
 
-      expect(screen.getByRole('article')).toHaveTextContent(
-        '# Current instructions'
+      await user.click(screen.getByRole('treeitem', { name: 'helper.py' }));
+      expect(await screen.findByTestId('skill-source')).toHaveTextContent(
+        'print("helper")'
       );
-      expect(fetchGet).toHaveBeenCalledTimes(1);
-      expect(fetchGet).toHaveBeenCalledWith('/skills/research%20notes');
-      expect(screen.queryByText(/Cached content/)).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('button', { name: /file tree/i })
-      ).not.toBeInTheDocument();
-      await user.click(screen.getByRole('button', { name: 'Source' }));
-      expect(screen.getByTestId('skill-source')).toHaveTextContent(
-        '# Current instructions'
+      expect(fetchGetBlob).toHaveBeenLastCalledWith(
+        '/skills/research%20notes/file',
+        { path: 'scripts/helper.py' },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
-      await user.click(screen.getByRole('button', { name: 'Preview' }));
-      expect(screen.getByRole('article')).toBeVisible();
-      expect(fetchGet).toHaveBeenCalledTimes(1);
     }
   );
 
-  it('omits YAML frontmatter only in Preview and preserves the complete Source', async () => {
+  it('omits SKILL.md frontmatter only in Preview and preserves Source', async () => {
     const user = userEvent.setup();
     const body = '\n# Research instructions\n\nCheck each cited source.\n';
     const raw = `---\nname: research\ndescription: Verify references\n---\n${body}`;
-    vi.mocked(fetchGet).mockResolvedValueOnce({ success: true, content: raw });
-    renderDocument(globalEntry());
+    vi.mocked(fetchGet).mockResolvedValueOnce(
+      inventory([{ path: 'SKILL.md', size: raw.length }])
+    );
+    vi.mocked(fetchGetBlob).mockResolvedValueOnce(fileBlob(raw));
+    renderPackage(globalEntry());
 
     expect((await screen.findByRole('article')).textContent).toBe(body);
-    expect(screen.queryByText(/name: research/)).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Source' }));
     expect(screen.getByTestId('skill-source').textContent).toBe(raw);
     await user.click(screen.getByRole('button', { name: 'Preview' }));
     expect(screen.getByRole('article').textContent).toBe(body);
-    expect(fetchGet).toHaveBeenCalledTimes(1);
-    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(fetchGetBlob).toHaveBeenCalledTimes(1);
   });
 
   it.each([
-    { success: false, content: '# Failed response' },
-    { success: true, content: null },
-  ])('rejects invalid document responses: %j', async (response) => {
+    { success: false, files: [] },
+    { success: true, files: [] },
+  ])('rejects an unusable package inventory: %j', async (response) => {
     vi.mocked(fetchGet).mockResolvedValueOnce(response);
-    renderDocument(globalEntry());
+    renderPackage(globalEntry());
+
     expect(await screen.findByRole('alert')).toHaveTextContent(
       'Could not load the skill document.'
     );
-    expect(screen.queryByRole('article')).not.toBeInTheDocument();
-    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(fetchGetBlob).not.toHaveBeenCalled();
   });
 
-  it('reloads the document when the same package is replaced in place', async () => {
+  it('retries an inventory failure and then loads the package', async () => {
+    const user = userEvent.setup();
     vi.mocked(fetchGet)
-      .mockResolvedValueOnce({ success: true, content: '# Original' })
-      .mockResolvedValueOnce({ success: true, content: '# Replaced' });
-    const view = renderDocument(globalEntry());
+      .mockRejectedValueOnce(new Error('Offline'))
+      .mockResolvedValueOnce(inventory());
+    vi.mocked(fetchGetBlob).mockResolvedValueOnce(fileBlob('# Recovered'));
+    renderPackage(globalEntry());
+
+    await screen.findByRole('alert');
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByRole('article')).toHaveTextContent('# Recovered');
+    expect(fetchGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries the selected file without refetching the inventory', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetchGet).mockResolvedValueOnce(inventory());
+    vi.mocked(fetchGetBlob)
+      .mockRejectedValueOnce(new Error('Offline'))
+      .mockResolvedValueOnce(fileBlob('# Recovered file'));
+    renderPackage(globalEntry());
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not load the skill document.'
+    );
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByRole('article')).toHaveTextContent(
+      '# Recovered file'
+    );
+    expect(fetchGet).toHaveBeenCalledTimes(1);
+    expect(fetchGetBlob).toHaveBeenCalledTimes(2);
+  });
+
+  it('reloads package inventory and content when it is replaced in place', async () => {
+    vi.mocked(fetchGet)
+      .mockResolvedValueOnce(inventory())
+      .mockResolvedValueOnce(inventory());
+    vi.mocked(fetchGetBlob)
+      .mockResolvedValueOnce(fileBlob('# Original'))
+      .mockResolvedValueOnce(fileBlob('# Replaced'));
+    const view = renderPackage(globalEntry());
     expect(await screen.findByRole('article')).toHaveTextContent('# Original');
 
     view.rerender(
@@ -188,99 +250,45 @@ describe('Skills document preview with the existing API', () => {
 
     expect(await screen.findByRole('article')).toHaveTextContent('# Replaced');
     expect(fetchGet).toHaveBeenCalledTimes(2);
+    expect(fetchGetBlob).toHaveBeenCalledTimes(2);
   });
 
-  it('retries a failed read without needing any package-browser endpoint', async () => {
-    vi.mocked(fetchGet)
-      .mockRejectedValueOnce(new Error('Offline'))
-      .mockResolvedValueOnce({ success: true, content: '# Recovered' });
-    const user = userEvent.setup();
-    renderDocument(globalEntry());
-    await screen.findByRole('alert');
-    await user.click(screen.getByRole('button', { name: 'Retry' }));
+  it('does not automatically read a file above the preview limit', async () => {
+    vi.mocked(fetchGet).mockResolvedValueOnce(
+      inventory([
+        {
+          path: 'SKILL.md',
+          size: FILE_PREVIEW_LIMITS.textBytes + 1,
+          mimeType: 'text/markdown',
+        },
+      ])
+    );
+    renderPackage(globalEntry());
 
-    expect(await screen.findByRole('article')).toHaveTextContent('# Recovered');
-    expect(vi.mocked(fetchGet).mock.calls).toEqual([
-      ['/skills/research'],
-      ['/skills/research'],
-    ]);
-  });
-
-  it.each(['skill', 'account'] as const)(
-    'ignores an old response after switching %s',
-    async (switchTarget) => {
-      const old = deferredResponse();
-      const current = deferredResponse();
-      vi.mocked(fetchGet)
-        .mockReturnValueOnce(old.promise)
-        .mockReturnValueOnce(current.promise);
-      const view = renderDocument(globalEntry());
-
-      if (switchTarget === 'skill') {
-        view.rerender(
-          <MemoryRouter>
-            <SkillFiles entry={globalEntry('writing')} />
-          </MemoryRouter>
-        );
-      } else {
-        act(() => {
-          useAuthStore.setState({ email: 'other@example.com', user_id: 2 });
-        });
-      }
-      await waitFor(() => expect(fetchGet).toHaveBeenCalledTimes(2));
-      await act(async () => {
-        current.resolve({ success: true, content: '# Current document' });
-      });
-      await act(async () => {
-        old.resolve({ success: true, content: '# Stale document' });
-      });
-
-      expect(screen.getByRole('article')).toHaveTextContent(
-        '# Current document'
-      );
-      expect(screen.queryByText('# Stale document')).not.toBeInTheDocument();
-      expect(createObjectURL).toHaveBeenCalledTimes(1);
-    }
-  );
-
-  it('releases the document URL without exposing an individual file download', async () => {
-    vi.mocked(fetchGet).mockResolvedValueOnce({
-      success: true,
-      content: '# Read me',
-    });
-    const view = renderDocument(globalEntry());
-    await screen.findByRole('article');
-
-    expect(
-      screen.queryByRole('button', { name: 'Download file' })
-    ).not.toBeInTheDocument();
-    expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
-    expect(revokeObjectURL).not.toHaveBeenCalled();
-    view.unmount();
-    expect(revokeObjectURL).toHaveBeenCalledWith('blob:skill-document');
-  });
-
-  it('keeps oversized instructions out of the preview without a file action', async () => {
-    vi.mocked(fetchGet).mockResolvedValueOnce({
-      success: true,
-      content: 'a'.repeat(FILE_PREVIEW_LIMITS.textBytes + 1),
-    });
-    renderDocument(globalEntry());
     expect(
       await screen.findByText(
         'This file exceeds the safe in-app preview limit.'
       )
     ).toBeVisible();
-    expect(
-      screen.queryByRole('button', { name: 'Download file' })
-    ).not.toBeInTheDocument();
-    expect(screen.queryByRole('article')).not.toBeInTheDocument();
+    expect(fetchGetBlob).not.toHaveBeenCalled();
   });
 
-  it('shows the exact Space reference and its settings without fetching another skill', async () => {
+  it('releases the selected file object URL on unmount', async () => {
+    vi.mocked(fetchGet).mockResolvedValueOnce(inventory());
+    vi.mocked(fetchGetBlob).mockResolvedValueOnce(fileBlob('# Read me'));
+    const view = renderPackage(globalEntry());
+    await screen.findByRole('article');
+
+    expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    view.unmount();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:skill-file');
+  });
+
+  it('shows the exact Space reference and settings without fetching a package', async () => {
     const user = userEvent.setup();
     const ref = 'bundle://skills/research/SKILL.md';
-    renderDocument({
+    renderPackage({
       id: `space:space 1:${ref}`,
       kind: 'space',
       name: 'research',
@@ -295,16 +303,36 @@ describe('Skills document preview with the existing API', () => {
     expect(screen.getByRole('status')).toHaveTextContent(
       'Space skill file previews are not supported here.'
     );
-    expect(
-      screen.queryByRole('button', { name: 'Retry' })
-    ).not.toBeInTheDocument();
     expect(fetchGet).not.toHaveBeenCalled();
+    expect(fetchGetBlob).not.toHaveBeenCalled();
     await user.click(
       screen.getByRole('button', { name: 'Manage in Space settings' })
     );
     expect(screen.getByTestId('location')).toHaveTextContent(
       '/home?section=spaces&spaceId=space%201&spaceTab=workspace-profile'
     );
-    expect(fetchGet).not.toHaveBeenCalled();
+  });
+
+  it('ignores a stale inventory after switching accounts', async () => {
+    let resolveOld!: (value: ReturnType<typeof inventory>) => void;
+    const oldInventory = new Promise<ReturnType<typeof inventory>>(
+      (resolve) => {
+        resolveOld = resolve;
+      }
+    );
+    vi.mocked(fetchGet)
+      .mockReturnValueOnce(oldInventory)
+      .mockResolvedValueOnce(inventory());
+    vi.mocked(fetchGetBlob).mockResolvedValueOnce(fileBlob('# Current'));
+    renderPackage(globalEntry());
+
+    act(() => {
+      useAuthStore.setState({ email: 'other@example.com', user_id: 2 });
+    });
+    expect(await screen.findByRole('article')).toHaveTextContent('# Current');
+    await act(async () => resolveOld(inventory()));
+
+    expect(screen.getByRole('article')).toHaveTextContent('# Current');
+    expect(fetchGetBlob).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/unit/components/Settings/Skills/SkillsProvider.test.tsx
+++ b/test/unit/components/Settings/Skills/SkillsProvider.test.tsx
@@ -144,16 +144,19 @@ describe('Skills library state', () => {
     await waitFor(() => expect(library.loading).toBe(false));
   });
 
-  it('bounds a stalled Space profile request and releases the library', async () => {
+  it('bounds the whole Space batch without blocking global Skill writes', async () => {
     vi.useFakeTimers();
-    mocks.spaceState.spaces = {
-      alpha: {
-        id: 'alpha',
-        name: 'Alpha',
-        status: 'active',
-        sourceType: 'cloud',
-      },
-    };
+    mocks.spaceState.spaces = Object.fromEntries(
+      Array.from({ length: 7 }, (_, index) => [
+        `space-${index}`,
+        {
+          id: `space-${index}`,
+          name: `Space ${index}`,
+          status: 'active',
+          sourceType: 'cloud',
+        },
+      ])
+    );
     mocks.fetchWorkspaceConfiguration.mockImplementation(
       (
         _spaceId: string,
@@ -170,13 +173,28 @@ describe('Skills library state', () => {
 
     render(<Library />);
     expect(library.loading).toBe(true);
+    expect(library.profilesLoading).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(library.loading).toBe(false);
+    expect(library.profilesLoading).toBe(true);
+    await act(async () => {
+      expect(await library.updateGlobal(skill, { enabled: false })).toBe(true);
+    });
+    expect(mocks.skillState.updateSkill).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchWorkspaceConfiguration).toHaveBeenCalledTimes(3);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(15_000);
     });
 
     expect(library.loading).toBe(false);
-    expect(library.errors).toContain('en:agents.library-space-load-failed');
+    expect(library.profilesLoading).toBe(false);
+    expect(library.errors).toHaveLength(7);
+    expect(mocks.fetchWorkspaceConfiguration).toHaveBeenCalledTimes(3);
   });
 
   it('prevents settings writes while a refresh is reading configuration', async () => {


### PR DESCRIPTION
# Pull Request

## Related Issue

Related to #1896. This is a stacked remediation PR targeting the head branch of #1896.

## Description

This PR addresses the three review findings identified against #1896 at `6bae6510c`:

- Decouples global Skill loading from background Space profile loading and caps the entire profile batch at 15 seconds.
- Adds a secure recursive Skill package file API and a full package browser using the existing file tree and viewer primitives.
- Keeps `ConnectorGateway` usable outside `ConnectorsNavigationProvider` while preserving sidebar publication inside Settings.
- Preserves the existing default `fetchWorkspaceConfiguration` call contract.

Skill package reads reject absolute paths, traversal, empty path segments, cross-Skill access, and symlinks. File inventories are capped at 1000 entries.

## Testing Evidence (REQUIRED)

Automated verification completed:

- `npm run type-check`
- focused ESLint checks
- `npm run check:i18n`
- `npm run check:design-tokens`
- `npm run check:design-system`
- focused Vitest: 13 files, 58 tests passed
- backend Skill controller/service/init: 20 tests passed
- backend Ruff, format, and Bandit hooks
- `git diff --check`

Human-verified Electron testing and frontend screenshots or screen recordings are still pending.

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

- [ ] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)