### PR TITLE
security: require the local-control principal on GET /files

### DIFF
--- a/backend/app/controller/file_controller.py
+++ b/backend/app/controller/file_controller.py
@@ -316,7 +316,10 @@ async def list_task_changed_files(
     }
 
 
-@router.get("/files")
+@router.get(
+    "/files",
+    dependencies=[Depends(require_local_control_principal)],
+)
 async def list_project_files(
     project_id: str = Query(..., description="Project ID"),
     email: str = Query(..., description="User email"),

--- a/backend/tests/app/controller/test_file_controller.py
+++ b/backend/tests/app/controller/test_file_controller.py
@@ -487,3 +487,32 @@ def test_task_changes_endpoint_requires_local_capability(
         "scan_status": "complete",
         "truncated": False,
     }
+
+
+def test_list_project_files_requires_local_capability(monkeypatch, tmp_path):
+    monkeypatch.setenv("EIGENT_RUNTIME", "electron")
+    monkeypatch.setenv("EIGENT_LOCAL_CONTROL_CAPABILITY", "secret-1")
+    project_root = tmp_path / "project-1"
+    project_root.mkdir()
+    (project_root / "report.md").write_text("hello")
+    monkeypatch.setattr(
+        file_controller,
+        "_resolve_file_root",
+        lambda email, project_id, space_id=None, user_id=None: project_root,
+    )
+
+    app = FastAPI()
+    app.include_router(file_controller.router)
+    client = TestClient(app, client=("127.0.0.1", 50000))
+    params = {"project_id": "project-1", "email": "user@example.com"}
+
+    # Without the renderer capability the listing is not served: the email
+    # query parameter names a user, it does not authenticate one.
+    assert client.get("/files", params=params).status_code == 401
+    response = client.get(
+        "/files",
+        params=params,
+        headers={LOCAL_CONTROL_CAPABILITY_HEADER: "secret-1"},
+    )
+    assert response.status_code == 200
+    assert [item["filename"] for item in response.json()] == ["report.md"]


### PR DESCRIPTION
## What

`GET /files` now carries the same `require_local_control_principal` dependency that `GET /files/changes` gained in #1842. A test mirrors the existing `/files/changes` capability test: the listing returns 401 without the renderer capability header and 200 with it.

## Why

The `email` and `project_id` query parameters select a user's project root; nothing on this route authenticated the caller. Any process that can reach the Brain port could list any user's project files by naming them. With the default bind now on loopback the reach is local processes; deployments that set `EIGENT_BRAIN_HOST=0.0.0.0` (Docker, Web mode) expose it to the network.

The frontend already sends the capability header for this call (`useProjectOutputFiles.ts` goes through `fetchGet`, which attaches `X-Eigent-Local-Capability`), so no renderer change is needed.

## Not covered here, deliberately

`GET /files/stream` and `GET /files/preview/...` have the same shape but are loaded as `<iframe>` / `<img>` sources (`Folder/index.tsx`), which cannot carry a request header. Protecting them needs either a short-lived signed token in the URL or `session.webRequest.onBeforeSendHeaders` in the Electron main process scoped to the Brain origin. Happy to follow up with either if maintainers have a preference.

## Verification

`python -m py_compile` on both files. The full backend suite needs Python 3.11 and the `camel-ai` tree, which the machine that prepared this does not have, so CI is the first full run.

Found by commitwork.
