### PR TITLE
fix: disable remote deployment and stabilize task cleanup

### DIFF
--- a/backend/app/agent/factory/developer.py
+++ b/backend/app/agent/factory/developer.py
@@ -35,7 +35,6 @@ from app.agent.toolkit.screenshot_toolkit import ScreenshotToolkit
 from app.agent.toolkit.search_toolkit import SearchToolkit
 from app.agent.toolkit.skill_toolkit import SkillToolkit
 from app.agent.toolkit.terminal_toolkit import TerminalToolkit
-from app.agent.toolkit.web_deploy_toolkit import WebDeployToolkit
 from app.agent.utils import NOW_STR
 from app.hands.interface import IHands
 from app.model.chat import Chat
@@ -63,10 +62,6 @@ async def developer_agent(
         working_directory=working_directory,
     )
     note_toolkit = message_integration.register_toolkits(note_toolkit)
-    web_deploy_toolkit = WebDeployToolkit(api_task_id=options.project_id)
-    web_deploy_toolkit = message_integration.register_toolkits(
-        web_deploy_toolkit
-    )
     screenshot_toolkit = ScreenshotToolkit(
         options.project_id,
         working_directory=working_directory,
@@ -98,7 +93,6 @@ async def developer_agent(
             options.project_id, Agents.developer_agent
         ),
         *note_toolkit.get_tools(),
-        *web_deploy_toolkit.get_tools(),
         *screenshot_toolkit.get_tools(),
         *skill_toolkit.get_tools(),
         *search_tools,
@@ -106,7 +100,6 @@ async def developer_agent(
     tool_names = [
         HumanToolkit.toolkit_name(),
         NoteTakingToolkit.toolkit_name(),
-        WebDeployToolkit.toolkit_name(),
         ScreenshotToolkit.toolkit_name(),
         SkillToolkit.toolkit_name(),
     ]

--- a/backend/app/agent/factory/toolkit_assembler.py
+++ b/backend/app/agent/factory/toolkit_assembler.py
@@ -45,7 +45,6 @@ from app.agent.toolkit.terminal_toolkit import (
     TerminalToolkit,
     is_secret_broker_environment_key,
 )
-from app.agent.toolkit.web_deploy_toolkit import WebDeployToolkit
 from app.agent.toolkit.workspace_git_toolkit import WorkspaceGitToolkit
 from app.component.environment import env
 from app.hands.interface import IHands
@@ -123,7 +122,6 @@ _SAFE_READ_TOOLKIT_FUNCTIONS: dict[str, frozenset[str] | None] = {
 DEFAULT_SINGLE_AGENT_TOOLKIT_CONFIG: dict[str, Any] = {
     "human": {"enabled": True},
     "file": {"enabled": True},
-    "web_deploy": {"enabled": True},
     "screenshot": {"enabled": True},
     "skill": {"enabled": True},
     "todo": {"enabled": True},
@@ -458,17 +456,6 @@ async def assemble_single_agent_toolkits(
         toolkit.agent_name = Agents.single_agent
         toolkit = message_integration.register_toolkits(toolkit)
         assembly.add_tools(toolkit.get_tools(), FileToolkit.toolkit_name())
-
-    if _enabled(config, "web_deploy"):
-        toolkit = WebDeployToolkit(
-            api_task_id=options.project_id,
-            **_options(config, "web_deploy"),
-        )
-        toolkit.agent_name = Agents.single_agent
-        toolkit = message_integration.register_toolkits(toolkit)
-        assembly.add_tools(
-            toolkit.get_tools(), WebDeployToolkit.toolkit_name()
-        )
 
     if _enabled(config, "screenshot"):
         screenshot_options = {

--- a/backend/app/agent/prompt.py
+++ b/backend/app/agent/prompt.py
@@ -535,8 +535,8 @@ DEVELOPER_SYS_PROMPT = """\
 You are a Lead Software Engineer, a master-level coding assistant with a
 powerful and unrestricted terminal. Your primary role is to solve any
 technical task by writing and executing code, installing necessary libraries,
-interacting with the operating system, and deploying applications. You are the
-team's go-to expert for all technical implementation.
+and interacting with the operating system. You are the team's go-to expert for
+all technical implementation.
 </role>
 
 <team_structure>
@@ -623,8 +623,6 @@ Your capabilities are extensive and powerful:
     prepare or suggest actions. Execute them to completion.
 - **Solution Verification**: You can immediately test and verify your
   solutions by executing them in the terminal.
-- **Web Deployment**: You can deploy web applications and content, serve
-  files, and manage deployments.
 - **Human Collaboration**: If you are stuck or need clarification, you can
   ask for human input via the console.
 - **Note Management**: Use `list_note()` and `read_note()` to discover

--- a/backend/app/agent/toolkit/terminal_toolkit.py
+++ b/backend/app/agent/toolkit/terminal_toolkit.py
@@ -96,7 +96,10 @@ _BUNDLE_RUNTIME_BASE_ENVIRONMENT_KEYS = {
     "WINDIR",
 }
 
-_RUN_BACKGROUND_QUIESCE_TIMEOUT_SECONDS = 5.0
+# A stopped background command still has to release its broad-write lease and
+# finish the workspace Git checkpoint before the Run can be terminalized. A
+# five-second budget was too close to normal checkpoint latency on macOS.
+_RUN_BACKGROUND_QUIESCE_TIMEOUT_SECONDS = 30.0
 
 _LOCAL_PROCESS_GROUP_BOOTSTRAP = (
     "import os,sys; os.setsid(); "

--- a/backend/app/service/chat_service.py
+++ b/backend/app/service/chat_service.py
@@ -2875,8 +2875,7 @@ the current date.
     workforce.add_single_agent_worker(
         "Developer Agent: A master-level coding assistant with a powerful "
         "terminal. It can write and execute code, manage files, automate "
-        "desktop tasks, and deploy web applications to solve complex "
-        "technical challenges.",
+        "desktop tasks, and solve complex technical challenges.",
         developer,
     )
     workforce.add_single_agent_worker(

--- a/backend/tests/app/agent/factory/test_developer.py
+++ b/backend/tests/app/agent/factory/test_developer.py
@@ -43,7 +43,6 @@ async def test_developer_agent_creation(sample_chat_data):
         patch("asyncio.create_task"),
         patch(f"{_mod}.HumanToolkit") as mock_human_toolkit,
         patch(f"{_mod}.NoteTakingToolkit") as mock_note_toolkit,
-        patch(f"{_mod}.WebDeployToolkit") as mock_web_toolkit,
         patch(f"{_mod}.ScreenshotToolkit") as mock_screenshot_toolkit,
         patch(f"{_mod}.TerminalToolkit") as mock_terminal_toolkit,
         patch(f"{_mod}.ToolkitMessageIntegration"),
@@ -51,7 +50,6 @@ async def test_developer_agent_creation(sample_chat_data):
         # Mock all toolkit instances
         mock_human_toolkit.get_can_use_tools.return_value = []
         mock_note_toolkit.return_value.get_tools.return_value = []
-        mock_web_toolkit.return_value.get_tools.return_value = []
         mock_screenshot_toolkit.return_value.get_tools.return_value = []
         mock_terminal_toolkit.return_value.get_tools.return_value = []
 
@@ -75,6 +73,7 @@ async def test_developer_agent_creation(sample_chat_data):
         )  # agent_name (enum contains this value)
         tools_arg = call_args[0][3]  # tools argument
         assert isinstance(tools_arg, list)
+        assert "Web Deploy Toolkit" not in call_args.kwargs["tool_names"]
 
 
 @pytest.mark.asyncio
@@ -97,7 +96,6 @@ async def test_developer_agent_with_multiple_toolkits(sample_chat_data):
         patch("asyncio.create_task"),
         patch(f"{_mod}.HumanToolkit") as mock_human_toolkit,
         patch(f"{_mod}.NoteTakingToolkit") as mock_note_toolkit,
-        patch(f"{_mod}.WebDeployToolkit") as mock_web_toolkit,
         patch(f"{_mod}.ScreenshotToolkit") as mock_screenshot_toolkit,
         patch(f"{_mod}.TerminalToolkit") as mock_terminal_toolkit,
         patch(f"{_mod}.ToolkitMessageIntegration"),
@@ -105,7 +103,6 @@ async def test_developer_agent_with_multiple_toolkits(sample_chat_data):
         # Mock all toolkit instances
         mock_human_toolkit.get_can_use_tools.return_value = []
         mock_note_toolkit.return_value.get_tools.return_value = []
-        mock_web_toolkit.return_value.get_tools.return_value = []
         mock_screenshot_toolkit.return_value.get_tools.return_value = []
         mock_terminal_toolkit.return_value.get_tools.return_value = []
 

--- a/backend/tests/app/agent/factory/test_tool_descriptions.py
+++ b/backend/tests/app/agent/factory/test_tool_descriptions.py
@@ -122,6 +122,42 @@ async def test_default_single_agent_tools_have_descriptions(
 
 
 @pytest.mark.asyncio
+async def test_single_agent_ignores_legacy_web_deploy_config(
+    sample_chat_data, monkeypatch, tmp_path
+):
+    import app.agent.factory.toolkit_assembler as assembler
+
+    toolkit_config = {
+        name: {"enabled": False}
+        for name in assembler.DEFAULT_SINGLE_AGENT_TOOLKIT_CONFIG
+    }
+    toolkit_config["web_deploy"] = {"enabled": True}
+    options = _bedrock_chat(sample_chat_data).model_copy(
+        update={"toolkit_config": toolkit_config}
+    )
+    _patch_toolkit_creation_side_effects(
+        monkeypatch, tmp_path, options.project_id
+    )
+
+    assembly = await assemble_single_agent_toolkits(
+        options,
+        task_id=options.task_id,
+        working_directory=str(tmp_path),
+        hands=None,
+        can_delegate=False,
+    )
+
+    function_names = {
+        tool.get_function_name()
+        for tool in assembly.tools
+        if hasattr(tool, "get_function_name")
+    }
+    assert "Web Deploy Toolkit" not in assembly.tool_names
+    assert "deploy_html_content" not in function_names
+    assert "deploy_folder" not in function_names
+
+
+@pytest.mark.asyncio
 async def test_active_bundle_runtime_inputs_override_request_toolkit_config(
     sample_chat_data, monkeypatch, tmp_path
 ):

--- a/backend/tests/app/agent/toolkit/test_terminal_workspace.py
+++ b/backend/tests/app/agent/toolkit/test_terminal_workspace.py
@@ -671,3 +671,27 @@ def test_run_completion_stops_background_session_before_checkpoint(
     assert toolkit.quiesce_run_background_sessions("run-1") == ()
     assert checkpointed.is_set()
     assert calls == ["kill", "complete", "finalize"]
+
+
+def test_run_completion_allows_workspace_checkpoint_to_settle():
+    toolkit = TerminalToolkit.__new__(TerminalToolkit)
+    toolkit._session_lock = threading.RLock()
+    toolkit.shell_sessions = {"preview-server": {"running": False}}
+    observed_timeouts: list[float] = []
+
+    class _Completion:
+        def wait(self, timeout):
+            observed_timeouts.append(timeout)
+            return True
+
+    toolkit._workspace_checkpoint_watchers_lock = threading.Lock()
+    toolkit._workspace_checkpoint_runs = {"preview-server": "run-1"}
+    toolkit._workspace_checkpoint_wakeups = {
+        "preview-server": threading.Event()
+    }
+    toolkit._workspace_checkpoint_completions = {
+        "preview-server": _Completion()
+    }
+
+    assert toolkit.quiesce_run_background_sessions("run-1") == ()
+    assert observed_timeouts[0] >= 29.0

--- a/backend/tests/app/service/test_chat_service.py
+++ b/backend/tests/app/service/test_chat_service.py
@@ -1253,6 +1253,12 @@ class TestChatServiceAgentOperations:
 
             # Should add multiple agent workers
             assert mock_workforce.add_single_agent_worker.call_count >= 4
+            developer_description = (
+                mock_workforce.add_single_agent_worker.call_args_list[0]
+                .args[0]
+                .lower()
+            )
+            assert "deploy" not in developer_description
             assert (
                 mock_workforce_cls.call_args.kwargs[
                     "use_structured_output_handler"

--- a/src/components/WorkFlow/agentToolkitLabels.ts
+++ b/src/components/WorkFlow/agentToolkitLabels.ts
@@ -13,11 +13,7 @@
 // ========= Copyright 2025-2026 @ Eigent.ai All Rights Reserved. =========
 
 const agentToolkits: Record<string, string[]> = {
-  developer_agent: [
-    '# Terminal & Shell ',
-    '# Web Deployment ',
-    '# Screen Capture ',
-  ],
+  developer_agent: ['# Terminal & Shell ', '# Screen Capture '],
   browser_agent: ['# Web Browser ', '# Search Engines '],
   multi_modal_agent: [
     '# Image Analysis ',

--- a/src/components/WorkFlow/baseWorkers.ts
+++ b/src/components/WorkFlow/baseWorkers.ts
@@ -17,12 +17,7 @@ export const BASE_WORKFLOW_AGENTS: Agent[] = [
   {
     tasks: [],
     agent_id: 'developer_agent',
-    tools: [
-      'Human Toolkit',
-      'Terminal Toolkit',
-      'Note Taking Toolkit',
-      'Web Deploy Toolkit',
-    ],
+    tools: ['Human Toolkit', 'Terminal Toolkit', 'Note Taking Toolkit'],
     name: 'Developer Agent',
     type: 'developer_agent',
     log: [],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

# Pull Request

## Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->

No linked Issue. This bug was found internally while investigating generated web tasks that did not terminate reliably.

## Description

This is the release-safe subset of #1906. It addresses the two direct causes found in the reproduced task while deliberately excluding the broader SSE, follow-up, background-trigger, Project eviction, and RunCoordinator lifecycle changes.

- Removes Web Deploy Toolkit from the Workforce Developer Agent and Single Agent assembly because Eigent does not need to upload generated content to the legacy remote deployment service.
- Ignores legacy toolkit configuration that still requests `web_deploy.enabled=true`.
- Removes deployment claims from the Developer Agent prompt, Workforce coordinator description, and workflow capability lists.
- Keeps `web_deploy_toolkit.py` and historical rendering support intact for possible future use and compatibility.
- Increases the terminal background-cleanup checkpoint budget from 5 seconds to 30 seconds so a stopped preview server can release its write lease and finish the workspace Git checkpoint before Run finalization.

## Testing Evidence (REQUIRED)

Automated validation completed through commit `c134cab4f`:

- Focused backend tests for Developer Agent assembly, toolkit descriptions, terminal workspace cleanup, and Workforce construction — 20 passed.
- `npm run type-check` — passed.
- Focused ESLint and Prettier checks — passed.
- Focused Ruff lint and Ruff format checks — passed.
- `npm run check:design-tokens` — passed.
- `git diff --check` — passed.

Human UI evidence has not yet been attached. The generated-web-task scenario will be retested against this branch before merge.

- [ ] I have included human-verified testing evidence in this PR.
- [ ] This PR includes frontend/UI changes, and I attached screenshot(s) or screen recording(s).
- [ ] No frontend/UI changes in this PR.

## What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

## Contribution Guidelines Acknowledgement

Pending confirmation by the human contributor; this is intentionally not checked on their behalf.

- [ ] I have read and agree to the [Eigent Contribution Guideline](https://github.com/eigent-ai/eigent/blob/main/CONTRIBUTING.md#eigent-contribution-guideline)
